### PR TITLE
Fix java deployment

### DIFF
--- a/src/uk/gov/hmcts/contino/WebAppDeploy.groovy
+++ b/src/uk/gov/hmcts/contino/WebAppDeploy.groovy
@@ -24,7 +24,7 @@ class WebAppDeploy implements Serializable {
 
     def computeCluster = getComputeFor(env)
     def healthCheckUrl = "http://${product}-${app}-${env}.${computeCluster}.p.azurewebsites.net/health"
-    return steps.sh("curl -vf ${healthCheckUrl}")
+    return steps.sh("curl --max-time 200 -vf ${healthCheckUrl}")
   }
 
   private def getComputeFor(env){


### PR DESCRIPTION
Add a null check for the spring config files.
add a max time to the curl healthcheck to 200 seconds