### PR TITLE
Use correct branch name for PRs

### DIFF
--- a/vars/stageCheckout.groovy
+++ b/vars/stageCheckout.groovy
@@ -11,7 +11,7 @@ def call(String url) {
   stage('Checkout') {
     deleteDir()
     git([url   : url,
-         branch: env.BRANCH_NAME])
+         branch: env.CHANGE_BRANCH])
   }
 
 }


### PR DESCRIPTION
See
https://build.platform.hmcts.net/job/HMCTS/job/moj-module-api-mgmt/view/change-requests/job/PR-2/2/console
where by default the library attempts to checkout a branch called PR-2
instead of the actual branch name:

```
Fetching upstream changes from git@github.com:hmcts/moj-module-api-mgmt.git
 > git fetch --tags --progress git@github.com:hmcts/moj-module-api-mgmt.git +refs/heads/*:refs/remotes/origin/*
 > git rev-parse refs/remotes/origin/PR-2^{commit} # timeout=10
 > git rev-parse refs/remotes/origin/origin/PR-2^{commit} # timeout=10
 > git rev-parse origin/PR-2^{commit} # timeout=10
```

Thanks to @njrich28 for really solving this
