### PR TITLE
Fix compilation issue on Jenkins

### DIFF
--- a/src/uk/gov/hmcts/contino/MetricsPublisher.groovy
+++ b/src/uk/gov/hmcts/contino/MetricsPublisher.groovy
@@ -11,8 +11,6 @@ import com.cloudbees.groovy.cps.NonCPS
 
 class MetricsPublisher implements Serializable {
 
-  private final static String defaultCosmosDbUrl = 'https://e520fc7bdb51bf9c.documents.azure.com:/'
-  private final static String defaultCollectionLink = 'dbs/jenkins-sandbox/colls/pipeline-metrics'
   def steps
   def env
   def currentBuild
@@ -32,7 +30,9 @@ class MetricsPublisher implements Serializable {
   }
 
   MetricsPublisher(steps, currentBuild, product, component) {
-    this(steps, currentBuild, product, component, defaultCosmosDbUrl, defaultCollectionLink)
+    // the following default string literals were stored as private static final fields but had to be moved here because
+    // we ran into compilation issues on Jenkins because it interfered and wrapped them in instance method calls
+    this(steps, currentBuild, product, component, 'https://e520fc7bdb51bf9c.documents.azure.com:/', 'dbs/jenkins-sandbox/colls/pipeline-metrics')
   }
 
   @NonCPS


### PR DESCRIPTION
Fix this issue on latest version of Jenkins

```
hudson.remoting.ProxyException: org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
file:/opt/jenkins/jobs/Contino/jobs/moj-rhubarb-recipes-service/branches/master/builds/2/libs/Infrastructure/src/uk/gov/hmcts/contino/MetricsPublisher.groovy: -1: cannot reference this inside of this (steps, currentBuild, product, component, org.kohsuke.groovy.sandbox.impl.Checker.checkedGetProperty(this, false, false, defaultCosmosDbUrl), org.kohsuke.groovy.sandbox.impl.Checker.checkedGetProperty(this, false, false, defaultCollectionLink))(....) before supertype constructor has been called
. At [-1:-1]  @ line -1, column -1.
1 error
```