### PR TITLE
KeyVault: don't check return code on failure

### DIFF
--- a/src/uk/gov/hmcts/contino/azure/KeyVault.groovy
+++ b/src/uk/gov/hmcts/contino/azure/KeyVault.groovy
@@ -25,7 +25,7 @@ class KeyVault extends Az implements Serializable {
       return this.az("keyvault secret show --vault-name '${this.vaultName}' --name '${key}' --query value -o tsv".toString())
     } catch (e) {
       // Unfortunately Jenkins does not support returning both stdout and exit code yet, so we need to assume the
-      // 'script returned exit code 1' was due to secret not being found or particular vault not being there.
+      // 'script returned exit code n' was due to secret not being found or particular vault not being there.
       if (e.getMessage().contains("script returned exit code")) {
         return null
       } else {


### PR DESCRIPTION
Don't explicitly check the actual return value on failure.  It won't be 0 and that's all we care about.
