### PR TITLE
Yarn mutex

### DIFF
--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -7,7 +7,7 @@ class YarnBuilder extends AbstractBuilder {
   }
 
   def build() {
-    yarn("--verbose --mutex file:/tmp/.yarn-mutex install")
+    yarn("--mutex file:/tmp/.yarn-mutex install")
     yarn("lint")
 
     addVersionInfo()


### PR DESCRIPTION
Disables concurrent execution of `yarn install`.  Attempt to mitigate instances of this problem:
```
11:31:48 + yarn install
11:31:50 yarn install v1.7.0
11:31:50 [1/5] Validating package.json...
11:31:50 [2/5] Resolving packages...
11:31:52 [3/5] Fetching packages...
11:31:53 error An unexpected error occurred: "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz: EEXIST: file already exists, mkdir '/home/jenkinsssh/.cache/yarn/v1/npm-combined-stream-1.0.6-723e7df6e801ac5613113a7e445a9b69cb632818'".
```
