### PR TITLE
Fix git gc exception handler in WebAppDeploy

### DIFF
--- a/src/uk/gov/hmcts/contino/WebAppDeploy.groovy
+++ b/src/uk/gov/hmcts/contino/WebAppDeploy.groovy
@@ -204,7 +204,7 @@ class WebAppDeploy implements Serializable {
         timeout: 600, // seconds
         url: "https://${profile.publishUrl}/api/command", validResponseCodes: '200'
     } catch (Exception ex) {
-      echo "ERROR: Failed to run git gc: ${ex}"
+      steps.echo "ERROR: Failed to run git gc: ${ex}"
     }
   }
 


### PR DESCRIPTION
Fixes error:
```
hudson.remoting.ProxyException: groovy.lang.MissingMethodException: No signature of method: uk.gov.hmcts.contino.WebAppDeploy.echo() is applicable for argument types: (org.codehaus.groovy.runtime.GStringImpl) values: [ERROR: Failed to run git gc: java.lang.IllegalStateException: hudson.AbortException: Fail: the returned code 502 is not in the accepted range: [[200‥200]]]
Possible solutions: each(groovy.lang.Closure), wait(), any(), find(), grep(), dump()
```