### PR TITLE
adding log message when folder not found

### DIFF
--- a/vars/folderExists.groovy
+++ b/vars/folderExists.groovy
@@ -15,4 +15,6 @@ def call(String folderPath, Closure block) {
   if (Files.exists(FileSystems.getDefault().getPath(localPath, folderPath))) {
     return block.call()
   }
+  else
+    log.info("$folderPath not found => There is no infrastructure to build")
 }


### PR DESCRIPTION
There's a hard to spot issue when infrastructure folder does not exist and `Build infrastructure` step just skips and having a log message for folderExists that folder was not found would make it immediately to spot.  