### PR TITLE
Helpers for jenkins test steps

### DIFF
--- a/resources/uk/gov/hmcts/contino/state-storage-template.json
+++ b/resources/uk/gov/hmcts/contino/state-storage-template.json
@@ -1,6 +1,0 @@
-{
-  "resourceGroup": "contino-moj-tf-state",
-  "storageAccount": "continomojtfstate",
-  "container": "contino-moj-tfstate-container"
-}
-

--- a/resources/uk/gov/hmcts/contino/state-storage.json
+++ b/resources/uk/gov/hmcts/contino/state-storage.json
@@ -1,0 +1,26 @@
+[
+  {
+    "env": "dev",
+    "resourceGroup": "contino-moj-tf-state",
+    "storageAccount": "continomojtfstate",
+    "container": "contino-moj-tfstate-container"
+  },
+  {
+    "env": "test",
+    "resourceGroup": "contino-moj-tf-state",
+    "storageAccount": "continomojtfstate",
+    "container": "contino-moj-tfstate-container"
+  },
+  {
+    "env": "prod",
+    "resourceGroup": "contino-moj-tf-state",
+    "storageAccount": "continomojtfstate",
+    "container": "contino-moj-tfstate-container"
+  },
+  {
+    "env": "default",
+    "resourceGroup": "contino-moj-tf-state",
+    "storageAccount": "continomojtfstate",
+    "container": "contino-moj-tfstate-container"
+  }
+]

--- a/src/uk/gov/hmcts/contino/Terraform.groovy
+++ b/src/uk/gov/hmcts/contino/Terraform.groovy
@@ -84,13 +84,12 @@ class Terraform implements Serializable {
   }
 
   private def getStateStoreConfig(env) {
-    def stateStores = new JsonSlurperClassic().parseText(steps.libraryResource('uk/gov/hmcts/contino/state-storage-template.json'))
-    if (canApply(env)) {
-      stateStores += ['env': env]
-    } else
-      throw new Exception("You cannot apply for Environment: '${env}' on branch '${steps.env.BRANCH_NAME}'. ['dev', 'test', 'prod'] are reserved for master branch, try other name")
+    def stateStores = new JsonSlurperClassic().parseText(steps.libraryResource('uk/gov/hmcts/contino/state-storage.json'))
+    def stateStoreConfig = stateStores.find { s -> s.env == env }
 
-    logMessage("Using following stateStores=$stateStores")
+    if (stateStoreConfig == null)
+      stateStoreConfig = stateStores.find { s -> s.env == "dev" }
+    logMessage("Using following stateStores=$stateStoreConfig")
 
     return stateStores
   }

--- a/test/uk/gov/hmcts/contino/TerraformTests.groovy
+++ b/test/uk/gov/hmcts/contino/TerraformTests.groovy
@@ -14,7 +14,7 @@ class TerraformTests extends Specification {
 
   def setup() {
     steps = Mock(JenkinsStepMock)
-    steps.libraryResource(_) >> new File("./resources/uk/gov/hmcts/contino/state-storage-template.json").text
+    steps.libraryResource(_) >> new File("./resources/uk/gov/hmcts/contino/state-storage.json").text
     steps.env >> ["PATH": ""]
 //    steps.ansiColor(_, _) >> { format, closure -> println "Format: "+ format+ "; Chained command"+ closure.metaClass.classNode.getDeclaredMethods("doCall")[0].code.text  }
 
@@ -44,17 +44,17 @@ class TerraformTests extends Specification {
     steps.env.BRANCH_NAME = 'some_branch'
 
     when:
-    terraform.plan("dev")
+    terraform.apply("dev")
     then:
     thrown(Exception)
 
     when:
-    terraform.plan("test")
+    terraform.apply("test")
     then:
     thrown(Exception)
 
     when:
-    terraform.plan("prod")
+    terraform.apply("prod")
     then:
     thrown(Exception)
 


### PR DESCRIPTION
moved unit tests to lib
changed the way state storage place is determined and how it works depending on branch master or not