### PR TITLE
Using system's nodejs just as with java

### DIFF
--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -59,8 +59,6 @@ EOF
   }
 
   def yarn(task){
-    def node = steps.tool(name: 'Node-8', type: 'jenkins.plugins.nodejs.tools.NodeJSInstallation')
-    steps.env.PATH = "${node}/bin:${steps.env.PATH}"
     steps.sh("yarn ${task}")
   }
 }


### PR DESCRIPTION
system-wide nodejs (including yarn) is now installed on both sandbox and prod jenkins