### PR TITLE
fix typo

### DIFF
--- a/vars/sharedInfrastructurePipeline.groovy
+++ b/vars/sharedInfrastructurePipeline.groovy
@@ -6,7 +6,7 @@ def call(String product, String environment, String subscription) {
 }
 
 def call(String product, String environment, String subscription, boolean planOnly) {
-  call(product, environment, subcription, planOnly, null)
+  call(product, environment, subscription, planOnly, null)
 }
 
 def call(String product, String environment, String subscription, boolean planOnly, String deploymentTarget) {


### PR DESCRIPTION
Pipelines failing e.g. https://build.platform.hmcts.net/job/HMCTS_CMC/job/cmc-shared-infrastructure/job/master/28/console:

```GitHub has been notified of this commit’s build result

groovy.lang.MissingPropertyException: No such property: subcription for class: sharedInfrastructurePipeline
	at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:53)
	at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.getProperty(ScriptBytecodeAdapter.java:458)
	at com.cloudbees.groovy.cps.sandbox.DefaultInvoker.getProperty(DefaultInvoker.java:39)
	at com.cloudbees.groovy.cps.impl.PropertyAccessBlock.rawGet(PropertyAccessBlock.java:20)```