### PR TITLE
Add a little more time for tests to run

### DIFF
--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -20,7 +20,7 @@ def call(PipelineCallbacks pl, Builder builder) {
 
   stage("Test") {
     pl.callAround('test') {
-      timeout(time: 15, unit: 'MINUTES') {
+      timeout(time: 20, unit: 'MINUTES') {
         builder.test()
       }
     }


### PR DESCRIPTION
CMC tests are constantly failing this morning for jenkins timeouts, they don't seem to be stuck just not completing quite in time
CMC have lots of mocked integration tests that run as part of this and not just static unit tests

Thoughts on upping the timeout to 20?