### PR TITLE
Expose environment context to helm chart values template

### DIFF
--- a/vars/helmInstall.groovy
+++ b/vars/helmInstall.groovy
@@ -18,8 +18,14 @@ def call(DockerImage dockerImage, Map params) {
   def aksServiceName = dockerImage.getAksServiceName()
   def aksDomain = "${(subscription in ['nonprod', 'prod']) ? 'service.core-compute-preview.internal' : 'service.core-compute-saat.internal'}"
   def serviceFqdn = "${aksServiceName}.${aksDomain}"
-  def templateEnvVars = ["NAMESPACE=${aksServiceName}", "SERVICE_NAME=${aksServiceName}", "IMAGE_NAME=${digestName}", "SERVICE_FQDN=${serviceFqdn}"]
-  
+  def templateEnvVars = [
+    "ENVIRONMENT=${environment}",
+    "NAMESPACE=${aksServiceName}",
+    "SERVICE_NAME=${aksServiceName}",
+    "IMAGE_NAME=${digestName}",
+    "SERVICE_FQDN=${serviceFqdn}"
+  ]
+
   withEnv(templateEnvVars) {
 
     def kubectl = new Kubectl(this, subscription, aksServiceName)


### PR DESCRIPTION
The reason is that any service url potentially used by a given app may have to be defined with this info.

But this is just a proposal, nothing that should be necessarily merged.

... And not tested so far ...