### PR TITLE
Temporarily remove dependency check because version looks old

### DIFF
--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -46,11 +46,11 @@ class GradleBuilder implements Builder, Serializable {
 
   def securityCheck() {
 
-    try {
-      gradle("-DdependencyCheck.failBuild=true dependencyCheck")
-    } finally {
-      steps.archiveArtifacts 'build/reports/dependency-check-report.html'
-    }
+    // try {
+    //   gradle("-DdependencyCheck.failBuild=true dependencyCheck")
+    // } finally {
+    //   steps.archiveArtifacts 'build/reports/dependency-check-report.html'
+    // }
 
   }
 


### PR DESCRIPTION
Looks like version in use by teams has issues with thread-safety and might fail and cause internal DB corruption amongst other things.

@timja-kainos has PR-131 (not ready for merge yet) to use tasks for newer version. Teams should upgrade their project builds and merge Tim's version when everyone has upgraded.