### PR TITLE
Ignoring TF WARN errors in kitchen

### DIFF
--- a/vars/infraModuleTesting.groovy
+++ b/vars/infraModuleTesting.groovy
@@ -15,8 +15,9 @@ def call () {
         gem install bundler
         export PATH=$PATH:/home/jenkinsssh/bin/
         export TF_WARN_OUTPUT_ERRORS=1
-        bundle install --path vendor/bundle && cd tests/int
-        bundle exec kitchen testi
+        bundle install --path vendor/bundle
+        cd tests/int
+        bundle exec kitchen test
         "
       '''
     }


### PR DESCRIPTION
Ignoring WARN TF errors for kitchen workflow. For more info about the issue please see https://github.com/hashicorp/terraform/issues/17655