### PR TITLE
Revert "NonCPS metrics (#247)"

### DIFF
--- a/src/uk/gov/hmcts/contino/MetricsPublisher.groovy
+++ b/src/uk/gov/hmcts/contino/MetricsPublisher.groovy
@@ -63,7 +63,6 @@ class MetricsPublisher implements Serializable {
     ]
   }
 
-  @NonCPS
   def publish(currentStepName) {
     try {
       steps.withCredentials([[$class: 'StringBinding', credentialsId: 'COSMOSDB_TOKEN_KEY', variable: 'COSMOSDB_TOKEN_KEY']]) {


### PR DESCRIPTION
It's stopping metrics being captured, I'll have another look at it next week
This reverts commit 8e1f93879631b871c21804a4b73f70c30c3b3735.