### PR TITLE
RPE 914 - Refactor AKS environment configuration in Preview

### DIFF
--- a/vars/helmInstall.groovy
+++ b/vars/helmInstall.groovy
@@ -56,7 +56,7 @@ def call(DockerImage dockerImage, Map params) {
     def templateValues = "${helmResourcesDir}/${chartName}/values.template.yaml"
     def defaultValues = "${helmResourcesDir}/${chartName}/values.yaml"
     if (fileExists(defaultValues)) {
-      onPR{
+      onPR {
         aksEnvironment ="preview"
       }
     } else {

--- a/vars/helmInstall.groovy
+++ b/vars/helmInstall.groovy
@@ -71,7 +71,7 @@ def call(DockerImage dockerImage, Map params) {
      \\/  \\/|____| |____||____| |___||_____|\\____||_____||_____|\\____|`._____.' 
                                                                                
 
-Provide values.yaml with the chart . Templating will be supported only for env specific values.
+Provide values.yaml with the chart . Builds will start failing without values.yaml in near future.
 ================================================================================
 '''
     }

--- a/vars/helmInstall.groovy
+++ b/vars/helmInstall.groovy
@@ -59,7 +59,7 @@ def call(DockerImage dockerImage, Map params) {
       onPR{
         aksEnvironment ="preview"
       }
-    }else{
+    } else{
       echo '''
 ================================================================================
 

--- a/vars/helmInstall.groovy
+++ b/vars/helmInstall.groovy
@@ -57,7 +57,7 @@ def call(DockerImage dockerImage, Map params) {
     def defaultValues = "${helmResourcesDir}/${chartName}/values.yaml"
     if (fileExists(defaultValues)) {
       onPR {
-        aksEnvironment ="preview"
+        aksEnvironment = "preview"
       }
     } else {
       echo '''

--- a/vars/helmInstall.groovy
+++ b/vars/helmInstall.groovy
@@ -57,7 +57,7 @@ def call(DockerImage dockerImage, Map params) {
     def defaultValues = "${helmResourcesDir}/${chartName}/values.yaml"
     if (fileExists(defaultValues)) {
       onPR {
-        aksEnvironment = "preview"
+        aksEnvironment = new Environment(env).previewName
       }
     } else {
       echo '''

--- a/vars/helmInstall.groovy
+++ b/vars/helmInstall.groovy
@@ -71,7 +71,7 @@ def call(DockerImage dockerImage, Map params) {
      \\/  \\/|____| |____||____| |___||_____|\\____||_____||_____|\\____|`._____.' 
                                                                                
 
-Provide values.yaml with the chart . Builds will start failing without values.yaml in near future.
+Provide values.yaml with the chart. Builds will start failing without values.yaml in the near future. 
 ================================================================================
 '''
     }

--- a/vars/helmInstall.groovy
+++ b/vars/helmInstall.groovy
@@ -11,6 +11,7 @@ def call(DockerImage dockerImage, Map params) {
 
   def subscription = params.subscription
   def environment = params.environment
+  def aksEnvironment = params.environment
   def product = params.product
   def component = params.component
 
@@ -54,6 +55,26 @@ def call(DockerImage dockerImage, Map params) {
     // default values + overrides
     def templateValues = "${helmResourcesDir}/${chartName}/values.template.yaml"
     def defaultValues = "${helmResourcesDir}/${chartName}/values.yaml"
+    if (fileExists(defaultValues)) {
+      onPR{
+        aksEnvironment ="preview"
+      }
+    }else{
+      echo '''
+================================================================================
+
+ ____      ____  _       _______     ____  _____  _____  ____  _____   ______  
+|_  _|    |_  _|/ \\     |_   __ \\   |_   \\|_   _||_   _||_   \\|_   _|.' ___  | 
+  \\ \\  /\\  / / / _ \\      | |__) |    |   \\ | |    | |    |   \\ | | / .'   \\_| 
+   \\ \\/  \\/ / / ___ \\     |  __ /     | |\\ \\| |    | |    | |\\ \\| | | |   ____ 
+    \\  /\\  /_/ /   \\ \\_  _| |  \\ \\_  _| |_\\   |_  _| |_  _| |_\\   |_\\ `.___]  |
+     \\/  \\/|____| |____||____| |___||_____|\\____||_____||_____|\\____|`._____.' 
+                                                                               
+
+Provide values.yaml with the chart . Templating will be supported only for env specific values.
+================================================================================
+'''
+    }
     if (!fileExists(templateValues) && !fileExists(defaultValues)) {
       throw new RuntimeException("No default values file found at ${templateValues} or ${defaultValues}")
     }
@@ -63,8 +84,8 @@ def call(DockerImage dockerImage, Map params) {
     values << defaultValues
 
     // environment specific values is optional
-    def valuesEnvTemplate = "${helmResourcesDir}/${chartName}/values.${environment}.template.yaml"
-    def valuesEnv = "${helmResourcesDir}/${chartName}/values.${environment}.yaml"
+    def valuesEnvTemplate = "${helmResourcesDir}/${chartName}/values.${aksEnvironment}.template.yaml"
+    def valuesEnv = "${helmResourcesDir}/${chartName}/values.${aksEnvironment}.yaml"
     if (fileExists(valuesEnvTemplate)) {
       sh "envsubst < ${valuesEnvTemplate} > ${valuesEnv}"
       values << valuesEnv

--- a/vars/helmInstall.groovy
+++ b/vars/helmInstall.groovy
@@ -6,6 +6,7 @@ import uk.gov.hmcts.contino.Consul
 import uk.gov.hmcts.contino.GithubAPI
 import uk.gov.hmcts.contino.ProjectBranch
 import uk.gov.hmcts.contino.TeamNames
+import uk.gov.hmcts.contino.Environment
 
 def call(DockerImage dockerImage, Map params) {
 

--- a/vars/helmInstall.groovy
+++ b/vars/helmInstall.groovy
@@ -59,7 +59,7 @@ def call(DockerImage dockerImage, Map params) {
       onPR{
         aksEnvironment ="preview"
       }
-    } else{
+    } else {
       echo '''
 ================================================================================
 


### PR DESCRIPTION
Refactor AKS environment configuration in Preview

Notes:
* values.yaml is used by default and is not templated.
* values.preview.template.yaml is used for preview deployments
* values.aat.template.yaml is used for aat deployments
* if values.yaml is not present the old values.aat.template.yaml pretending to be preview is used, but logs a deprecation warning
* Test build with warning: https://build.platform.hmcts.net/job/HMCTS_Platform/job/draft-store/job/PR-280/2/consoleFull
* Succesful test build: https://build.platform.hmcts.net/job/HMCTS_Platform/job/draft-store/job/PR-280/3/consoleFull
