### PR TITLE
[PREVIEW] Feature/fix nightly vault issue

### DIFF
--- a/vars/sectionNightlyTests.groovy
+++ b/vars/sectionNightlyTests.groovy
@@ -3,9 +3,9 @@ import uk.gov.hmcts.contino.PipelineCallbacks
 import uk.gov.hmcts.contino.PipelineType
 
 
-def call(PipelineCallbacks pl, PipelineType pipelineType, environment) {
+def call(PipelineCallbacks pl, PipelineType pipelineType) {
 
-  withTeamSecrets(pl, environment) {
+  withTeamSecrets(pl) {
     Builder builder = pipelineType.builder
 
     stage('Checkout') {
@@ -103,13 +103,12 @@ def call(PipelineCallbacks pl, PipelineType pipelineType, environment) {
 }
 
 
-def withTeamSecrets(PipelineCallbacks pl, String environment, Closure block) {
+def withTeamSecrets(PipelineCallbacks pl, Closure block) {
   def keyvaultUrl = null
 
   if (pl.vaultSecrets?.size() > 0) {
     if (pl.vaultName) {
-      def projectKeyvaultName = pl.vaultName + '-' + environment
-      keyvaultUrl = "https://${projectKeyvaultName}.vault.azure.net/"
+      keyvaultUrl = "https://${pl.vaultName}.vault.azure.net/"
     } else {
       error "Please set vault name `setVaultName(${pl.vaultName})` if loading vault secrets"
     }

--- a/vars/withNightlyPipeline.groovy
+++ b/vars/withNightlyPipeline.groovy
@@ -36,8 +36,7 @@ def call(type,product,component,Closure body) {
     try {
       node {
         env.PATH = "$env.PATH:/usr/local/bin"
-        def environment = "$env.environment"
-        sectionNightlyTests(pl, pipelineType, environment)
+        sectionNightlyTests(pl, pipelineType)
         assert  pipelineType!= null
       }
     }


### PR DESCRIPTION
This PR is to fix the vault key reading issues in the Nightly pipeline.

The way it is going to work

 **Teams are going to have code similar to following in their Jenkins_nightly file** 

```

library "Infrastructure@${params.LIB_VERSION}"

String product = "probate"

String component = "pfe"

def type = "nodejs"

List<LinkedHashMap<String, Object>> secrets = [
        secret('serviceAuthProviderBaseUrl', 'SERVICE_AUTH_PROVIDER_BASE_URL'),
        secret('userAuthProviderOauth2Url', 'USER_AUTH_PROVIDER_OAUTH2_URL'),
        secret('evidenceManagementUrl', 'EVIDENCE_MANAGEMENT_URL'),
        secret('idamUserId', 'IDAM_USER_ID'),
        secret('s2sAuthTotpSecret', 'S2S_AUTH_TOTP_SECRET')
]

static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
    [ $class: 'AzureKeyVaultSecret',
      secretType: 'Secret',
      name: secretName,
      version: '',
      envVariable: envVar
    ]
}

    withNightlyPipeline(type, product, component) {
        loadVaultSecrets(secrets)
        setVaultName('probate-saat')
        env.TEST_URL = 'https://probate-frontend-saat.service.core-compute-saat.internal'
        enableCrossBrowserTest()
    }

```
