### PR TITLE
Updated cve validity to 48 hours

### DIFF
--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -78,7 +78,7 @@ class GradleBuilder extends AbstractBuilder {
   def securityCheck() {
     steps.withCredentials([steps.usernamePassword(credentialsId: 'owasp-db-login', passwordVariable: 'OWASPDB_ACCOUNT', usernameVariable: 'OWASPDB_PASSWORD')]) {
       try {
-        gradle("-DdependencyCheck.failBuild=true -DdependencyCheck.cveValidForHours=24 -Danalyzer.central.enabled=false -DdependencyCheck.data.driver='com.microsoft.sqlserver.jdbc.SQLServerDriver' -DdependencyCheck.data.connectionString='jdbc:sqlserver://owaspdependencycheck.database.windows.net:1433;database=owaspdependencycheck;user=${steps.env.OWASPDB_ACCOUNT}@owaspdependencycheck;password=${steps.env.OWASPDB_PASSWORD};encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.database.windows.net;loginTimeout=30;' -DdependencyCheck.data.username='${steps.env.OWASPDB_ACCOUNT}' -DdependencyCheck.data.password='${steps.env.OWASPDB_PASSWORD}' dependencyCheckAnalyze")
+        gradle("-DdependencyCheck.failBuild=true -DdependencyCheck.cveValidForHours=48 -Danalyzer.central.enabled=false -DdependencyCheck.data.driver='com.microsoft.sqlserver.jdbc.SQLServerDriver' -DdependencyCheck.data.connectionString='jdbc:sqlserver://owaspdependencycheck.database.windows.net:1433;database=owaspdependencycheck;user=${steps.env.OWASPDB_ACCOUNT}@owaspdependencycheck;password=${steps.env.OWASPDB_PASSWORD};encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.database.windows.net;loginTimeout=30;' -DdependencyCheck.data.username='${steps.env.OWASPDB_ACCOUNT}' -DdependencyCheck.data.password='${steps.env.OWASPDB_PASSWORD}' dependencyCheckAnalyze")
       }
       finally {
         steps.archiveArtifacts 'build/reports/dependency-check-report.html'


### PR DESCRIPTION

Notes:
* Currently CVE validity is 24 hours and this PR updates it to 48 hours.
* This PR is a temporary resolution to download the CVE's only after 48 hours as currently there is a problem where downloading of CVE's fail intermittently and the build are completely blocked.
* Platform team is working on a more strategic which once done then this change can be reverted.
