### PR TITLE
provide mechanism to get environment without suffix

### DIFF
--- a/src/uk/gov/hmcts/contino/Environment.groovy
+++ b/src/uk/gov/hmcts/contino/Environment.groovy
@@ -9,17 +9,21 @@ class Environment implements Serializable {
 
   def final functionalTestEnvironments
 
-  Environment(Object env) {
+  Environment(Object env, boolean includeSuffix = true) {
     Objects.requireNonNull(env)
     org.codehaus.groovy.runtime.NullObject.metaClass.toString = {return ''}
 
-    nonProdName = (env.NONPROD_ENVIRONMENT_NAME ?: 'aat') + env.ENV_SUFFIX ?: ""
-    prodName = (env.PROD_ENVIRONMENT_NAME ?: 'prod') + env.ENV_SUFFIX ?: ""
-    demoName = (env.DEMO_ENVIRONMENT_NAME ?: 'demo') + env.ENV_SUFFIX ?: ""
-    previewName = (env.PREVIEW_ENVIRONMENT_NAME ?: 'preview') + env.ENV_SUFFIX ?: ""
-    hmctsDemoName = (env.HMCTSDEMO_ENVIRONMENT_NAME ?: 'hmctsdemo') + env.ENV_SUFFIX ?: ""
+    nonProdName = envName(env.NONPROD_ENVIRONMENT_NAME, 'aat', env, includeSuffix)
+    prodName = envName(env.PROD_ENVIRONMENT_NAME, 'prod', env, includeSuffix)
+    demoName = envName(env.DEMO_ENVIRONMENT_NAME, 'demo', env, includeSuffix)
+    previewName = envName(env.PREVIEW_ENVIRONMENT_NAME, 'preview', env, includeSuffix)
+    hmctsDemoName = envName(env.HMCTSDEMO_ENVIRONMENT_NAME, 'hmctsdemo', env, includeSuffix)
 
     functionalTestEnvironments = [nonProdName, previewName]
+  }
+
+  def envName(envVar, defaultName, env, includeSuffix) {
+    (envVar ?: defaultName) + (includeSuffix ? env.ENV_SUFFIX ?: "" : "")
   }
 
   def onFunctionalTestEnvironment(environment) {

--- a/test/uk/gov/hmcts/contino/EnvironmentTest.groovy
+++ b/test/uk/gov/hmcts/contino/EnvironmentTest.groovy
@@ -124,4 +124,28 @@ class EnvironmentTest extends Specification {
     then:
     assert environment.hmctsDemoName == "hmctsdemov2"
   }
+
+  def "environment suffix is EXCLUDED from hmctsdemo environment"() {
+    when:
+    def environment = new Environment(["unusedVar": "unused", "ENV_SUFFIX": "v2"], false)
+
+    then:
+    assert environment.hmctsDemoName == "hmctsdemo"
+  }
+
+  def "environment suffix is EXCLUDED to default nonprod environment"() {
+    when:
+    def environment = new Environment(["unusedVar": "unused", "ENV_SUFFIX": "v2"], false)
+
+    then:
+    assert environment.nonProdName == "aat"
+  }
+
+  def "environment suffix is NOT applied to default nonprod environment when includeSuffix is false"() {
+    when:
+    def environment = new Environment(["unusedVar": "unused"], false)
+
+    then:
+    assert environment.nonProdName == "aat"
+  }
 }


### PR DESCRIPTION
If using shared infrastructure, things like Keyvault won't follow the same naming convention as other resources.  That is, they won't necessarily have a `v2` suffix.

This provides a way to preserve the previous functionality and get the environment name without the suffix.
