### PR TITLE
Make terraform available for withInfrastructurePipeline builds

### DIFF
--- a/vars/withInfrastructurePipeline.groovy
+++ b/vars/withInfrastructurePipeline.groovy
@@ -2,6 +2,8 @@
 def call(String product, String environment, String subscription) {
 
   node {
+    env.PATH = "$env.PATH:/usr/local/bin"
+
     stage('Checkout') {
       deleteDir()
       checkout scm


### PR DESCRIPTION
`withInfrastructurePipeline` did not have it's PATH updated with `/usr/local/bin` where Terraform is installed.