### PR TITLE
Enhance health check

### DIFF
--- a/src/uk/gov/hmcts/contino/HealthChecker.groovy
+++ b/src/uk/gov/hmcts/contino/HealthChecker.groovy
@@ -9,7 +9,7 @@ class HealthChecker {
   }
 
   def check(url, sleepDuration, maxAttempts,
-            Closure verifyHealthy = { resp -> resp.status <= 300 }) {
+            Closure isHealthy = { resp -> resp.status <= 300 }) {
 
     int attemptCounter = 1
 
@@ -27,7 +27,7 @@ class HealthChecker {
           ignoreSslErrors: true
         )
 
-        if (!verifyHealthy(response)) {
+        if (!isHealthy(response)) {
           if (attemptCounter < maxAttempts) {
             steps.sleep sleepDuration
           }


### PR DESCRIPTION
Enhanced health check with the ability to specify custom verification of the health based on the response.
This is needed by the ElasticSearch pipeline, where we call the health check and need to verify whether the status code returned is red, yellow, or green

used here: https://github.com/hmcts/ccd-elastic-search/blob/15081e61a1f32e24f5eaaf780d51c7174ab2af44/Jenkinsfile_parameterized#L20