### PR TITLE
Return empty list if sub/env not found

### DIFF
--- a/vars/deploymentTargets.groovy
+++ b/vars/deploymentTargets.groovy
@@ -22,5 +22,5 @@ def call(String subscription, String environment) {
     prod: [
       prod: ["-v2"]
     ]]
-  return deploymentTargets[subscription]?.get(environment, [])
+  return deploymentTargets.get(subscription, [:])?.get(environment, [])
 }


### PR DESCRIPTION
Return empty list if subscription is not found. Currently returns null which breaks things.