### PR TITLE
Copy executable wars as well as executable jars

### DIFF
--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -13,7 +13,7 @@ class GradleBuilder implements Builder, Serializable {
   def build() {
     addVersionInfo()
     gradle("assemble")
-    //steps.stash(name: product, includes: "**/libs/*.jar")
+    steps.stash(name: product, includes: "**/libs/*.jar,**/libs/*.war")
   }
 
   def test() {

--- a/src/uk/gov/hmcts/contino/JavaDeployer.groovy
+++ b/src/uk/gov/hmcts/contino/JavaDeployer.groovy
@@ -13,7 +13,7 @@ class JavaDeployer implements Deployer, Serializable {
   }
 
   def deploy(String env) {
-    //steps.unstash(product)
+    steps.unstash(product)
     deployer.deployJavaWebApp(env)
   }
 

--- a/src/uk/gov/hmcts/contino/WebAppDeploy.groovy
+++ b/src/uk/gov/hmcts/contino/WebAppDeploy.groovy
@@ -128,17 +128,14 @@ class WebAppDeploy implements Serializable {
     steps.sh("git checkout ${branch.branchName}")
 
     steps.sh("mkdir ${tempDir}")
-    steps.sh("ls -laR *")
-    //steps.sh("ls -la build/libs")
+
     def status = copyAndReturnStatus('build/libs/*.jar', tempDir)
-    steps.echo "Return Status - Copy Jar - ${status}"
     if (status != 0) {
       status = copyAndReturnStatus('build/libs/*.war', tempDir)
-      steps.echo "Return Status - Copy War - ${status}"
     }
 
     if (status != 0) {
-      error 'deployJavaWebApp expects an executable JAR or WAR deployment, neither was found.'
+      steps.error "deployJavaWebApp expects an executable JAR or WAR deployment, neither was found. status = ${status}"
     }
 
     checkAndCopy('web.config', tempDir)


### PR DESCRIPTION
Some projects may build executable-wars rather than executable-jars. Copy over files with the `war` extension as well as `jar` extension