### PR TITLE
Add mgmt subscription id to vars

### DIFF
--- a/test/withPipeline/BaseCnpPipelineTest.groovy
+++ b/test/withPipeline/BaseCnpPipelineTest.groovy
@@ -20,7 +20,7 @@ abstract class BaseCnpPipelineTest extends BasePipelineTest {
     binding.setVariable("Jenkins", [instance: new MockJenkins(new MockJenkinsPluginManager([new MockJenkinsPlugin('sonar', true)] as MockJenkinsPlugin[]))])
     binding.setVariable("env", [
       BRANCH_NAME : branchName, TEST_URL: '', SUBSCRIPTION_NAME: '', ARM_CLIENT_ID: '', ARM_CLIENT_SECRET: '', ARM_TENANT_ID: '',
-      ARM_SUBSCRIPTION_ID: '', STORE_rg_name_template: '', STORE_sa_name_template: '', STORE_sa_container_name_template: '',
+      ARM_SUBSCRIPTION_ID: '', JENKINS_SUBSCRIPTION_ID: '', STORE_rg_name_template: '', STORE_sa_name_template: '', STORE_sa_container_name_template: '',
       CHANGE_URL:'', CHANGE_BRANCH:'', BEARER_TOKEN:'', CHANGE_TITLE:''])
 
     def library = library()

--- a/vars/withSubscription.groovy
+++ b/vars/withSubscription.groovy
@@ -46,7 +46,7 @@ def call(String subscription, Closure body) {
                "TF_VAR_secret_access_key=${subscriptionCredValues.azure_client_secret}",
                "TF_VAR_tenant_id=${subscriptionCredValues.azure_tenant_id}",
                "TF_VAR_subscription_id=${subscriptionCredValues.azure_subscription}",
-               "TF_VAR_mgmt_subscription_id=${JENKINS_SUBSCRIPTION_ID}",
+               "TF_VAR_mgmt_subscription_id=${env.JENKINS_SUBSCRIPTION_ID}",
                "TF_VAR_token=${subscriptionCredValues.azure_tenant_id}",
                // other variables
                "TOKEN=${subscriptionCredValues.azure_tenant_id}",


### PR DESCRIPTION
Bulk scanning needs to refer to the prod mgmt subscription to whitelist jenkins on its storage account