### PR TITLE
Update key to match java

### DIFF
--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -37,7 +37,7 @@ class YarnBuilder implements Builder, Serializable {
   def addVersionInfo() {
     steps.sh '''tee version <<EOF
 version: $(node -pe 'require("./package.json").version')
-build: ${BUILD_NUMBER}
+number: ${BUILD_NUMBER}
 commit: $(git rev-parse HEAD)
 date: $(date)
 EOF


### PR DESCRIPTION
Noticed when we started serving this up that when it was wrapped with build it becomes
```
build: {
  build: 11
}
```
Whereas java uses `number`