### PR TITLE
Add perftest to auto deploy environments

### DIFF
--- a/src/uk/gov/hmcts/contino/Environment.groovy
+++ b/src/uk/gov/hmcts/contino/Environment.groovy
@@ -6,6 +6,7 @@ class Environment implements Serializable {
   def final demoName
   def final previewName
   def final hmctsDemoName
+  def final perftestName
 
   def final functionalTestEnvironments
 
@@ -18,6 +19,7 @@ class Environment implements Serializable {
     demoName = (env.DEMO_ENVIRONMENT_NAME ?: 'demo') + env.ENV_SUFFIX ?: ""
     previewName = (env.PREVIEW_ENVIRONMENT_NAME ?: 'preview') + env.ENV_SUFFIX ?: ""
     hmctsDemoName = (env.HMCTSDEMO_ENVIRONMENT_NAME ?: 'hmctsdemo') + env.ENV_SUFFIX ?: ""
+    perftestName = (env.PERFTEST_ENVIRONMENT_NAME ?: 'perftest') + env.ENV_SUFFIX ?: ""
 
     functionalTestEnvironments = [nonProdName, previewName]
   }

--- a/src/uk/gov/hmcts/contino/Subscription.groovy
+++ b/src/uk/gov/hmcts/contino/Subscription.groovy
@@ -6,6 +6,7 @@ class Subscription implements Serializable {
   def final demoName
   def final previewName
   def final hmctsDemoName
+  def final qaName
 
   Subscription(Object env) {
     Objects.requireNonNull(env)
@@ -15,5 +16,6 @@ class Subscription implements Serializable {
     demoName = env.DEMO_SUBSCRIPTION_NAME ?: 'nonprod'
     previewName = env.PREVIEW_SUBSCRIPTION_NAME ?: 'nonprod'
     hmctsDemoName = env.HMCTSDEMO_SUBSCRIPTION_NAME ?: 'hmctsdemo'
+    qaName = env.QA_SUBSCRIPTION_NAME ?: 'qa'
   }
 }

--- a/test/withInfraPipeline/onDemo/withInfraPipelineOnDemoTests.groovy
+++ b/test/withInfraPipeline/onDemo/withInfraPipelineOnDemoTests.groovy
@@ -1,0 +1,18 @@
+package withInfraPipeline.onDemo
+
+import org.junit.Test
+import withPipeline.BaseCnpPipelineTest
+
+class withInfraPipelineOnDemoTests extends BaseCnpPipelineTest {
+  final static jenkinsFile = "exampleInfraPipeline.jenkins"
+
+  withInfraPipelineOnDemoTests() {
+    super("demo", jenkinsFile)
+  }
+
+  @Test
+  void PipelineExecutesExpectedStepsInExpectedOrder() {
+    runScript("testResources/$jenkinsFile")
+  }
+}
+

--- a/vars/autoDeployEnvironment.groovy
+++ b/vars/autoDeployEnvironment.groovy
@@ -1,0 +1,27 @@
+import uk.gov.hmcts.contino.Environment
+import uk.gov.hmcts.contino.Subscription
+
+def call() {
+
+  def branch = env.BRANCH_NAME
+
+  def environment = new Environment(env)
+  def subscription = new Subscription(env)
+
+  // map of branch name to environment
+  def autoDeployEnvironments = [
+    demo: [
+      environmentName: environment.demoName,
+      subscriptionName: subscription.nonProdName
+    ],
+    hmctsdemo: [
+      environmentName: environment.hmctsDemoName,
+      subscriptionName: subscription.hmctsDemoName
+    ],
+    perftest: [
+      environmentName: environment.perftestName,
+      subscriptionName: subscription.qaName
+    ]
+  ]
+  return autoDeployEnvironments[branch]
+}

--- a/vars/onAutoDeployBranch.groovy
+++ b/vars/onAutoDeployBranch.groovy
@@ -1,0 +1,7 @@
+
+def call(Closure block) {
+  def envSub = autoDeployEnvironment()
+  if (envSub) {
+    return block.call(envSub.subscriptionName, envSub.subscriptionName)
+  }
+}

--- a/vars/withInfraPipeline.groovy
+++ b/vars/withInfraPipeline.groovy
@@ -44,19 +44,11 @@ def call(String product, Closure body) {
             product: product)
         }
 
-        onDemo {
+        onAutoDeployBranch { subscriptionName, environmentName ->
           sectionInfraBuild(
             pipelineConfig: pipelineConfig,
-            subscription: subscription.demoName,
-            environment: environment.demoName,
-            product: product)
-        }
-
-        onHMCTSDemo {
-          sectionInfraBuild(
-            pipelineConfig: pipelineConfig,
-            subscription: subscription.hmctsDemoName,
-            environment: environment.hmctsDemoName,
+            subscription: subscriptionName,
+            environment: environmentName,
             product: product)
         }
 

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -96,22 +96,12 @@ def call(type, String product, String component, Closure body) {
             component: component)
         }
 
-        onDemo {
+        onAutoDeployBranch { subscriptionName, environmentName ->
           sectionDeployToEnvironment(
             pipelineCallbacks: pl,
             pipelineType: pipelineType,
-            subscription: subscription.demoName,
-            environment: environment.demoName,
-            product: product,
-            component: component)
-        }
-
-        onHMCTSDemo {
-          sectionDeployToEnvironment(
-            pipelineCallbacks: pl,
-            pipelineType: pipelineType,
-            subscription: subscription.hmctsDemoName,
-            environment: environment.hmctsDemoName,
+            subscription: subscriptionName,
+            environment: environmentName,
             product: product,
             component: component)
         }


### PR DESCRIPTION
Minor refactoring to make it easier to add auto deploy branches in the future i.e. forthcoming ithc environment.

Had to leave `onDemo` and other library functions because they are in use in teams' Jenkinsfiles