### PR TITLE
use network mutex

### DIFF
--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -7,7 +7,7 @@ class YarnBuilder extends AbstractBuilder {
   }
 
   def build() {
-    yarn("--mutex file:/tmp/.yarn-mutex install")
+    yarn("--mutex network install")
     yarn("lint")
 
     addVersionInfo()


### PR DESCRIPTION
it looks like using `--mutex file` with projects with a lot of dependencies causes delays in updating the mutex lockfile leading to failures.  
