### PR TITLE
Untag docker image if any of the parallel stages fail

### DIFF
--- a/src/uk/gov/hmcts/contino/DockerImage.groovy
+++ b/src/uk/gov/hmcts/contino/DockerImage.groovy
@@ -100,6 +100,10 @@ class DockerImage {
     return (imageTag == 'latest' ? imageTag : "${imageTag}-${this.commit}")
   }
 
+  def isLatest() {
+    return getTag() == 'latest'
+  }
+
   /**
    * Get the 'short name' of the image, without the registry prefix
    *

--- a/src/uk/gov/hmcts/contino/azure/Acr.groovy
+++ b/src/uk/gov/hmcts/contino/azure/Acr.groovy
@@ -114,7 +114,7 @@ class Acr extends Az {
 
   def untag(DockerImage dockerImage) {
     if (!dockerImage.isLatest()) {
-      this.az "acr untag -n ${registryName} -g ${resourceGroup} --image ${dockerImage.getShortName()}"
+      this.az "acr repository untag -n ${registryName} -g ${resourceGroup} --image ${dockerImage.getShortName()}"
     }
   }
 

--- a/src/uk/gov/hmcts/contino/azure/Acr.groovy
+++ b/src/uk/gov/hmcts/contino/azure/Acr.groovy
@@ -112,6 +112,12 @@ class Acr extends Az {
     this.az "acr import --force -n ${registryName} -g ${resourceGroup} --source ${dockerImage.getTaggedName()} -t ${additionalTag}"?.trim()
   }
 
+  def untag(DockerImage dockerImage) {
+    if (!dockerImage.isLatest()) {
+      this.az "acr untag -n ${registryName} -g ${resourceGroup} --image ${dockerImage.getShortName()}"
+    }
+  }
+
   def hasTag(DockerImage dockerImage) {
     return hasTag(dockerImage.getTag(), dockerImage.getRepositoryName())
   }

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -103,8 +103,9 @@ def call(params) {
               }
             }
           }
-        }
+        },
 
+        failFast: true
       )
     }
   }

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -47,7 +47,7 @@ def call(params) {
     }
   }
 
-  stage("Tests/Checks") {
+  stage("Tests/Checks/Container Build") {
     pcr.config.registerOnStageFailure {
       if (config.dockerBuild) {
         withAksClient(subscription) {


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

https://tools.hmcts.net/jira/browse/RPE-1037

Instead of serialising image build, untag the image if it has been built before one of the other tasks failed.

Notes:
*
*
*