### PR TITLE
Flux AAT deployment trigger on master pipeline

### DIFF
--- a/src/uk/gov/hmcts/contino/azure/Acr.groovy
+++ b/src/uk/gov/hmcts/contino/azure/Acr.groovy
@@ -100,4 +100,23 @@ class Acr extends Az {
     return host?.trim()
   }
 
+  /**
+   * Retags an image in the registry with an appended hash
+   *
+   * e.g.: <image-name>:latest will also be tagged as <image-name>:latest-dfb02
+   *
+   * @param hash
+   *   a string hash (use only alphanumeric characters)
+   *
+   * @param dockerImage
+   *   the docker image to build
+   *
+   * @return
+   *   stdout of the step
+   */
+  def retagWithAppendedHash(String hash, DockerImage dockerImage) {
+    def additionalTag = "${dockerImage.getShortName()}-${hash}"
+    this.az "acr import -n ${registryName} -g ${resourceGroup} --source ${dockerImage.getTaggedName()} -t ${additionalTag}"?.trim()
+  }
+
 }

--- a/src/uk/gov/hmcts/contino/azure/Acr.groovy
+++ b/src/uk/gov/hmcts/contino/azure/Acr.groovy
@@ -94,12 +94,12 @@ class Acr extends Az {
   }
 
   /**
-   * Retags an image in the registry with an appended hash
+   * Retags an image in the registry with an appended suffix
    *
    * e.g.: <image-name>:latest will also be tagged as <image-name>:latest-dfb02
    *
-   * @param hash
-   *   a string hash (use only alphanumeric characters)
+   * @param suffix
+   *   a string suffix (use only alphanumeric characters)
    *
    * @param dockerImage
    *   the docker image to build
@@ -107,8 +107,8 @@ class Acr extends Az {
    * @return
    *   stdout of the step
    */
-  def retagWithAppendedHash(String hash, DockerImage dockerImage) {
-    def additionalTag = "${dockerImage.getShortName()}-${hash}"
+  def retagWithSuffix(String suffix, DockerImage dockerImage) {
+    def additionalTag = "${dockerImage.getShortName()}-${suffix}"
     this.az "acr import -n ${registryName} -g ${resourceGroup} --source ${dockerImage.getTaggedName()} -t ${additionalTag}"?.trim()
   }
 

--- a/src/uk/gov/hmcts/contino/azure/Acr.groovy
+++ b/src/uk/gov/hmcts/contino/azure/Acr.groovy
@@ -52,12 +52,6 @@ class Acr extends Az {
   /**
    * Build an image
    *
-   * Notice that when an image is tagged as 'latest', another tag
-   * with a suffix appended to 'latest' is also created.
-   * The intent is to trigger downstream deployments using this tag pattern.
-   *
-   * e.g.: <image-name>:latest will also be tagged as <image-name>:latest-dfb02
-   *
    * @param dockerImage
    *   the docker image to build
    *
@@ -65,8 +59,7 @@ class Acr extends Az {
    *   stdout of the step
    */
   def build(DockerImage dockerImage) {
-    def additionalTag = (dockerImage.getTag() != "latest") ? "" : "-t ${dockerImage.getShortName()}-{{.Run.ID}} "
-    this.az "acr build --no-format -r ${registryName} -t ${dockerImage.getShortName()} " + additionalTag + "-g ${resourceGroup} ."
+    this.az "acr build --no-format -r ${registryName} -t ${dockerImage.getShortName()} -g ${resourceGroup} ."
   }
 
   /**

--- a/test/uk/gov/hmcts/contino/azure/AcrTest.groovy
+++ b/test/uk/gov/hmcts/contino/azure/AcrTest.groovy
@@ -56,19 +56,6 @@ class AcrTest extends Specification {
                     it.get('returnStdout').equals(true)})
   }
 
-  def "build() should call az with acr build with the right arguments and an extra tag when the image version is marked as latest"() {
-    when:
-      dockerImage.getTag() >> "latest"
-      dockerImage.getShortName() >> IMAGE_NAME
-      acr.build(dockerImage)
-
-    then:
-      1 * steps.sh({it.containsKey('script') &&
-                    it.get('script').contains("az acr build --no-format -r ${REGISTRY_NAME} -t ${IMAGE_NAME} -t ${IMAGE_NAME}-{{.Run.ID}} -g ${REGISTRY_RESOURCE_GROUP} .") &&
-                    it.containsKey('returnStdout') &&
-                    it.get('returnStdout').equals(true)})
-  }
-
   def "getHostname() should call az with correct arguments"() {
     when:
       acr.getHostname()

--- a/test/uk/gov/hmcts/contino/azure/AcrTest.groovy
+++ b/test/uk/gov/hmcts/contino/azure/AcrTest.groovy
@@ -99,7 +99,6 @@ class AcrTest extends Specification {
 
   def "retagWithSuffix() should call the import command the provided arguments"() {
     when:
-      when:
       dockerImage.getTag() >> "sometag"
       dockerImage.getShortName() >> IMAGE_NAME
       dockerImage.getTaggedName() >> "${REGISTRY_NAME}.azurecr.io/${IMAGE_NAME}"

--- a/test/uk/gov/hmcts/contino/azure/AcrTest.groovy
+++ b/test/uk/gov/hmcts/contino/azure/AcrTest.groovy
@@ -110,4 +110,19 @@ class AcrTest extends Specification {
 
   }
 
+  def "retagWithAppendedHash() should call the import command the provided arguments"() {
+    when:
+      when:
+      dockerImage.getTag() >> "sometag"
+      dockerImage.getShortName() >> IMAGE_NAME
+      dockerImage.getTaggedName() >> "${REGISTRY_NAME}.azurecr.io/${IMAGE_NAME}"
+      acr.retagWithAppendedHash("Ac0mpl1catedH4sh", dockerImage)
+
+    then:
+      1 * steps.sh({it.containsKey('script') &&
+                    it.get('script').contains("acr import -n ${REGISTRY_NAME} -g ${REGISTRY_RESOURCE_GROUP} --source ${REGISTRY_NAME}.azurecr.io/${IMAGE_NAME} -t ${IMAGE_NAME}-Ac0mpl1catedH4sh") &&
+                    it.containsKey('returnStdout') &&
+                    it.get('returnStdout').equals(true)})
+  }
+
 }

--- a/test/uk/gov/hmcts/contino/azure/AcrTest.groovy
+++ b/test/uk/gov/hmcts/contino/azure/AcrTest.groovy
@@ -97,13 +97,13 @@ class AcrTest extends Specification {
 
   }
 
-  def "retagWithAppendedHash() should call the import command the provided arguments"() {
+  def "retagWithSuffix() should call the import command the provided arguments"() {
     when:
       when:
       dockerImage.getTag() >> "sometag"
       dockerImage.getShortName() >> IMAGE_NAME
       dockerImage.getTaggedName() >> "${REGISTRY_NAME}.azurecr.io/${IMAGE_NAME}"
-      acr.retagWithAppendedHash("Ac0mpl1catedH4sh", dockerImage)
+      acr.retagWithSuffix("Ac0mpl1catedH4sh", dockerImage)
 
     then:
       1 * steps.sh({it.containsKey('script') &&

--- a/vars/sectionTriggerFluxDeployment.groovy
+++ b/vars/sectionTriggerFluxDeployment.groovy
@@ -7,7 +7,7 @@ import uk.gov.hmcts.contino.ProjectBranch
 import uk.gov.hmcts.contino.azure.Acr
 
 /*
- * The image retaging in ACR is used as a trigger for Weaveworks Flux
+ * The image retagging in ACR is used as a trigger for Weaveworks Flux
  * to (re-)deploy the image
  *
  * Any image re-tagged following the pattern displayed below is

--- a/vars/sectionTriggerFluxDeployment.groovy
+++ b/vars/sectionTriggerFluxDeployment.groovy
@@ -1,0 +1,39 @@
+#!groovy
+import uk.gov.hmcts.contino.AppPipelineConfig
+import uk.gov.hmcts.contino.PipelineCallbacksRunner
+import uk.gov.hmcts.contino.PipelineType
+import uk.gov.hmcts.contino.DockerImage
+import uk.gov.hmcts.contino.ProjectBranch
+import uk.gov.hmcts.contino.azure.Acr
+
+/*
+ * The image retaging in ACR is used as a trigger for Weaveworks Flux
+ * to (re-)deploy the image
+ *
+ * Any image re-tagged following the pattern displayed below is
+ * eventually deployed in Flux AKS cluster:
+ *
+ * e.g.: <my-app-image>:latest-<random-hash>
+ */
+
+def call(params) {
+
+  PipelineCallbacksRunner pcr = params.pipelineCallbacksRunner
+  AppPipelineConfig config = params.appPipelineConfig
+  PipelineType pipelineType = params.pipelineType
+
+  def subscription = params.subscription
+  def product = params.product
+  def component = params.component
+
+  stage('AAT Flux deployment') {
+    pcr.callAround('fluxdeployment') {
+      withAksClient(subscription) {
+        def acr = new Acr(this, subscription, env.REGISTRY_NAME, env.REGISTRY_RESOURCE_GROUP)
+        def dockerImage = new DockerImage(product, component, acr, new ProjectBranch(env.BRANCH_NAME).imageTag())
+        def randomHash = Long.toUnsignedString(new Random().nextLong(), 16)
+        acr.retagWithAppendedHash(randomHash, dockerImage)
+      }
+    }
+  }
+}

--- a/vars/sectionTriggerFluxDeployment.groovy
+++ b/vars/sectionTriggerFluxDeployment.groovy
@@ -29,10 +29,14 @@ def call(params) {
   stage('AAT Flux deployment') {
     if (config.dockerBuild) {
       withAksClient(subscription) {
+
         def acr = new Acr(this, subscription, env.REGISTRY_NAME, env.REGISTRY_RESOURCE_GROUP)
         def dockerImage = new DockerImage(product, component, acr, new ProjectBranch(env.BRANCH_NAME).imageTag())
         def randomHash = Long.toUnsignedString(new Random().nextLong(), 16)
-        acr.retagWithSuffix(randomHash, dockerImage)
+
+        pcr.callAround('fluxdeployment') {
+          acr.retagWithSuffix(randomHash, dockerImage)
+        }
       }
     }
   }

--- a/vars/sectionTriggerFluxDeployment.groovy
+++ b/vars/sectionTriggerFluxDeployment.groovy
@@ -27,7 +27,7 @@ def call(params) {
   def component = params.component
 
   stage('AAT Flux deployment') {
-    pcr.callAround('fluxdeployment') {
+    if (config.dockerBuild) {
       withAksClient(subscription) {
         def acr = new Acr(this, subscription, env.REGISTRY_NAME, env.REGISTRY_RESOURCE_GROUP)
         def dockerImage = new DockerImage(product, component, acr, new ProjectBranch(env.BRANCH_NAME).imageTag())

--- a/vars/sectionTriggerFluxDeployment.groovy
+++ b/vars/sectionTriggerFluxDeployment.groovy
@@ -32,7 +32,7 @@ def call(params) {
         def acr = new Acr(this, subscription, env.REGISTRY_NAME, env.REGISTRY_RESOURCE_GROUP)
         def dockerImage = new DockerImage(product, component, acr, new ProjectBranch(env.BRANCH_NAME).imageTag())
         def randomHash = Long.toUnsignedString(new Random().nextLong(), 16)
-        acr.retagWithAppendedHash(randomHash, dockerImage)
+        acr.retagWithSuffix(randomHash, dockerImage)
       }
     }
   }

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -80,6 +80,16 @@ def call(type, String product, String component, Closure body) {
         )
 
         onMaster {
+
+          sectionTriggerFluxDeployment(
+            appPipelineConfig: pipelineConfig,
+            pipelineCallbacksRunner: callbacksRunner,
+            pipelineType: pipelineType,
+            subscription: subscription.nonProdName,
+            product: product,
+            component: component
+          )
+
           sectionDeployToEnvironment(
             appPipelineConfig: pipelineConfig,
             pipelineCallbacksRunner: callbacksRunner,


### PR DESCRIPTION
This PR adds a step in the master pipeline allowing the re-tagging of the latest image produced in ACR.

This actually triggers a deployment in the Flux AAT cluster.

Here is a [working example](https://sandbox-build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_Sandbox_Pipeline_Test%2Fcnp-plum-recipes-service/detail/master/56/pipeline) on a master branch and the corresponding images in the [hmctssanbox acr here](https://portal.azure.com/#@HMCTS.NET/resource/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourceGroups/cnp-acr-rg/providers/Microsoft.ContainerRegistry/registries/hmctssandbox/repository) (select the `hmcts/crumble-recipe-backend` repository).

Alongside those changes there is the removal of the previous image tagging modification introduced in a previous PR which applied the re-tagging on image creation.