### PR TITLE
Uses jenkins credentials for owasp db connection

### DIFF
--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -49,7 +49,7 @@ class GradleBuilder implements Builder, Serializable {
   }
 
   def securityCheck() {
-    steps.withCredentials([usernamePassword(credentialsId: 'owasp-db-login', passwordVariable: 'OWASPDB_ACCOUNT', usernameVariable: 'OWASPDB_PASSWORD')]) {
+    steps.withCredentials([steps.usernamePassword(credentialsId: 'owasp-db-login', passwordVariable: 'OWASPDB_ACCOUNT', usernameVariable: 'OWASPDB_PASSWORD')]) {
       try {
         gradle("-DdependencyCheck.failBuild=true -DdependencyCheck.cveValidForHours=24 -Danalyzer.central.enabled=false -DdependencyCheck.data.driver='com.microsoft.sqlserver.jdbc.SQLServerDriver' -DdependencyCheck.data.connectionString='jdbc:sqlserver://owaspdependencycheck.database.windows.net:1433;database=owaspdependencycheck;user=${steps.env.OWASPDB_ACCOUNT}@owaspdependencycheck;password=${steps.env.OWASPDB_PASSWORD};encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.database.windows.net;loginTimeout=30;' -DdependencyCheck.data.username='${steps.env.OWASPDB_ACCOUNT}' -DdependencyCheck.data.password='${steps.env.OWASPDB_PASSWORD}' dependencyCheckAnalyze")
       }

--- a/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
@@ -12,7 +12,7 @@ class GradleBuilderTest extends Specification {
 
   def setup() {
     steps = Mock(JenkinsStepMock.class)
-    steps.getEnv() >> [INFRA_VAULT_NAME: 'blah']
+    steps.getEnv() >> []
     builder = new GradleBuilder(steps, 'test')
   }
 
@@ -55,7 +55,7 @@ class GradleBuilderTest extends Specification {
     setup:
     def closure
     steps.withCredentials(_, { closure = it }) >> { closure.call() }
-    builder.metaClass.usernamePassword { LinkedHashMap map ->
+    steps.metaClass.usernamePassword { LinkedHashMap map ->
       return []
     }
 


### PR DESCRIPTION
Part of [CNP-573](https://tools.hmcts.net/jira/browse/CNP-573) to remove reliance on the env var set in jenkins specifying the infra vault name