### PR TITLE
Deprecate old infra pipelines

### DIFF
--- a/vars/sharedInfrastructurePipeline.groovy
+++ b/vars/sharedInfrastructurePipeline.groovy
@@ -13,6 +13,22 @@ def call(String product, String environment, String subscription, boolean planOn
 
 @Deprecated
 def call(String product, String environment, String subscription, boolean planOnly, String deploymentTarget) {
+  echo '''
+================================================================================
+sharedInfrastructurePipeline is
+______                              _           _ _ 
+|  _  \\                            | |         | | |
+| | | |___ _ __  _ __ ___  ___ __ _| |_ ___  __| | |
+| | | / _ \\ '_ \\| '__/ _ \\/ __/ _` | __/ _ \\/ _` | |
+| |/ /  __/ |_) | | |  __/ (_| (_| | ||  __/ (_| |_|
+|___/ \\___| .__/|_|  \\___|\\___\\__,_|\\__\\___|\\__,_(_)
+          | |                                       
+          |_|                                       
+ Use withInfraPipeline instead
+ https://github.com/hmcts/cnp-jenkins-library#opinionated-infrastructure-pipeline
+================================================================================
+'''
+
   node {
     env.PATH = "$env.PATH:/usr/local/bin"
 

--- a/vars/withInfrastructurePipeline.groovy
+++ b/vars/withInfrastructurePipeline.groovy
@@ -2,6 +2,24 @@
 @Deprecated
 def call(String product, String environment, String subscription, String deploymentTarget = "") {
 
+  echo '''
+================================================================================
+withInfrastructurePipeline is
+______                              _           _ _ 
+|  _  \\                            | |         | | |
+| | | |___ _ __  _ __ ___  ___ __ _| |_ ___  __| | |
+| | | / _ \\ '_ \\| '__/ _ \\/ __/ _` | __/ _ \\/ _` | |
+| |/ /  __/ |_) | | |  __/ (_| (_| | ||  __/ (_| |_|
+|___/ \\___| .__/|_|  \\___|\\___\\__,_|\\__\\___|\\__,_(_)
+          | |                                       
+          |_|                                       
+
+Use withInfraPipeline instead
+
+https://github.com/hmcts/cnp-jenkins-library#opinionated-infrastructure-pipeline
+================================================================================
+'''
+
   def environmentDeploymentTarget = "$environment$deploymentTarget"
 
   node {


### PR DESCRIPTION
Tested https://sandbox-build.platform.hmcts.net/job/HMCTS_Sandbox_CNP/job/cnp-plum-shared-infrastructure/job/dnm-test-deprecated-pipeline/3/console

```Commit message: "Deprecated sharedInfrastructurePipeline"
[Pipeline] properties
[Pipeline] echo
Building 'plum' in 'sandbox' depoyment target ''
[Pipeline] echo

================================================================================
sharedInfrastructurePipeline is
______                              _           _ _ 
|  _  \                            | |         | | |
| | | |___ _ __  _ __ ___  ___ __ _| |_ ___  __| | |
| | | / _ \ '_ \| '__/ _ \/ __/ _` | __/ _ \/ _` | |
| |/ /  __/ |_) | | |  __/ (_| (_| | ||  __/ (_| |_|
|___/ \___| .__/|_|  \___|\___\__,_|\__\___|\__,_(_)
          | |                                       
          |_|                                       
 Use withInfraPipeline instead
 https://github.com/hmcts/cnp-jenkins-library#opinionated-infrastructure-pipeline
================================================================================

[Pipeline] node
Running on cnp-jenkins-builders29bf00 in /opt/jenkins/workspace/ure_dnm-test-deprecated-pipeline
[Pipeline] {
```
