### PR TITLE
increase healthcheck attempts to mitigate for possible slow OSBA prov…

### DIFF
--- a/vars/aksDeploy.groovy
+++ b/vars/aksDeploy.groovy
@@ -53,7 +53,7 @@ def call(DockerImage dockerImage, Map params) {
 
     def url = env.AKS_TEST_URL + '/health'
     def healthChecker = new HealthChecker(this)
-    healthChecker.check(url, 10, 10)
+    healthChecker.check(url, 10, 20)
 
     return env.AKS_TEST_URL
   }


### PR DESCRIPTION
increase health check attempts to 20 (from 10).  If the AKS config is using an OSBA-provisioned resource, it could be a few minutes before the pod is ready.

