### PR TITLE
add ivy as a compileOnly dependency so tests can run in IntelliJ

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,8 @@ compileTestGroovy {
 }
 
 dependencies {
+  compileOnly 'org.apache.ivy:ivy:2.4.0'
+
   compile group: 'org.codehaus.groovy', name: 'groovy-all', version: '2.4.9'
   compile group: 'com.cloudbees', name: 'groovy-cps', version: '1.12'
   //used for generating RandomStrings


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
*
*
*
