### PR TITLE
build and Test phase for withparameterizedpipeline

### DIFF
--- a/vars/withParameterizedPipeline.groovy
+++ b/vars/withParameterizedPipeline.groovy
@@ -40,18 +40,7 @@ def call(type, String product, String component, String environment, String subs
       node {
         env.PATH = "$env.PATH:/usr/local/bin"
 
-        stage('Checkout') {
-          pl.callAround('checkout') {
-            deleteDir()
-            checkout scm
-          }
-        }
-
-        stage("Build") {
-          pl.callAround('build') {
-            builder.build()
-          }
-        }
+        sectionBuildAndTest(pl, pipelineType.builder)
 
         sectionDeployToEnvironment(
           pipelineCallbacks: pl,


### PR DESCRIPTION
This is breaking change for those who uses with parameterized pipeline

Currently we are using SAAT for testing SIDAM but sandbox jenkins uses this pipeline which was missing running the test phase in withParameterizedPipeline.groovy()  

Please close this PR if we think "withParameterizedPipeline.groovy" only for infrastructure code.