### PR TITLE
Disable flakey central analyzer

### DIFF
--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -55,7 +55,7 @@ class GradleBuilder implements Builder, Serializable {
       def owaspU = az "keyvault secret show --vault-name '${steps.env.INFRA_VAULT_NAME}' --name 'OWASPDb-Account' --query value -o tsv"
       def owaspP = az "keyvault secret show --vault-name '${steps.env.INFRA_VAULT_NAME}' --name 'OWASPDb-Password' --query value -o tsv"
 
-      gradle("-DdependencyCheck.failBuild=true -DdependencyCheck.cveValidForHours=24 -DdependencyCheck.data.driver='com.microsoft.sqlserver.jdbc.SQLServerDriver' -DdependencyCheck.data.connectionString='jdbc:sqlserver://owaspdependencycheck.database.windows.net:1433;database=owaspdependencycheck;user=${owaspU}@owaspdependencycheck;password=${owaspP};encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.database.windows.net;loginTimeout=30;' -DdependencyCheck.data.username='${owaspU}' -DdependencyCheck.data.password='${owaspP}' dependencyCheckAnalyze")
+      gradle("-DdependencyCheck.failBuild=true -DdependencyCheck.cveValidForHours=24 -Danalyzer.central.enabled=false -DdependencyCheck.data.driver='com.microsoft.sqlserver.jdbc.SQLServerDriver' -DdependencyCheck.data.connectionString='jdbc:sqlserver://owaspdependencycheck.database.windows.net:1433;database=owaspdependencycheck;user=${owaspU}@owaspdependencycheck;password=${owaspP};encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.database.windows.net;loginTimeout=30;' -DdependencyCheck.data.username='${owaspU}' -DdependencyCheck.data.password='${owaspP}' dependencyCheckAnalyze")
 
     }
     finally {


### PR DESCRIPTION
Central analyzer has been flakey recently, the maintainer says it gives minimal value and will be disabled by default soon for maven and gradle builds

Tested locally
```
$ rg -i central out-deps.txt
252:Finished Central Analyzer (16 seconds)
320:Finished Central Analyzer (5 seconds)
377:Finished Central Analyzer (10 seconds)
443:Finished Central Analyzer (5 seconds)
500:Finished Central Analyzer (2 seconds)
560:Finished Central Analyzer (5 seconds)
```

```
$ rg -i central out-deps2.txt
189:Central analyzer disabled
265:Central analyzer disabled
333:Central analyzer disabled
390:Central analyzer disabled
456:Central analyzer disabled
513:Central analyzer disabled
```

See:
https://github.com/jeremylong/DependencyCheck/issues/1193#issuecomment-381397016