### PR TITLE
Tweak gradle build phases (also add test archiving)

### DIFF
--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -20,7 +20,7 @@ class GradleBuilder implements Builder, Serializable {
     try {
       gradle("check")
     } finally {
-      junit 'build/test-results/**/*.xml'
+      steps.junit 'build/test-results/**/*.xml'
     }
   }
 


### PR DESCRIPTION
Gradle `build` task includes a lot of stuff, plus at least in CMC we have more than one test task that doesn't need to run in the build task.
Since it would be a bit awkward allowing team to pass exclusions for `build` along, I've changed it to only build the executable `jar` in build and then run all the static check's in the `check` tasks

Also added test archiving as when I had a build failing for an integration test running as part of the build I couldn't see the error and needed to `scp` the reports directory to my local machine.