### PR TITLE
Ensure smoke and functional gradle tests are executed

### DIFF
--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -30,7 +30,9 @@ class GradleBuilder implements Builder, Serializable {
 
   def smokeTest() {
     try {
-      gradle("--info clean smoke")
+      // By default Gradle will skip task execution if it's already been run (is 'up to date').
+      // --rerun-tasks ensures that subsequent calls to tests against different slots are executed.
+      gradle("--info --rerun-tasks smoke")
     } finally {
       steps.junit '**/test-results/**/*.xml'
     }
@@ -38,7 +40,9 @@ class GradleBuilder implements Builder, Serializable {
 
   def functionalTest() {
     try {
-      gradle("--info clean functional")
+      // By default Gradle will skip task execution if it's already been run (is 'up to date').
+      // --rerun-tasks ensures that subsequent calls to tests against different slots are executed.
+      gradle("--info --rerun-tasks functional")
     } finally {
       steps.junit '**/test-results/**/*.xml'
     }


### PR DESCRIPTION
We've noticed that the second smoke test executed in CNP pipeline does nothing. This is because Gradle does not see any code changes and choses to do nothing in order to save time. Added a `clean` before invoking smoke and functional tests to ensure they are always executed.