### PR TITLE
Use https for smoketest url

### DIFF
--- a/src/uk/gov/hmcts/contino/WebAppDeploy.groovy
+++ b/src/uk/gov/hmcts/contino/WebAppDeploy.groovy
@@ -170,7 +170,7 @@ class WebAppDeploy implements Serializable {
    * @return
    */
   def getServiceUrl(product, app, env) {
-    return "http://${getServiceHost(product, app, env)}"
+    return "https://${getServiceHost(product, app, env)}"
   }
 
   def getServiceUrl(env) {


### PR DESCRIPTION
Tested here for a nodejs app:
http://build.platform.hmcts.net/job/HMCTS/job/cmc-citizen-frontend/job/cnp/57/console
(its using an abbreviated pipeline)