### PR TITLE
Bump sonar timeout

### DIFF
--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -39,7 +39,7 @@ def call(PipelineCallbacks pl, Builder builder) {
           builder.sonarScan()
         }
 
-        timeout(time: 5, unit: 'MINUTES') {
+        timeout(time: 15, unit: 'MINUTES') {
           def qg = waitForQualityGate()
           if (qg.status != 'OK') {
             error "Pipeline aborted due to quality gate failure: ${qg.status}"


### PR DESCRIPTION
We've been seeing timeouts due to tactical sonar being able to only process 1 job at a time, each job takes approx 70 seconds to process, if too many come in at the same time then builds fail.

We saw ~10 builds fail on thursday.
It has been agreed that sonar cloud is going to be spiked on sandbox by platform engineering
https://tools.hmcts.net/jira/browse/RPE-586
Agreed 15 minutes with Jason too
