### PR TITLE
Move ACR image build along with unit tests and sonar checks

### DIFF
--- a/vars/sectionCI.groovy
+++ b/vars/sectionCI.groovy
@@ -33,14 +33,6 @@ def call(params) {
       def acr = new Acr(this, subscription, env.REGISTRY_NAME, env.REGISTRY_RESOURCE_GROUP)
       def dockerImage = new DockerImage(product, component, acr, new ProjectBranch(env.BRANCH_NAME).imageTag())
 
-      stage('Docker Build') {
-        pl.callAround('dockerbuild') {
-          timeoutWithMsg(time: 15, unit: 'MINUTES', action: 'Docker build') {
-            acr.build(dockerImage)
-          }
-        }
-      }
-
       onPR {
         if (pl.deployToAKS) {
           withTeamSecrets(pl, params.environment) {

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -50,7 +50,13 @@ def call(type, String product, String component, Closure body) {
       try {
         env.PATH = "$env.PATH:/usr/local/bin"
 
-        sectionBuildAndTest(pl, pipelineType.builder)
+        sectionBuildAndTest(
+          pipelineCallbacks: pl,
+          builder: pipelineType.builder,
+          subscription: subscription.nonProdName,
+          product: product,
+          component: component
+        )
 
         sectionCI(
           pipelineCallbacks: pl,


### PR DESCRIPTION
JIRA ticket: https://tools.hmcts.net/jira/browse/CNP-1117

Part of the [Pipelines optimisation initiative](https://tools.hmcts.net/confluence/display/CNP/Pipeline+optimisations), this PR allow a gain of time by running the ACR docker image build in parallel with unit tests and security checks.

<img width="809" alt="screenshot 2019-01-21 at 14 22 50" src="https://user-images.githubusercontent.com/602143/51480077-0f3e2700-1d88-11e9-861d-50d417a84563.png">
