### PR TITLE
Add a tag to latest images to trigger Flux deployments

### DIFF
--- a/src/uk/gov/hmcts/contino/azure/Acr.groovy
+++ b/src/uk/gov/hmcts/contino/azure/Acr.groovy
@@ -55,7 +55,7 @@ class Acr extends Az {
    * Notice that when an image is tagged as 'latest', another tag
    * with a suffix appended 'latest' is also created to trigger
    * possible downstream deployments:
-   * e.g. <image-name>:latest will also be tagged <image-name>:latest~dfb02
+   * e.g. <image-name>:latest will also be tagged <image-name>:latest_dfb02
    *
    * @param dockerImage
    *   the docker image to build
@@ -64,7 +64,7 @@ class Acr extends Az {
    *   stdout of the step
    */
   def build(DockerImage dockerImage) {
-    def additionalTag = (dockerImage.getTag() != "latest") ? "" : "-t ${dockerImage.getShortName()}~{{.Run.ID}} "
+    def additionalTag = (dockerImage.getTag() != "latest") ? "" : "-t ${dockerImage.getShortName()}_{{.Run.ID}} "
     this.az "acr build --no-format -r ${registryName} -t ${dockerImage.getShortName()} " + additionalTag + "-g ${resourceGroup} ."
   }
 

--- a/src/uk/gov/hmcts/contino/azure/Acr.groovy
+++ b/src/uk/gov/hmcts/contino/azure/Acr.groovy
@@ -53,9 +53,10 @@ class Acr extends Az {
    * Build an image
    *
    * Notice that when an image is tagged as 'latest', another tag
-   * with a suffix appended 'latest' is also created to trigger
-   * possible downstream deployments:
-   * e.g. <image-name>:latest will also be tagged <image-name>:latest_dfb02
+   * with a suffix appended to 'latest' is also created.
+   * The intent is to trigger downstream deployments using this tag pattern.
+   *
+   * e.g.: <image-name>:latest will also be tagged as <image-name>:latest_dfb02
    *
    * @param dockerImage
    *   the docker image to build

--- a/src/uk/gov/hmcts/contino/azure/Acr.groovy
+++ b/src/uk/gov/hmcts/contino/azure/Acr.groovy
@@ -56,7 +56,7 @@ class Acr extends Az {
    * with a suffix appended to 'latest' is also created.
    * The intent is to trigger downstream deployments using this tag pattern.
    *
-   * e.g.: <image-name>:latest will also be tagged as <image-name>:latest_dfb02
+   * e.g.: <image-name>:latest will also be tagged as <image-name>:latest-dfb02
    *
    * @param dockerImage
    *   the docker image to build
@@ -65,7 +65,7 @@ class Acr extends Az {
    *   stdout of the step
    */
   def build(DockerImage dockerImage) {
-    def additionalTag = (dockerImage.getTag() != "latest") ? "" : "-t ${dockerImage.getShortName()}_{{.Run.ID}} "
+    def additionalTag = (dockerImage.getTag() != "latest") ? "" : "-t ${dockerImage.getShortName()}-{{.Run.ID}} "
     this.az "acr build --no-format -r ${registryName} -t ${dockerImage.getShortName()} " + additionalTag + "-g ${resourceGroup} ."
   }
 

--- a/src/uk/gov/hmcts/contino/azure/Acr.groovy
+++ b/src/uk/gov/hmcts/contino/azure/Acr.groovy
@@ -52,6 +52,11 @@ class Acr extends Az {
   /**
    * Build an image
    *
+   * Notice that when an image is tagged as 'latest', another tag
+   * with a suffix appended 'latest' is also created to trigger
+   * possible downstream deployments:
+   * e.g. <image-name>:latest will also be tagged <image-name>:latest~dfb02
+   *
    * @param dockerImage
    *   the docker image to build
    *
@@ -59,7 +64,8 @@ class Acr extends Az {
    *   stdout of the step
    */
   def build(DockerImage dockerImage) {
-    this.az "acr build --no-format -r ${registryName} -t ${dockerImage.getShortName()} -g ${resourceGroup} ."
+    def additionalTag = (dockerImage.getTag() != "latest") ? "" : "-t ${dockerImage.getShortName()}~{{.Run.ID}} "
+    this.az "acr build --no-format -r ${registryName} -t ${dockerImage.getShortName()} " + additionalTag + "-g ${resourceGroup} ."
   }
 
   /**

--- a/test/uk/gov/hmcts/contino/azure/AcrTest.groovy
+++ b/test/uk/gov/hmcts/contino/azure/AcrTest.groovy
@@ -64,7 +64,7 @@ class AcrTest extends Specification {
 
     then:
       1 * steps.sh({it.containsKey('script') &&
-                    it.get('script').contains("az acr build --no-format -r ${REGISTRY_NAME} -t ${IMAGE_NAME} -t ${IMAGE_NAME}~{{.Run.ID}} -g ${REGISTRY_RESOURCE_GROUP} .") &&
+                    it.get('script').contains("az acr build --no-format -r ${REGISTRY_NAME} -t ${IMAGE_NAME} -t ${IMAGE_NAME}_{{.Run.ID}} -g ${REGISTRY_RESOURCE_GROUP} .") &&
                     it.containsKey('returnStdout') &&
                     it.get('returnStdout').equals(true)})
   }

--- a/test/uk/gov/hmcts/contino/azure/AcrTest.groovy
+++ b/test/uk/gov/hmcts/contino/azure/AcrTest.groovy
@@ -45,12 +45,26 @@ class AcrTest extends Specification {
 
   def "build() should call az with acr build and correct arguments"() {
     when:
+      dockerImage.getTag() >> "sometag"
       dockerImage.getShortName() >> IMAGE_NAME
       acr.build(dockerImage)
 
     then:
       1 * steps.sh({it.containsKey('script') &&
                     it.get('script').contains("az acr build --no-format -r ${REGISTRY_NAME} -t ${IMAGE_NAME} -g ${REGISTRY_RESOURCE_GROUP} .") &&
+                    it.containsKey('returnStdout') &&
+                    it.get('returnStdout').equals(true)})
+  }
+
+  def "build() should call az with acr build with the right arguments and an extra tag when the image version is marked as latest"() {
+    when:
+      dockerImage.getTag() >> "latest"
+      dockerImage.getShortName() >> IMAGE_NAME
+      acr.build(dockerImage)
+
+    then:
+      1 * steps.sh({it.containsKey('script') &&
+                    it.get('script').contains("az acr build --no-format -r ${REGISTRY_NAME} -t ${IMAGE_NAME} -t ${IMAGE_NAME}~{{.Run.ID}} -g ${REGISTRY_RESOURCE_GROUP} .") &&
                     it.containsKey('returnStdout') &&
                     it.get('returnStdout').equals(true)})
   }

--- a/test/uk/gov/hmcts/contino/azure/AcrTest.groovy
+++ b/test/uk/gov/hmcts/contino/azure/AcrTest.groovy
@@ -64,7 +64,7 @@ class AcrTest extends Specification {
 
     then:
       1 * steps.sh({it.containsKey('script') &&
-                    it.get('script').contains("az acr build --no-format -r ${REGISTRY_NAME} -t ${IMAGE_NAME} -t ${IMAGE_NAME}_{{.Run.ID}} -g ${REGISTRY_RESOURCE_GROUP} .") &&
+                    it.get('script').contains("az acr build --no-format -r ${REGISTRY_NAME} -t ${IMAGE_NAME} -t ${IMAGE_NAME}-{{.Run.ID}} -g ${REGISTRY_RESOURCE_GROUP} .") &&
                     it.containsKey('returnStdout') &&
                     it.get('returnStdout').equals(true)})
   }


### PR DESCRIPTION
This PR is related to the implementation of flux and allows it to trigger a deployment in the aat AKS cluster when any new master image is pushed in the hmcts registry.

The known drawback is that it'll create loads of tags but I assume we'll create or re-use the existing images cleanup scripts.

Typically this modification means that any image built with the following name:

```
<image-name>:latest
```

will also be tagged as

```
<image-name>:latest-dfb02 # corresponding to the {{.Run.ID}} of the acr build task
```

There is no other functional change, and should not have any impact on the existing pipelines. It just generates an additional tag triggering a deployment in the aat aks cluster if Flux is in use and expecting this pattern.