### PR TITLE
Expose registry name in acr build and run

### DIFF
--- a/src/uk/gov/hmcts/contino/azure/Acr.groovy
+++ b/src/uk/gov/hmcts/contino/azure/Acr.groovy
@@ -59,7 +59,7 @@ class Acr extends Az {
    *   stdout of the step
    */
   def build(DockerImage dockerImage) {
-    this.az "acr build --no-format -r ${registryName} -t ${dockerImage.getShortName()} -g ${resourceGroup} ."
+    this.az "acr build --no-format -r ${registryName} -t ${dockerImage.getShortName()} -g ${resourceGroup} --build-arg REGISTRY_NAME=${registryName} ."
   }
 
   /**
@@ -70,7 +70,7 @@ class Acr extends Az {
    *   stdout of the step
    */
   def run() {
-    this.az "acr run -r ${registryName} -g ${resourceGroup} ."
+    this.az "acr run -r ${registryName} -g ${resourceGroup} --build-arg REGISTRY_NAME=${registryName} ."
   }
 
   def runWithTemplate(String acbTemplateFilePath, DockerImage dockerImage) {

--- a/test/uk/gov/hmcts/contino/azure/AcrTest.groovy
+++ b/test/uk/gov/hmcts/contino/azure/AcrTest.groovy
@@ -50,7 +50,7 @@ class AcrTest extends Specification {
 
     then:
       1 * steps.sh({it.containsKey('script') &&
-                    it.get('script').contains("az acr build --no-format -r ${REGISTRY_NAME} -t ${IMAGE_NAME} -g ${REGISTRY_RESOURCE_GROUP} .") &&
+                    it.get('script').contains("az acr build --no-format -r ${REGISTRY_NAME} -t ${IMAGE_NAME} -g ${REGISTRY_RESOURCE_GROUP} --build-arg REGISTRY_NAME=${REGISTRY_NAME} .") &&
                     it.containsKey('returnStdout') &&
                     it.get('returnStdout').equals(true)})
   }
@@ -72,7 +72,7 @@ class AcrTest extends Specification {
 
     then:
       1 * steps.sh({it.containsKey('script') &&
-                    it.get('script').contains("acr run -r ${REGISTRY_NAME} -g ${REGISTRY_RESOURCE_GROUP} .") &&
+                    it.get('script').contains("acr run -r ${REGISTRY_NAME} -g ${REGISTRY_RESOURCE_GROUP} --build-arg REGISTRY_NAME=${REGISTRY_NAME} .") &&
                     it.containsKey('returnStdout') &&
                     it.get('returnStdout').equals(true)})
   }
@@ -90,7 +90,7 @@ class AcrTest extends Specification {
                     it.get('returnStdout').equals(true)
                   })
     and:
-      1 * steps.sh({it.get('script').contains("acr run -r ${REGISTRY_NAME} -g ${REGISTRY_RESOURCE_GROUP} .") &&
+      1 * steps.sh({it.get('script').contains("acr run -r ${REGISTRY_NAME} -g ${REGISTRY_RESOURCE_GROUP} --build-arg REGISTRY_NAME=${REGISTRY_NAME} .") &&
                     it.get('returnStdout').equals(true)
                   })
 


### PR DESCRIPTION
This PR brings the exposition of the current ACR subscription name to the build and run commands. 

This modification will allow the use of context-friendly Dockerfiles, e.g.:

```Dockerfile
# The default registry is set to hmcts
ARG REGISTRY_NAME=hmcts
FROM ${REGISTRY_NAME}.azurecr.io/hmcts/base/node/alpine-lts-10 as base
...
```

This sample image will be built using the `hmctssandbox` registry in the context of a sandbox build (provided that the corresponding image exists on this registry).
