### PR TITLE
Remove verbose to speed up install

### DIFF
--- a/resources/uk/gov/hmcts/contino/yarn-install/deploy.cmd
+++ b/resources/uk/gov/hmcts/contino/yarn-install/deploy.cmd
@@ -107,7 +107,7 @@ set PATH=%PATH%;%appdata%\npm
 echo Installing Yarn Packages.
 IF EXIST "%DEPLOYMENT_TARGET%\package.json" (
   pushd "%DEPLOYMENT_TARGET%"
-  call :ExecuteCmd yarn install --production --force --pure-lockfile --verbose
+  call :ExecuteCmd yarn install --production --force --pure-lockfile
   IF !ERRORLEVEL! NEQ 0 goto error
   popd
 )


### PR DESCRIPTION
Tested here:
https://build.platform.hmcts.net/blue/organizations/jenkins/HMCTS%2Fcmc-citizen-frontend/detail/PR-546/3/pipeline/179

Deploy - preview (staging slot)
 - 1m 34s

![image](https://user-images.githubusercontent.com/21194782/39044777-0ea4a680-4489-11e8-8808-68d7e78a6ec3.png)
