### PR TITLE
Allow git gc to fail quietly

### DIFF
--- a/src/uk/gov/hmcts/contino/WebAppDeploy.groovy
+++ b/src/uk/gov/hmcts/contino/WebAppDeploy.groovy
@@ -190,19 +190,22 @@ class WebAppDeploy implements Serializable {
     // the "|| true" is required here to allow the pipeline to use the same env for both aat and prod stages
     steps.sh("git -c http.sslVerify=false remote add ${defaultRemote}-${env} 'https://${profile.userName}:${profile.userPWD}@${profile.publishUrl}/${serviceName}.git' || true")
     steps.sh("git -c http.sslVerify=false push ${defaultRemote}-${env} HEAD:master -f")
-
-    def basicAuthToken = "${profile.userName}:${profile.userPWD}".bytes.encodeBase64().toString()
-    steps.httpRequest acceptType: 'APPLICATION_JSON', contentType: 'APPLICATION_JSON',
-      ignoreSslErrors: true,
-      customHeaders: [[maskValue: true, name: 'Authorization', value: "Basic " + basicAuthToken]],
-      httpMode: 'POST',
-      consoleLogResponseBody: true,
-      requestBody: '''{
-    "command": "git gc",
-    "dir": "site\\\\repository"
-}''',
-      timeout: 600, // seconds
-      url: "https://${profile.publishUrl}/api/command", validResponseCodes: '200'
+    try {
+      def basicAuthToken = "${profile.userName}:${profile.userPWD}".bytes.encodeBase64().toString()
+      steps.httpRequest acceptType: 'APPLICATION_JSON', contentType: 'APPLICATION_JSON',
+        ignoreSslErrors: true,
+        customHeaders: [[maskValue: true, name: 'Authorization', value: "Basic " + basicAuthToken]],
+        httpMode: 'POST',
+        consoleLogResponseBody: true,
+        requestBody: '''{
+      "command": "git gc",
+      "dir": "site\\\\repository"
+  }''',
+        timeout: 600, // seconds
+        url: "https://${profile.publishUrl}/api/command", validResponseCodes: '200'
+    } catch (Exception ex) {
+      echo "ERROR: Failed to run git gc: ${ex}"
+    }
   }
 
 }


### PR DESCRIPTION
CMC are seeing lots of deployments fail with the `git gc` command. Only effecting cmc-citizen-frontend staging slots but not limited to one env, we have seen on aat and prod.

Just adding try catch so it will fail quietly and report in logs.
