### PR TITLE
Force no gradle daemon

### DIFF
--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -93,7 +93,7 @@ class GradleBuilder extends AbstractBuilder {
 mkdir -p src/main/resources/META-INF
 
 tee src/main/resources/META-INF/build-info.properties <<EOF 2>/dev/null
-build.version=$(./gradlew --init-script init.gradle -q :printVersionInit)
+build.version=$(./gradlew --no-daemon --init-script init.gradle -q :printVersionInit)
 build.number=${BUILD_NUMBER}
 build.commit=$(git rev-parse HEAD)
 build.date=$(date)
@@ -104,7 +104,7 @@ EOF
 
   def gradle(String task) {
     addInitScript()
-    steps.sh("./gradlew --init-script init.gradle ${task}")
+    steps.sh("./gradlew --no-daemon --init-script init.gradle ${task}")
   }
 
   def fullFunctionalTest() {


### PR DESCRIPTION
We tried disabling the daemon through jvm properties but something must be wrong there.
This really forces no daemon and will stop these errors:

```
02:47:53 Daemon vm is shutting down... The daemon has exited normally or was terminated in response to a user interrupt.
02:47:53 ----- End of the daemon log -----
02:47:53 
02:47:53 
02:47:53 FAILURE: Build failed with an exception.
02:47:53 
02:47:53 * What went wrong:
02:47:53 Gradle build daemon disappeared unexpectedly (it may have been killed or may have crashed)
```