### PR TITLE
configure artifact mirror

### DIFF
--- a/resources/uk/gov/hmcts/gradle/init.gradle
+++ b/resources/uk/gov/hmcts/gradle/init.gradle
@@ -1,4 +1,5 @@
-def mirrorUrl = System.getenv("ARTIFACT_MIRROR")
+def mirrorHost = (System.getenv("NONPROD_SUBSCRIPTION_NAME") == "sandbox") ? 'sandbox-artifactory' : 'artifactory'
+def mirrorUrl = "https://${mirrorHost}.platform.hmcts.net/artifactory/maven-remotes"
 
 allprojects {
   repositories {

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -50,9 +50,6 @@ def call(type, String product, String component, Closure body) {
       try {
         env.PATH = "$env.PATH:/usr/local/bin"
 
-        def mirrorHost = (subscription.nonProdName == "sandbox") ? 'sandbox-artifactory' : 'artifactory'
-        env.ARTIFACT_MIRROR = "https://${mirrorHost}.platform.hmcts.net/artifactory/maven-remotes"
-
         sectionBuildAndTest(pl, pipelineType.builder)
 
         sectionCI(


### PR DESCRIPTION
Gradle will use the appropriate internal mirror depending on subscription

the reason I put the logic in the pipeline was in case we ever wanted to mirror Node repos as well