### PR TITLE
Fixed problem where branches couldn't get built

### DIFF
--- a/vars/stageCheckout.groovy
+++ b/vars/stageCheckout.groovy
@@ -11,7 +11,7 @@ def call(String url) {
   stage('Checkout') {
     deleteDir()
     git([url   : url,
-         branch: env.CHANGE_BRANCH])
+         branch: env.CHANGE_BRANCH ?: env.BRANCH_NAME])
   }
 
 }


### PR DESCRIPTION
The last change to this file fixed PRs being build, but broke it for
branches. Now the code checks if the CHANGE_NAME env var is set first
and if not, falls back to the BRANCH_NAME
