### PR TITLE
Disable gradle daemon

### DIFF
--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -11,6 +11,8 @@ class GradleBuilder implements Builder, Serializable {
   }
 
   def build() {
+    // disable gradle daemon as it has caused quite a lot of build failures
+    steps.sh("mkdir -p ~/.gradle && echo 'org.gradle.daemon=false' > ~/.gradle/gradle.properties")
     addVersionInfo()
     gradle("assemble")
     steps.stash(name: product, includes: "**/libs/*.jar,**/libs/*.war")


### PR DESCRIPTION
Resolves this build failure:
> Gradle build daemon disappeared unexpectedly (it may have been killed or may have crashed)
