### PR TITLE
Changing staging images to be tagged with commit hash

### DIFF
--- a/src/uk/gov/hmcts/contino/DockerImage.groovy
+++ b/src/uk/gov/hmcts/contino/DockerImage.groovy
@@ -153,7 +153,7 @@ class DockerImage {
    *   the short name. e.g. hmcts/product-component:branch
    */
   def getBaseShortName() {
-    def baseShortName = imageTag == 'staging' ? getTag(this.imageTag) : imageTag
+    def baseShortName = this.imageTag == 'staging' ? "${this.imageTag}-${this.commit}" : imageTag
     return repositoryName().concat(':')
       .concat(baseShortName)
   }

--- a/src/uk/gov/hmcts/contino/DockerImage.groovy
+++ b/src/uk/gov/hmcts/contino/DockerImage.groovy
@@ -146,14 +146,16 @@ class DockerImage {
   }
 
   /**
-   * Get the 'short name' of the image, without the registry prefix and the commit suffix
+   * Get the 'short name' of the image, without the registry prefix ,commit suffix is added only for staging.
+   * Use this while resolving name for the base image for building or re-tagging.
    *
    * @return
    *   the short name. e.g. hmcts/product-component:branch
    */
   def getBaseShortName() {
+    def baseShortName = imageTag == 'staging' ? getTag(this.imageTag) : imageTag
     return repositoryName().concat(':')
-      .concat(imageTag)
+      .concat(baseShortName)
   }
 
   def getRepositoryName() {

--- a/src/uk/gov/hmcts/contino/azure/Acr.groovy
+++ b/src/uk/gov/hmcts/contino/azure/Acr.groovy
@@ -109,7 +109,7 @@ class Acr extends Az {
    */
   def retagForStage(DockerImage.DeploymentStage stage, DockerImage dockerImage) {
     def additionalTag = dockerImage.getShortName(stage)
-    def baseTag = stage == DockerImage.DeploymentStage.PR ? dockerImage.getBaseTaggedName() : dockerImage.getTaggedName()
+    def baseTag = (stage == DockerImage.DeploymentStage.PR  || dockerImage.imageTag == 'staging') ? dockerImage.getBaseTaggedName() : dockerImage.getTaggedName()
     this.az "acr import --force -n ${registryName} -g ${resourceGroup} --source ${baseTag} -t ${additionalTag}"?.trim()
   }
 


### PR DESCRIPTION
Notes:
* Currently, staging images are tagged as staging and not with commit hash. This can make concurrent builds override latest un-tested staging image to be incorrectly tagged as prod/latest image.
