### PR TITLE
Initialize TF output with a null instead of a blank string

### DIFF
--- a/vars/spinInfra.groovy
+++ b/vars/spinInfra.groovy
@@ -37,7 +37,7 @@ def call(productName, environment, planOnly = false, subscription) {
         stage("Apply ${productName}-${environment} in ${environment}") {
           sh "terraform apply -auto-approve -var 'env=${environment}' -var 'name=${productName}' -var 'subscription=${subscription}'" +
             (fileExists("${environment}.tfvars") ? " -var-file=${environment}.tfvars" : "")
-          parseResult = ""
+          parseResult = null
           try {
             result = sh(script: "terraform output -json", returnStdout: true).trim()
             parseResult = new JsonSlurperClassic().parseText(result)


### PR DESCRIPTION
That way it's easier to tell that given module has no TF output.