### PR TITLE
Always build for now as some frontend builds need the folder structure

### DIFF
--- a/test/withPipeline/onBranch/withJavaPipelineOnBranchTests.groovy
+++ b/test/withPipeline/onBranch/withJavaPipelineOnBranchTests.groovy
@@ -73,7 +73,7 @@ class withJavaPipelineOnBranchTests extends BasePipelineTest {
     helper.registerAllowedMethod("when", [boolean, Closure.class], {})
 
     def stubBuilder = new StubFor(GradleBuilder)
-    stubBuilder.demand.build(0) {}
+    stubBuilder.demand.build(1) {}
     stubBuilder.demand.test(0) {}
     stubBuilder.demand.securityCheck(0) {}
     stubBuilder.demand.sonarScan(0) {}

--- a/test/withPipeline/onMaster/withJavaPipelineOnMasterTests.groovy
+++ b/test/withPipeline/onMaster/withJavaPipelineOnMasterTests.groovy
@@ -57,7 +57,7 @@ class withJavaPipelineOnMasterTests extends BaseCnpPipelineTest {
 
     def stubBuilder = new StubFor(GradleBuilder)
     stubBuilder.demand.with {
-      build(0) {}
+      build(1) {}
       test(0) {}
       securityCheck(0) {}
       sonarScan(0) {}

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -40,12 +40,9 @@ def call(params) {
 
 
   stage("Build") {
-    // always build master as we currently do not deploy an image there
-    when(noSkipImgBuild || projectBranch.isMaster()) {
-      pcr.callAround('build') {
-        timeoutWithMsg(time: 15, unit: 'MINUTES', action: 'build') {
-          builder.build()
-        }
+    pcr.callAround('build') {
+      timeoutWithMsg(time: 15, unit: 'MINUTES', action: 'build') {
+        builder.build()
       }
     }
   }


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

See:

https://build.platform.hmcts.net/job/HMCTS_RPA/job/rpa-em-showcase/job/master/41/consoleFull


Notes:
*
*
*