### PR TITLE
Tag PR image using commit only after all checks have completed

### DIFF
--- a/src/uk/gov/hmcts/contino/DockerImage.groovy
+++ b/src/uk/gov/hmcts/contino/DockerImage.groovy
@@ -40,11 +40,23 @@ class DockerImage {
    * need to build an image
    *
    * @return
-   *   the image name, e.g.: 'cnpacr.azurecr.io/hmcts/alpine-test:sometag'
+   *   the image name, e.g.: 'cnpacr.azurecr.io/hmcts/alpine-test:sometag-commit'
    */
   def getTaggedName() {
     return this.getRegistryHostname().concat('/')
       .concat(this.getShortName())
+  }
+
+  /**
+   * Get the full image name, including the tag but excluding the commit.
+   * Use when you need to retag (promote) a pr image
+   *
+   * @return
+   *   the image name, e.g.: 'cnpacr.azurecr.io/hmcts/alpine-test:sometag'
+   */
+  def getBaseTaggedName() {
+    return this.getRegistryHostname().concat('/')
+      .concat(this.getBaseShortName())
   }
 
   /**

--- a/src/uk/gov/hmcts/contino/DockerImage.groovy
+++ b/src/uk/gov/hmcts/contino/DockerImage.groovy
@@ -93,6 +93,10 @@ class DockerImage {
   }
 
   def getTag(DeploymentStage stage) {
+    // if it's a PR use the full imageTag (e.g. pr-42)
+    if (stage == DeploymentStage.PR) {
+      return getTag(this.imageTag)
+    }
     return getTag(stage.label)
   }
 
@@ -108,19 +112,34 @@ class DockerImage {
    * Get the 'short name' of the image, without the registry prefix
    *
    * @return
-   *   the short name. e.g. hmcts/product-component:branch
+   *   the short name. e.g. hmcts/product-component:branch-commit or hmcts/product-component:latest
    */
   def getShortName() {
     return shortName(this.imageTag)
   }
 
   def getShortName(DeploymentStage stage) {
+    // if it's a PR use the full imageTag (e.g. pr-42)
+    if (stage == DeploymentStage.PR) {
+      return shortName(this.imageTag)
+    }
     return shortName(stage.label)
   }
 
   private def shortName(String imageTag) {
     return repositoryName().concat(':')
       .concat(getTag(imageTag))
+  }
+
+  /**
+   * Get the 'short name' of the image, without the registry prefix and the commit suffix
+   *
+   * @return
+   *   the short name. e.g. hmcts/product-component:branch
+   */
+  def getBaseShortName() {
+    return repositoryName().concat(':')
+      .concat(imageTag)
   }
 
   def getRepositoryName() {

--- a/src/uk/gov/hmcts/contino/azure/Acr.groovy
+++ b/src/uk/gov/hmcts/contino/azure/Acr.groovy
@@ -109,7 +109,8 @@ class Acr extends Az {
    */
   def retagForStage(DockerImage.DeploymentStage stage, DockerImage dockerImage) {
     def additionalTag = dockerImage.getShortName(stage)
-    this.az "acr import --force -n ${registryName} -g ${resourceGroup} --source ${dockerImage.getTaggedName()} -t ${additionalTag}"?.trim()
+    def baseTag = stage == DockerImage.DeploymentStage.PR ? dockerImage.getBaseTaggedName() : dockerImage.getTaggedName()
+    this.az "acr import --force -n ${registryName} -g ${resourceGroup} --source ${baseTag} -t ${additionalTag}"?.trim()
   }
 
   def untag(DockerImage dockerImage) {

--- a/src/uk/gov/hmcts/contino/azure/Acr.groovy
+++ b/src/uk/gov/hmcts/contino/azure/Acr.groovy
@@ -59,7 +59,7 @@ class Acr extends Az {
    *   stdout of the step
    */
   def build(DockerImage dockerImage) {
-    this.az "acr build --no-format -r ${registryName} -t ${dockerImage.getShortName()} -g ${resourceGroup} --build-arg REGISTRY_NAME=${registryName} ."
+    this.az "acr build --no-format -r ${registryName} -t ${dockerImage.getBaseShortName()} -g ${resourceGroup} --build-arg REGISTRY_NAME=${registryName} ."
   }
 
   /**

--- a/test/uk/gov/hmcts/contino/azure/AcrTest.groovy
+++ b/test/uk/gov/hmcts/contino/azure/AcrTest.groovy
@@ -46,7 +46,7 @@ class AcrTest extends Specification {
   def "build() should call az with acr build and correct arguments"() {
     when:
       dockerImage.getImageTag() >> "sometag"
-      dockerImage.getShortName() >> IMAGE_NAME
+      dockerImage.getBaseShortName() >> IMAGE_NAME
       acr.build(dockerImage)
 
     then:

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -49,13 +49,6 @@ def call(params) {
   }
 
   stage("Tests/Checks/Container Build") {
-    pcr.config.registerOnStageFailure {
-      if (config.dockerBuild) {
-        withAksClient(subscription) {
-          acr.untag(dockerImage)
-        }
-      }
-    }
 
     when (noSkipImgBuild) {
       parallel(

--- a/vars/sectionCI.groovy
+++ b/vars/sectionCI.groovy
@@ -36,6 +36,8 @@ def call(params) {
       def dockerImage = new DockerImage(product, component, acr, new ProjectBranch(env.BRANCH_NAME).imageTag(), env.GIT_COMMIT)
 
       onPR {
+        acr.retagForStage(DockerImage.DeploymentStage.PR, dockerImage)
+
         if (config.deployToAKS) {
           withTeamSecrets(config, params.environment) {
             stage('Deploy to AKS') {

--- a/vars/sectionPromoteBuildToAAT.groovy
+++ b/vars/sectionPromoteBuildToAAT.groovy
@@ -7,13 +7,15 @@ import uk.gov.hmcts.contino.ProjectBranch
 import uk.gov.hmcts.contino.azure.Acr
 
 /*
- * The image retagging in ACR is used as a trigger for Weaveworks Flux
- * to (re-)deploy the image
+ * The image retagging in ACR is used to promote an image to AAT.
+ * This will mark the image as having passed all the prior stages.
  *
  * Any image re-tagged following the pattern displayed below is
- * eventually deployed in Flux AKS cluster:
+ * not going to be rebuilt unless the commit hash changes (i.e.
+ * there is a new commit) or the environment variable NO_SKIP_IMG_BUILD
+ * is set:
  *
- * e.g.: <my-app-image>:aat-rc-<commit-hash>
+ * e.g.: <my-app-image>:aat-<commit-hash>
  */
 
 def call(params) {
@@ -26,14 +28,14 @@ def call(params) {
   def product = params.product
   def component = params.component
 
-  stage('AAT Flux deployment') {
+  stage('AAT build promotion') {
     if (config.dockerBuild) {
       withAksClient(subscription) {
 
         def acr = new Acr(this, subscription, env.REGISTRY_NAME, env.REGISTRY_RESOURCE_GROUP)
         def dockerImage = new DockerImage(product, component, acr, new ProjectBranch(env.BRANCH_NAME).imageTag(), env.GIT_COMMIT)
 
-        pcr.callAround('fluxdeployment') {
+        pcr.callAround('aatpromotion') {
           acr.retagForStage(DockerImage.DeploymentStage.AAT, dockerImage)
         }
       }

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -81,7 +81,7 @@ def call(type, String product, String component, Closure body) {
 
         onMaster {
 
-          sectionTriggerFluxDeployment(
+          sectionPromoteBuildToAAT(
             appPipelineConfig: pipelineConfig,
             pipelineCallbacksRunner: callbacksRunner,
             pipelineType: pipelineType,


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RPE-1037

There is a risk in the current implementation that a bad image is left tagged as the untag callback does not work after a test/check fails. This resolves that issue by postponing tagging the image after all the tests/checks have completed successfully

Notes:
*
*
*
