### PR TITLE
Acr registry name as build arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,13 @@ steps:
       - runtime
 ```
 
-Notice the `{{CI_IMAGE_TAG}}` which is evaluated in Jenkins.
+Properties expanded by Jenkins:
+
+| Property matcher    |                                                                                                            |
+| ------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `{{CI_IMAGE_TAG}}`  | is the stadard name of the runtime image                                                                   |
+| `{{REGISTRY_NAME}}` | is the registry name, e.g. hmcts of hmctssandbox. Useful if you want to pass it as `--build-arg` parameter |
+
 
 If you want to learn more about ACR tasks, [here is the documentation](https://docs.microsoft.com/en-gb/azure/container-registry/container-registry-tasks-reference-yaml).
 

--- a/src/uk/gov/hmcts/contino/azure/Acr.groovy
+++ b/src/uk/gov/hmcts/contino/azure/Acr.groovy
@@ -59,7 +59,7 @@ class Acr extends Az {
    *   stdout of the step
    */
   def build(DockerImage dockerImage) {
-    this.az "acr build --no-format -r ${registryName} -t ${dockerImage.getShortName()} -g ${resourceGroup} ."
+    this.az "acr build --no-format -r ${registryName} -t ${dockerImage.getShortName()} -g ${resourceGroup} --build-arg REGISTRY_NAME=${registryName} ."
   }
 
   /**
@@ -76,7 +76,7 @@ class Acr extends Az {
   def runWithTemplate(String acbTemplateFilePath, DockerImage dockerImage) {
     def defaultAcrScriptFilePath = "acb.yaml"
     steps.sh(
-      script: "sed -e \"s@{{CI_IMAGE_TAG}}@${dockerImage.getShortName()}@g\" ${acbTemplateFilePath} > ${defaultAcrScriptFilePath}",
+      script: "sed -e \"s@{{CI_IMAGE_TAG}}@${dockerImage.getShortName()}@g\" -e \"s@{{REGISTRY_NAME}}@${registryName}@g\" ${acbTemplateFilePath} > ${defaultAcrScriptFilePath}",
       returnStdout: true
     )?.trim()
     this.run()

--- a/test/uk/gov/hmcts/contino/azure/AcrTest.groovy
+++ b/test/uk/gov/hmcts/contino/azure/AcrTest.groovy
@@ -51,7 +51,7 @@ class AcrTest extends Specification {
 
     then:
       1 * steps.sh({it.containsKey('script') &&
-                    it.get('script').contains("az acr build --no-format -r ${REGISTRY_NAME} -t ${IMAGE_NAME} -g ${REGISTRY_RESOURCE_GROUP} .") &&
+                    it.get('script').contains("az acr build --no-format -r ${REGISTRY_NAME} -t ${IMAGE_NAME} -g ${REGISTRY_RESOURCE_GROUP} --build-arg REGISTRY_NAME=${REGISTRY_NAME} .") &&
                     it.containsKey('returnStdout') &&
                     it.get('returnStdout').equals(true)})
   }
@@ -87,7 +87,7 @@ class AcrTest extends Specification {
 
     then:
       1 * steps.sh({it.containsKey('script') &&
-                    it.get('script').contains("sed -e \"s@{{CI_IMAGE_TAG}}@${dockerImage.getShortName()}@g\" acb.tpl.yaml > acb.yaml") &&
+                    it.get('script').contains("sed -e \"s@{{CI_IMAGE_TAG}}@${dockerImage.getShortName()}@g\" -e \"s@{{REGISTRY_NAME}}@${REGISTRY_NAME}@g\" acb.tpl.yaml > acb.yaml") &&
                     it.get('returnStdout').equals(true)
                   })
     and:


### PR DESCRIPTION
This PR is a re-run of https://github.com/hmcts/cnp-jenkins-library/pull/411, it brings back the exposition of the current ACR subscription name to the acr build and run commands.

```Dockerfile
# Dockerfile
# The default registry is set to hmcts
ARG REGISTRY_NAME=hmcts
FROM ${REGISTRY_NAME}.azurecr.io/hmcts/base/node/alpine-lts-10 as base
...
```

Using a custom acr build:

```yaml
# acb.tpl.yaml
...
  - id: runtime
    build: >
      -t {{.Run.Registry}}/{{CI_IMAGE_TAG}}
      --cache-from {{.Run.Registry}}/hmcts/cnp-plum-frontend/base:latest
      --build-arg REGISTRY_NAME={{REGISTRY_NAME}} # <-- pass the acr registry
      --target runtime
      .
...
```

In sandbox jenkins, `hmctssandbox` will be used.

---

Pipeline tests:

- Here is the default case: https://sandbox-build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_Sandbox_Pipeline_Test%2Fcnp-plum-frontend/detail/PR-15/6/pipeline
- and when using custom acr build: https://sandbox-build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_Sandbox_Pipeline_Test%2Fcnp-plum-frontend/detail/PR-15/7/pipeline