### PR TITLE
Ensure lockfile is up-to-date

### DIFF
--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -7,7 +7,7 @@ class YarnBuilder extends AbstractBuilder {
   }
 
   def build() {
-    yarn("--mutex network install")
+    yarn("--mutex network install --frozen-lockfile")
     yarn("lint")
 
     addVersionInfo()


### PR DESCRIPTION
Fail installation if the yarn.lock file is not in sync with
packages.json. This forces any package.json changes to have a matching
yarn.lock change.  Also prevents deploying apps with dependencies that
do not matches the the truth in yarn.lock.

From yarn docs:

`yarn install --frozen-lockfile`
Don’t generate a yarn.lock lockfile and fail if an update is needed.

Tested in:

https://github.com/hmcts/ccd-case-management-web/pull/414

This is based on a currently out of sync app with commits as follows:
1. Bring the app back into sync - build passes
2. Put package.json and yarn.lock out of sync - build fails
3. Update yarn.lock for above change - build passes

Impact on teams:
* If they have package.json and yarn.lock out of sync then PRs and master will fail builds.
* Simply committing an update to yarn.lock will fix this.