### PR TITLE
In prod jenkins, apps such as rhubarb are calling enablePerformanceTe…

### DIFF
--- a/src/uk/gov/hmcts/contino/DocumentPublisher.groovy
+++ b/src/uk/gov/hmcts/contino/DocumentPublisher.groovy
@@ -38,7 +38,7 @@ class DocumentPublisher implements Serializable {
   @NonCPS
   private def publish(cosmosDbKey, collectionLink, documents) {
 
-    def cosmosDbUrl = params.subscription == 'prod' ? DB_DEFAULT_URL : DB_SANDBOX_URL
+    def cosmosDbUrl = params.subscription == 'sandbox' ? DB_SANDBOX_URL : DB_DEFAULT_URL
     def documentClient = new DocumentClient(cosmosDbUrl, cosmosDbKey, null, null)
 
     try {


### PR DESCRIPTION
In prod jenkins, apps such as rhubarb are calling enablePerformanceTest(). Since perf tests in prod pipelines are exercised across more than one subscription (i.e. prod and nonprod) we are swapping the check as a temporary fix, otherwise the pipeline fails while trying to write to the cosmosdb instance in sandbox from prod jenkins.
