### PR TITLE
Pact tests hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,23 +396,21 @@ withInfraPipeline(product) {
 
 The following hooks will then be ran before the deployment:
 
-| Role           | Order | Yarn               | Gradle                        |
-| -------------- | ----- | ------------------ | ----------------------------- |
-| Provider       | 1     | `test:pact-verify` | `runProviderPactVerification` |
-| Consumer       | 2     | `test:pact`        | `runConsumerPactTests`        |
+| Role     | Order | Yarn               | Gradle                        |
+| -------- | ----- | ------------------ | ----------------------------- |
+| Provider | 1     | `test:pact-verify` | `runProviderPactVerification` |
+| Consumer | 2     | `test:pact`        | `runConsumerPactTests`        |
 
 Notice that the Pact broker url is passed to these hooks as following:
 
-- `yarn`: `PACT_BROKER_URL` environment variable
-- `gradlew`: `-Dpact.broker.url` parameter
+- `yarn`: `PACT_BROKER_URL` and `PACT_CONSUMER_VERSION`/`PACT_PROVIDER_VERSION` environment variables
+- `gradlew`: `-Dpact.broker.url` and `-Dpact.consumer.version`/`-Dpact.provider.version` parameters
 
 It is expected that the scripts are responsible for figuring out what version (git revision, tag, branch) is currently tested.
 
 In any case the `can-i-deploy` pact-broker command is run after these ones.
 
-
 ## Contributing
 
  1. Use the Github pull requests to make change
  2. Test the change by pointing a build, to the branch with the change
-

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ import uk.gov.hmcts.contino.AppPipelineDsl.PactRoles as PactRoles
 
 /* … */
 
-withInfraPipeline(product) {
+withPipeline(product) {
 
   /* … */
 

--- a/README.md
+++ b/README.md
@@ -372,6 +372,8 @@ If you want to learn more about ACR tasks, [here is the documentation](https://d
 
 ## Contract testing with Pact
 
+#### Usage
+
 You can activate contract testing lifecycle hooks in the CI using the `enablePactAs()` method.
 
 The different hooks are based on roles that you can assign to your project: `CONSUMER` and/or `PROVIDER`. A common broker will be used as well as the naming and tagging conventions.
@@ -396,17 +398,24 @@ withInfraPipeline(product) {
 
 The following hooks will then be ran before the deployment:
 
-| Role     | Order | Yarn                           | Gradle                                  |
-| -------- | ----- | ------------------------------ | --------------------------------------- |
-| Provider | 1     | `test:pact:verify-and-publish` | `runAndPublishProviderPactVerification` |
-| Consumer | 2     | `test:pact:run-and-publish`    | `runAndPublishConsumerPactTests`        |
+| Role     | Order | Yarn                           | Gradle                                  | Active on branch |
+| -------- | ----- | ------------------------------ | --------------------------------------- | ---------------- |
+| Provider | 1     | `test:pact:verify-and-publish` | `runAndPublishProviderPactVerification` | `master` only    |
+| Consumer | 2     | `test:pact:run-and-publish`    | `runAndPublishConsumerPactTests`        | Any branch       |
 
-Notice that the Pact broker url is passed to these hooks as following:
+#### Notes
 
-- `yarn`: `PACT_BROKER_URL` and `PACT_CONSUMER_VERSION`/`PACT_PROVIDER_VERSION` environment variables
-- `gradlew`: `-Dpact.broker.url` and `-Dpact.consumer.version`/`-Dpact.provider.version` parameters
+The Pact broker url and other parameters are passed to these hooks as following:
 
-It is expected that the scripts are responsible for figuring out what version (git revision, tag, branch) is currently tested.
+- `yarn`:
+  - `PACT_BROKER_URL`
+  - `PACT_CONSUMER_VERSION`/`PACT_PROVIDER_VERSION`
+- `gradlew`:
+  - `-Dpact.broker.url`
+  - `-Dpact.consumer.version`/`-Dpact.provider.version`
+  - `-Dpact.verifier.publishResults=true` is passed by default for providers
+
+🛎️  It is expected that the scripts are responsible for figuring out which tag or branch is currently tested.
 
 The `can-i-deploy` pact-broker command is run after if the project is tagged as `CONSUMER`.
 

--- a/README.md
+++ b/README.md
@@ -398,10 +398,13 @@ withInfraPipeline(product) {
 
 The following hooks will then be ran before the deployment:
 
-| Role     | Order | Yarn                           | Gradle                                  | Active on branch |
-| -------- | ----- | ------------------------------ | --------------------------------------- | ---------------- |
-| Provider | 1     | `test:pact:verify-and-publish` | `runAndPublishProviderPactVerification` | `master` only    |
-| Consumer | 2     | `test:pact:run-and-publish`    | `runAndPublishConsumerPactTests`        | Any branch       |
+| Role       | Order | Yarn                           | Gradle                                  | Active on branch |
+| ---------- | ----- | ------------------------------ | --------------------------------------- | ---------------- |
+| `PROVIDER` | 1     | `test:pact:verify-and-publish` | `runAndPublishProviderPactVerification` | `master` only    |
+| `CONSUMER` | 2     | `test:pact:run-and-publish`    | `runAndPublishConsumerPactTests`        | Any branch       |
+| `CONSUMER` | 3     | `can-i-deploy`\*               | `can-i-deploy`\*                        | `master` only    |
+
+\*: `can-i-deploy` is already available in the CI and doesn't need any hook or installation process.
 
 #### Notes
 
@@ -416,8 +419,6 @@ The Pact broker url and other parameters are passed to these hooks as following:
   - `-Dpact.verifier.publishResults=true` is passed by default for providers
 
 🛎️  It is expected that the scripts are responsible for figuring out which tag or branch is currently tested.
-
-The `can-i-deploy` pact-broker command is run after if the project is tagged as `CONSUMER`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ Notice that the Pact broker url is passed to these hooks as following:
 
 It is expected that the scripts are responsible for figuring out what version (git revision, tag, branch) is currently tested.
 
-In any case the `can-i-deploy` pact-broker command is run after these ones.
+The `can-i-deploy` pact-broker command is run after if the project is tagged as `PROVIDER`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -396,10 +396,10 @@ withInfraPipeline(product) {
 
 The following hooks will then be ran before the deployment:
 
-| Role     | Order | Yarn               | Gradle                        |
-| -------- | ----- | ------------------ | ----------------------------- |
-| Provider | 1     | `test:pact-verify` | `runProviderPactVerification` |
-| Consumer | 2     | `test:pact`        | `runConsumerPactTests`        |
+| Role     | Order | Yarn                           | Gradle                                  |
+| -------- | ----- | ------------------------------ | --------------------------------------- |
+| Provider | 1     | `test:pact:verify-and-publish` | `runAndPublishProviderPactVerification` |
+| Consumer | 2     | `test:pact:run-and-publish`    | `runAndPublishConsumerPactTests`        |
 
 Notice that the Pact broker url is passed to these hooks as following:
 
@@ -408,7 +408,7 @@ Notice that the Pact broker url is passed to these hooks as following:
 
 It is expected that the scripts are responsible for figuring out what version (git revision, tag, branch) is currently tested.
 
-The `can-i-deploy` pact-broker command is run after if the project is tagged as `PROVIDER`.
+The `can-i-deploy` pact-broker command is run after if the project is tagged as `CONSUMER`.
 
 ## Contributing
 

--- a/src/uk/gov/hmcts/contino/AbstractBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/AbstractBuilder.groovy
@@ -25,4 +25,10 @@ abstract class AbstractBuilder implements Builder, Serializable {
   def securityScan(){
     this.securitytest.execute()
   }
+
+  @Override
+  def runProviderVerification() {}
+
+  @Override
+  def runConsumerTests() {}
 }

--- a/src/uk/gov/hmcts/contino/AngularBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/AngularBuilder.groovy
@@ -74,4 +74,13 @@ class AngularBuilder extends AbstractBuilder {
   def setupToolVersion() {
     builder.setupToolVersion()
   }
+
+  def runProviderVerification(){
+    builder.runProviderVerification()
+  }
+
+  @Override
+  def runConsumerTests(){
+    builder.runConsumerTests()
+  }
 }

--- a/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
@@ -17,8 +17,10 @@ class AppPipelineConfig extends CommonPipelineConfig implements Serializable {
   boolean securityScan = false
   boolean serviceApp = true
   boolean aksStagingDeployment = false
-
   boolean legacyDeployment = true
+  boolean pactBrokerEnabled = false
+  boolean pactProviderVerificationsEnabled = false
+  boolean pactConsumerTestsEnabled = false
 
   int crossBrowserTestTimeout
   int perfTestTimeout

--- a/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
@@ -87,8 +87,12 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
     config.aksStagingDeployment = true
   }
 
-  void enablePactBroker() {
+  enum PactRoles { CONSUMER, PROVIDER }
+
+  void enablePactAs(List<PactRoles> roles) {
     config.pactBrokerEnabled = true
+    config.pactConsumerTestsEnabled = roles.contains(PactRoles.CONSUMER)
+    config.pactProviderVerificationsEnabled = roles.contains(PactRoles.PROVIDER)
   }
 
 }

--- a/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
@@ -87,4 +87,8 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
     config.aksStagingDeployment = true
   }
 
+  void enablePactBroker() {
+    config.pactBrokerEnabled = true
+  }
+
 }

--- a/src/uk/gov/hmcts/contino/Builder.groovy
+++ b/src/uk/gov/hmcts/contino/Builder.groovy
@@ -14,6 +14,8 @@ interface Builder {
   def mutationTest()
   def fullFunctionalTest()
   def securityScan()
+  def runProviderVerification()
+  def runConsumerTests()
 
   /**
    * Setup any required versions of a tool

--- a/src/uk/gov/hmcts/contino/Environment.groovy
+++ b/src/uk/gov/hmcts/contino/Environment.groovy
@@ -8,6 +8,7 @@ class Environment implements Serializable {
   def final hmctsDemoName
   def final perftestName
   def final ithcName
+  def final pactBrokerUrl
 
   def final functionalTestEnvironments
 
@@ -22,6 +23,7 @@ class Environment implements Serializable {
     hmctsDemoName = env.HMCTSDEMO_ENVIRONMENT_NAME ?: 'hmctsdemo'
     perftestName = env.PERFTEST_ENVIRONMENT_NAME ?: 'perftest'
     ithcName = env.ITHC_ENVIRONMENT_NAME ?: 'ithc'
+    pactBrokerUrl = env.PACT_BROKER_URL ?: 'https://pact-broker.platform.hmcts.net'
 
     functionalTestEnvironments = [nonProdName, previewName]
   }

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -105,11 +105,11 @@ EOF
   }
 
   def runProviderVerification(pactBrokerUrl, version) {
-    gradle("-Dpact.broker.url=${pactBrokerUrl} -Dpact.provider.version=${version} runProviderPactVerification")
+    gradle("-Dpact.broker.url=${pactBrokerUrl} -Dpact.provider.version=${version} runAndPublishProviderPactVerification")
   }
 
   def runConsumerTests(pactBrokerUrl, version) {
-    gradle("-Dpact.broker.url=${pactBrokerUrl} -Dpact.consumer.version=${version} runConsumerPactTests")
+    gradle("-Dpact.broker.url=${pactBrokerUrl} -Dpact.consumer.version=${version} runAndPublishConsumerPactTests")
   }
 
   def gradle(String task) {

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -105,7 +105,7 @@ EOF
   }
 
   def runProviderVerification(pactBrokerUrl, version) {
-    gradle("-Dpact.broker.url=${pactBrokerUrl} -Dpact.provider.version=${version} runAndPublishProviderPactVerification")
+    gradle("-Dpact.broker.url=${pactBrokerUrl} -Dpact.provider.version=${version} -Dpact.verifier.publishResults=true runAndPublishProviderPactVerification")
   }
 
   def runConsumerTests(pactBrokerUrl, version) {

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -104,6 +104,14 @@ EOF
 '''
   }
 
+  def runProviderVerification() {
+    gradle('runProviderPactVerification')
+  }
+
+  def runConsumerTests() {
+    gradle('runConsumerPactTests')
+  }
+
   def gradle(String task) {
     addInitScript()
     steps.sh("./gradlew --no-daemon --init-script init.gradle ${task}")

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -104,12 +104,12 @@ EOF
 '''
   }
 
-  def runProviderVerification() {
-    gradle('runProviderPactVerification')
+  def runProviderVerification(pactBrokerUrl) {
+    gradle("-Dpact.broker.url=${pactBrokerUrl} runProviderPactVerification")
   }
 
-  def runConsumerTests() {
-    gradle('runConsumerPactTests')
+  def runConsumerTests(pactBrokerUrl) {
+    gradle("-Dpact.broker.url=${pactBrokerUrl} runConsumerPactTests")
   }
 
   def gradle(String task) {

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -104,12 +104,12 @@ EOF
 '''
   }
 
-  def runProviderVerification(pactBrokerUrl) {
-    gradle("-Dpact.broker.url=${pactBrokerUrl} runProviderPactVerification")
+  def runProviderVerification(pactBrokerUrl, version) {
+    gradle("-Dpact.broker.url=${pactBrokerUrl} -Dpact.provider.version=${version} runProviderPactVerification")
   }
 
-  def runConsumerTests(pactBrokerUrl) {
-    gradle("-Dpact.broker.url=${pactBrokerUrl} runConsumerPactTests")
+  def runConsumerTests(pactBrokerUrl, version) {
+    gradle("-Dpact.broker.url=${pactBrokerUrl} -Dpact.consumer.version=${version} runConsumerPactTests")
   }
 
   def gradle(String task) {
@@ -149,10 +149,10 @@ EOF
         steps.env.PATH = "${steps.env.JAVA_HOME}/bin:${steps.env.PATH}"
       }
     } catch(err) {
-      steps.echo "Failed to detect java version, ensure the root project has sourceCompatibility set" 
+      steps.echo "Failed to detect java version, ensure the root project has sourceCompatibility set"
     }
     steps.sh "java -version"
-    
+
   }
 
   def hasPlugin(String pluginName) {

--- a/src/uk/gov/hmcts/contino/PactBroker.groovy
+++ b/src/uk/gov/hmcts/contino/PactBroker.groovy
@@ -16,10 +16,16 @@ class PactBroker {
     this.brokerUrl = brokerUrl
   }
 
+  /**
+   * Runs the can-i-deploy command
+   * @param version the version of the current project, usually a git commit hash
+   * @return
+   */
   def canIDeploy(version) {
+    def reference = "${this.product}_${this.component}"
     steps.withDocker(PACT_BROKER_IMAGE, '--entrypoint ""') {
       steps.sh(
-        script: "pact-broker can-i-deploy --retry-while-unknown=12 --retry-interval=10 -a ${this.product}_${this.component} -b ${this.brokerUrl} -e ${version}",
+        script: "pact-broker can-i-deploy --retry-while-unknown=12 --retry-interval=10 -a ${reference} -b ${this.brokerUrl} -e ${version}",
         returnStdout: true
       )?.trim()
     }

--- a/src/uk/gov/hmcts/contino/PactBroker.groovy
+++ b/src/uk/gov/hmcts/contino/PactBroker.groovy
@@ -2,23 +2,24 @@ package uk.gov.hmcts.contino
 
 class PactBroker {
 
-  static String PACT_BROKER_URL = "https://pact-broker.platform.hmcts.net"
   static String PACT_BROKER_IMAGE = "hmcts/pact-broker-cli"
 
   def steps
   def product
   def component
+  def brokerUrl
 
-  PactBroker(steps, product, component) {
+  PactBroker(steps, product, component, brokerUrl) {
     this.steps = steps
     this.product = product
     this.component = component
+    this.brokerUrl = brokerUrl
   }
 
   def canIDeploy(version) {
     steps.withDocker(PACT_BROKER_IMAGE, '--entrypoint ""') {
       steps.sh(
-        script: "pact-broker can-i-deploy --retry-while-unknown=12 --retry-interval=10 -a ${this.product}_${this.component} -b ${PACT_BROKER_URL} -e ${version}",
+        script: "pact-broker can-i-deploy --retry-while-unknown=12 --retry-interval=10 -a ${this.product}_${this.component} -b ${this.brokerUrl} -e ${version}",
         returnStdout: true
       )?.trim()
     }

--- a/src/uk/gov/hmcts/contino/PactBroker.groovy
+++ b/src/uk/gov/hmcts/contino/PactBroker.groovy
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.contino
+
+class PactBroker {
+
+  static String PACT_BROKER_URL = "https://pact-broker.platform.hmcts.net"
+  static String PACT_BROKER_IMAGE = "hmcts/pact-broker-cli"
+
+  def steps
+  def product
+  def component
+
+  PactBroker(steps, product, component) {
+    this.steps = steps
+    this.product = product
+    this.component = component
+  }
+
+  def canIDeploy(version) {
+    steps.withDocker(PACT_BROKER_IMAGE, '--entrypoint ""') {
+      steps.sh(
+        script: "pact-broker can-i-deploy --retry-while-unknown=12 --retry-interval=10 -a ${this.product}_${this.component} -b ${PACT_BROKER_URL} -e ${version}",
+        returnStdout: true
+      )?.trim()
+    }
+  }
+}

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -106,7 +106,7 @@ EOF
    * @return
    */
   def runProviderVerification(pactBrokerUrl, version) {
-    steps.sh("PACT_BROKER_URL=${pactBrokerUrl} PACT_PROVIDER_VERSION=${version} yarn test:pact-verify")
+    steps.sh("PACT_BROKER_URL=${pactBrokerUrl} PACT_PROVIDER_VERSION=${version} yarn test:pact:verify-and-publish")
   }
 
   /**
@@ -116,7 +116,7 @@ EOF
    * @return
    */
   def runConsumerTests(pactBrokerUrl, version) {
-    steps.sh("PACT_BROKER_URL=${pactBrokerUrl} PACT_CONSUMER_VERSION=${version} yarn test:pact")
+    steps.sh("PACT_BROKER_URL=${pactBrokerUrl} PACT_CONSUMER_VERSION=${version} yarn test:pact:run-and-publish")
   }
 
   private runYarn(task){

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -99,12 +99,24 @@ EOF
     '''
   }
 
-  def runProviderVerification(pactBrokerUrl) {
-    steps.sh("PACT_BROKER_URL=${pactBrokerUrl} yarn test:pact-verify")
+  /**
+   * Triggers a yarn hook
+   * @param pactBrokerUrl the url of the pact broker
+   * @param version the version of the current project, usually a git commit hash
+   * @return
+   */
+  def runProviderVerification(pactBrokerUrl, version) {
+    steps.sh("PACT_BROKER_URL=${pactBrokerUrl} PACT_PROVIDER_VERSION=${version} yarn test:pact-verify")
   }
 
-  def runConsumerTests(pactBrokerUrl) {
-    steps.sh("PACT_BROKER_URL=${pactBrokerUrl} yarn test:pact")
+  /**
+   * Triggers a yarn hook
+   * @param pactBrokerUrl the url of the pact broker
+   * @param version the version of the current project, usually a git commit hash
+   * @return
+   */
+  def runConsumerTests(pactBrokerUrl, version) {
+    steps.sh("PACT_BROKER_URL=${pactBrokerUrl} PACT_CONSUMER_VERSION=${version} yarn test:pact")
   }
 
   private runYarn(task){

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -99,12 +99,12 @@ EOF
     '''
   }
 
-  def runProviderVerification() {
-    runYarn('test:pact-verify')
+  def runProviderVerification(pactBrokerUrl) {
+    steps.sh("PACT_BROKER_URL=${pactBrokerUrl} yarn test:pact-verify")
   }
 
-  def runConsumerTests() {
-    runYarn('test:pact')
+  def runConsumerTests(pactBrokerUrl) {
+    steps.sh("PACT_BROKER_URL=${pactBrokerUrl} yarn test:pact")
   }
 
   private runYarn(task){

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -84,7 +84,7 @@ class YarnBuilder extends AbstractBuilder {
 
   def securityCheck() {
     // no-op
-    // to be replaced with yarn audit once suppressing vulnerabilities is possible 
+    // to be replaced with yarn audit once suppressing vulnerabilities is possible
     // https://github.com/yarnpkg/yarn/issues/6669
   }
 
@@ -97,6 +97,14 @@ commit: $(git rev-parse HEAD)
 date: $(date)
 EOF
     '''
+  }
+
+  def runProviderVerification() {
+    runYarn('test:pact-verify')
+  }
+
+  def runConsumerTests() {
+    runYarn('test:pact')
   }
 
   private runYarn(task){

--- a/test/uk/gov/hmcts/contino/AbstractBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/AbstractBuilderTest.groovy
@@ -95,6 +95,16 @@ class AbstractBuilderTest extends Specification {
     }
 
     @Override
+    def runProviderVerification() {
+      return null
+    }
+
+    @Override
+    def runConsumerTests() {
+      return null
+    }
+
+    @Override
     def setupToolVersion() {
       return null
     }

--- a/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
+++ b/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
@@ -30,6 +30,9 @@ class AppPipelineConfigTest extends Specification {
       assertThat(pipelineConfig.securityScan).isFalse()
       assertThat(pipelineConfig.legacyDeployment).isTrue()
       assertThat(pipelineConfig.serviceApp).isTrue()
+      assertThat(pipelineConfig.pactBrokerEnabled).isFalse()
+      assertThat(pipelineConfig.pactProviderVerificationsEnabled).isFalse()
+      assertThat(pipelineConfig.pactConsumerTestsEnabled).isFalse()
   }
 
   def "ensure securityScan can be set in steps"() {

--- a/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
+++ b/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
@@ -50,7 +50,7 @@ class AppPipelineConfigTest extends Specification {
       assertThat(pipelineConfig.vaultSecrets).isEqualTo(secrets)
   }
 
-  def "load vault secrets (deprecated)"() {
+  def "load vault secrets - deprecated"() {
     given:
       def secrets = [['secretName': 'name', 'var': 'var']]
     when:
@@ -149,4 +149,46 @@ class AppPipelineConfigTest extends Specification {
     then:
     assertThat(pipelineConfig.aksStagingDeployment).isTrue()
   }
+
+  def "ensure enable pact broker deployment check"() {
+    given:
+      assertThat(pipelineConfig.pactBrokerEnabled).isFalse()
+    when:
+      dsl.enablePactAs([])
+    then:
+      assertThat(pipelineConfig.pactBrokerEnabled).isTrue()
+  }
+
+  def "ensure enable pact consumer tests"() {
+    given:
+      assertThat(pipelineConfig.pactConsumerTestsEnabled).isFalse()
+    when:
+      dsl.enablePactAs([AppPipelineDsl.PactRoles.CONSUMER])
+    then:
+      assertThat(pipelineConfig.pactConsumerTestsEnabled).isTrue()
+  }
+
+  def "ensure enable pact provider verification"() {
+    given:
+      assertThat(pipelineConfig.pactProviderVerificationsEnabled).isFalse()
+    when:
+      dsl.enablePactAs([AppPipelineDsl.PactRoles.PROVIDER])
+    then:
+      assertThat(pipelineConfig.pactProviderVerificationsEnabled).isTrue()
+  }
+
+  def "ensure enable pact consumer tests and provider verification"() {
+    given:
+      assertThat(pipelineConfig.pactProviderVerificationsEnabled).isFalse()
+      assertThat(pipelineConfig.pactBrokerEnabled).isFalse()
+    when:
+      dsl.enablePactAs([
+        AppPipelineDsl.PactRoles.CONSUMER,
+        AppPipelineDsl.PactRoles.PROVIDER
+      ])
+    then:
+      assertThat(pipelineConfig.pactProviderVerificationsEnabled).isTrue()
+      assertThat(pipelineConfig.pactConsumerTestsEnabled).isTrue()
+  }
+
 }

--- a/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
@@ -87,7 +87,7 @@ class GradleBuilderTest extends Specification {
       builder.runProviderVerification(PACT_BROKER_URL, version)
     then:
       1 * steps.sh({it.startsWith(GRADLE_CMD) &&
-                    it.contains("-Dpact.broker.url=${PACT_BROKER_URL} -Dpact.provider.version=${version} runProviderPactVerification")})
+                    it.contains("-Dpact.broker.url=${PACT_BROKER_URL} -Dpact.provider.version=${version} runAndPublishProviderPactVerification")})
   }
 
   def "runConsumerTests triggers a gradlew hook"() {
@@ -97,6 +97,6 @@ class GradleBuilderTest extends Specification {
       builder.runConsumerTests(PACT_BROKER_URL, version)
     then:
       1 * steps.sh({it.startsWith(GRADLE_CMD) &&
-                    it.contains("-Dpact.broker.url=${PACT_BROKER_URL} -Dpact.consumer.version=${version} runConsumerPactTests")})
+                    it.contains("-Dpact.broker.url=${PACT_BROKER_URL} -Dpact.consumer.version=${version} runAndPublishConsumerPactTests")})
   }
 }

--- a/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
@@ -5,6 +5,7 @@ import spock.lang.Specification
 class GradleBuilderTest extends Specification {
 
   static final String GRADLE_CMD = './gradlew'
+  static final String PACT_BROKER_URL = "https://pact-broker.platform.hmcts.net"
 
   def steps
 
@@ -81,16 +82,16 @@ class GradleBuilderTest extends Specification {
 
   def "runProviderVerification triggers a gradlew hook"() {
     when:
-      builder.runProviderVerification()
+      builder.runProviderVerification(PACT_BROKER_URL)
     then:
-      1 * steps.sh({ it.startsWith(GRADLE_CMD) && it.contains("runProviderPactVerification") })
+      1 * steps.sh({ it.startsWith(GRADLE_CMD) && it.contains("-Dpact.broker.url=${PACT_BROKER_URL} runProviderPactVerification") })
   }
 
   def "runConsumerTests triggers a gradlew hook"() {
     when:
-      builder.runConsumerTests()
+      builder.runConsumerTests(PACT_BROKER_URL)
     then:
-      1 * steps.sh({ it.startsWith(GRADLE_CMD) && it.contains("runConsumerPactTests") })
+      1 * steps.sh({ it.startsWith(GRADLE_CMD) && it.contains("-Dpact.broker.url=${PACT_BROKER_URL} runConsumerPactTests") })
   }
 
 }

--- a/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
@@ -81,17 +81,22 @@ class GradleBuilderTest extends Specification {
   }
 
   def "runProviderVerification triggers a gradlew hook"() {
+    setup:
+      def version = "v3r510n"
     when:
-      builder.runProviderVerification(PACT_BROKER_URL)
+      builder.runProviderVerification(PACT_BROKER_URL, version)
     then:
-      1 * steps.sh({ it.startsWith(GRADLE_CMD) && it.contains("-Dpact.broker.url=${PACT_BROKER_URL} runProviderPactVerification") })
+      1 * steps.sh({it.startsWith(GRADLE_CMD) &&
+                    it.contains("-Dpact.broker.url=${PACT_BROKER_URL} -Dpact.provider.version=${version} runProviderPactVerification")})
   }
 
   def "runConsumerTests triggers a gradlew hook"() {
+    setup:
+      def version = "v3r510n"
     when:
-      builder.runConsumerTests(PACT_BROKER_URL)
+      builder.runConsumerTests(PACT_BROKER_URL, version)
     then:
-      1 * steps.sh({ it.startsWith(GRADLE_CMD) && it.contains("-Dpact.broker.url=${PACT_BROKER_URL} runConsumerPactTests") })
+      1 * steps.sh({it.startsWith(GRADLE_CMD) &&
+                    it.contains("-Dpact.broker.url=${PACT_BROKER_URL} -Dpact.consumer.version=${version} runConsumerPactTests")})
   }
-
 }

--- a/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
@@ -79,4 +79,18 @@ class GradleBuilderTest extends Specification {
       1 * steps.sh({ GString it -> it.startsWith(GRADLE_CMD) && it.contains('dependencyCheckAnalyze') })
   }
 
+  def "runProviderVerification triggers a gradlew hook"() {
+    when:
+      builder.runProviderVerification()
+    then:
+      1 * steps.sh({ it.startsWith(GRADLE_CMD) && it.contains("runProviderPactVerification") })
+  }
+
+  def "runConsumerTests triggers a gradlew hook"() {
+    when:
+      builder.runConsumerTests()
+    then:
+      1 * steps.sh({ it.startsWith(GRADLE_CMD) && it.contains("runConsumerPactTests") })
+  }
+
 }

--- a/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
@@ -87,7 +87,7 @@ class GradleBuilderTest extends Specification {
       builder.runProviderVerification(PACT_BROKER_URL, version)
     then:
       1 * steps.sh({it.startsWith(GRADLE_CMD) &&
-                    it.contains("-Dpact.broker.url=${PACT_BROKER_URL} -Dpact.provider.version=${version} runAndPublishProviderPactVerification")})
+                    it.contains("-Dpact.broker.url=${PACT_BROKER_URL} -Dpact.provider.version=${version} -Dpact.verifier.publishResults=true runAndPublishProviderPactVerification")})
   }
 
   def "runConsumerTests triggers a gradlew hook"() {

--- a/test/uk/gov/hmcts/contino/PactBrokerTest.groovy
+++ b/test/uk/gov/hmcts/contino/PactBrokerTest.groovy
@@ -20,7 +20,7 @@ class PactBrokerTest extends Specification {
 
   def "canIDeploy calls the pack-broker command in a container with the right parameters"() {
     given:
-      pactBroker = new PactBroker(steps, PRODUCT, COMPONENT)
+      pactBroker = new PactBroker(steps, PRODUCT, COMPONENT, PACT_BROKER_URL)
       version = "rand0mha5h"
       def closure
 

--- a/test/uk/gov/hmcts/contino/PactBrokerTest.groovy
+++ b/test/uk/gov/hmcts/contino/PactBrokerTest.groovy
@@ -1,0 +1,42 @@
+package uk.gov.hmcts.contino
+
+import spock.lang.Specification
+import static org.assertj.core.api.Assertions.*
+
+class PactBrokerTest extends Specification {
+
+  static final String PACT_BROKER_URL   = "https://pact-broker.platform.hmcts.net"
+  static final String PACT_BROKER_IMAGE = "hmcts/pact-broker-cli"
+  static final String PRODUCT           = 'product'
+  static final String COMPONENT         = 'component'
+
+  def steps
+  def pactBroker
+  def version
+
+  void setup() {
+    steps = Mock(JenkinsStepMock.class)
+  }
+
+  def "canIDeploy calls the pack-broker command in a container with the right parameters"() {
+    given:
+      pactBroker = new PactBroker(steps, PRODUCT, COMPONENT)
+      version = "rand0mha5h"
+      def closure
+
+    when:
+      pactBroker.canIDeploy(version)
+
+    then:
+      1 * steps.withDocker(PACT_BROKER_IMAGE, '--entrypoint ""', { closure = it })
+
+    when:
+      closure.call()
+
+    then:
+      1 * steps.sh({ it.get('script').contains("pact-broker can-i-deploy --retry-while-unknown=12 --retry-interval=10 -a product_component -b ${PACT_BROKER_URL} -e ${version}") &&
+                     it.get('returnStdout').equals(true) })
+
+  }
+
+}

--- a/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
@@ -124,7 +124,7 @@ class YarnBuilderTest extends Specification {
     when:
       builder.runProviderVerification(PACT_BROKER_URL, version)
     then:
-      1 * steps.sh({ it.contains("PACT_BROKER_URL=${PACT_BROKER_URL} PACT_PROVIDER_VERSION=${version} yarn test:pact-verify") })
+      1 * steps.sh({ it.contains("PACT_BROKER_URL=${PACT_BROKER_URL} PACT_PROVIDER_VERSION=${version} yarn test:pact:verify-and-publish") })
   }
 
   def "runConsumerTests triggers a yarn hook"() {
@@ -133,6 +133,6 @@ class YarnBuilderTest extends Specification {
     when:
       builder.runConsumerTests(PACT_BROKER_URL, version)
     then:
-      1 * steps.sh({ it.contains("PACT_BROKER_URL=${PACT_BROKER_URL} PACT_CONSUMER_VERSION=${version} yarn test:pact") })
+      1 * steps.sh({ it.contains("PACT_BROKER_URL=${PACT_BROKER_URL} PACT_CONSUMER_VERSION=${version} yarn test:pact:run-and-publish") })
   }
 }

--- a/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
@@ -117,5 +117,19 @@ class YarnBuilderTest extends Specification {
         1*steps.sh({ it.startsWith(YARN_CMD) && it.contains('test:fullfunctional') })
   }
 
+  def "runProviderVerification triggers a yarn hook"() {
+    when:
+      builder.runProviderVerification()
+    then:
+      1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains("test:pact-verify") })
+  }
+
+  def "runConsumerTests triggers a yarn hook"() {
+    when:
+      builder.runConsumerTests()
+    then:
+      1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains("test:pact") })
+  }
+
 
 }

--- a/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
@@ -119,18 +119,20 @@ class YarnBuilderTest extends Specification {
   }
 
   def "runProviderVerification triggers a yarn hook"() {
+    setup:
+      def version = "v3r510n"
     when:
-      builder.runProviderVerification("${PACT_BROKER_URL}")
+      builder.runProviderVerification(PACT_BROKER_URL, version)
     then:
-      1 * steps.sh({ it.contains("PACT_BROKER_URL=${PACT_BROKER_URL} yarn test:pact-verify") })
+      1 * steps.sh({ it.contains("PACT_BROKER_URL=${PACT_BROKER_URL} PACT_PROVIDER_VERSION=${version} yarn test:pact-verify") })
   }
 
   def "runConsumerTests triggers a yarn hook"() {
+    setup:
+      def version = "v3r510n"
     when:
-      builder.runConsumerTests("${PACT_BROKER_URL}")
+      builder.runConsumerTests(PACT_BROKER_URL, version)
     then:
-      1 * steps.sh({ it.contains("PACT_BROKER_URL=${PACT_BROKER_URL} yarn test:pact") })
+      1 * steps.sh({ it.contains("PACT_BROKER_URL=${PACT_BROKER_URL} PACT_CONSUMER_VERSION=${version} yarn test:pact") })
   }
-
-
 }

--- a/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
@@ -4,6 +4,7 @@ import spock.lang.Specification
 
 class YarnBuilderTest extends Specification {
   static final String YARN_CMD = 'yarn'
+  static final String PACT_BROKER_URL = "https://pact-broker.platform.hmcts.net"
 
   def steps
 
@@ -119,16 +120,16 @@ class YarnBuilderTest extends Specification {
 
   def "runProviderVerification triggers a yarn hook"() {
     when:
-      builder.runProviderVerification()
+      builder.runProviderVerification("${PACT_BROKER_URL}")
     then:
-      1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains("test:pact-verify") })
+      1 * steps.sh({ it.contains("PACT_BROKER_URL=${PACT_BROKER_URL} yarn test:pact-verify") })
   }
 
   def "runConsumerTests triggers a yarn hook"() {
     when:
-      builder.runConsumerTests()
+      builder.runConsumerTests("${PACT_BROKER_URL}")
     then:
-      1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains("test:pact") })
+      1 * steps.sh({ it.contains("PACT_BROKER_URL=${PACT_BROKER_URL} yarn test:pact") })
   }
 
 

--- a/test/withPipeline/onBranch/withNodeJsPipelineOnBranchPactTests.groovy
+++ b/test/withPipeline/onBranch/withNodeJsPipelineOnBranchPactTests.groovy
@@ -1,0 +1,82 @@
+package withPipeline.onBranch
+
+import com.lesfurets.jenkins.unit.BasePipelineTest
+import groovy.mock.interceptor.MockFor
+import groovy.mock.interceptor.StubFor
+import org.junit.Test
+import uk.gov.hmcts.contino.*
+
+import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
+import static uk.gov.hmcts.contino.ProjectSource.projectSource
+
+class withNodeJsPipelineOnBranchPactTests extends BasePipelineTest {
+  final static jenkinsFile = "exampleNodeJsPipelineForPact.jenkins"
+
+  // get the 'project' directory
+  String projectDir = (new File(this.getClass().getClassLoader().getResource(jenkinsFile).toURI())).parentFile.parentFile.parentFile.parentFile
+
+  withNodeJsPipelineOnBranchPactTests() {
+    super.setUp()
+    binding.setVariable("scm", null)
+    binding.setVariable("env", [BRANCH_NAME: "feature-branch"])
+    binding.setVariable("Jenkins", [instance: new MockJenkins(new MockJenkinsPluginManager([new MockJenkinsPlugin('sonar', true) ] as MockJenkinsPlugin[]))])
+
+    def library = library()
+      .name('Infrastructure')
+      .targetPath(projectDir)
+      .retriever(projectSource(projectDir))
+      .defaultVersion("master")
+      .allowOverride(true)
+      .implicit(false)
+      .build()
+    helper.registerSharedLibrary(library)
+    helper.registerAllowedMethod("deleteDir", {})
+    helper.registerAllowedMethod("stash", [Map.class], {})
+    helper.registerAllowedMethod("unstash", [String.class], {})
+    helper.registerAllowedMethod("withEnv", [List.class, Closure.class], {})
+    helper.registerAllowedMethod("ansiColor", [String.class, Closure.class], { s, c -> c.call() })
+    helper.registerAllowedMethod("withCredentials", [LinkedHashMap, Closure.class], { c -> c.call()})
+    helper.registerAllowedMethod("azureServicePrincipal", [LinkedHashMap, Closure.class], { c -> c.call()})
+    helper.registerAllowedMethod("sh", [Map.class], { return "" })
+    helper.registerAllowedMethod('fileExists', [String.class], { c -> true })
+    helper.registerAllowedMethod("timestamps", [Closure.class], { c -> c.call() })
+    helper.registerAllowedMethod("withSonarQubeEnv", [String.class, Closure.class], { s, c -> c.call() })
+    helper.registerAllowedMethod("waitForQualityGate", { [status: 'OK'] })
+  }
+
+  @Test
+  void PipelineExecutesExpectedSteps() {
+    def stubBuilder = new StubFor(YarnBuilder)
+    def stubPactBroker = new StubFor(PactBroker)
+
+    stubBuilder.demand.with {
+      setupToolVersion(1) {}
+      build(1) {}
+      test(1) {}
+      sonarScan(1) {}
+      securityCheck(1) {}
+      runConsumerTests(1) { url, version -> return null }
+      runProviderVerification(0) { url, version -> return null }
+    }
+
+    stubPactBroker.demand.with {
+      canIDeploy(0) { version -> return null }
+    }
+
+
+    // ensure no deployer methods are called
+    def mockDeployer = new MockFor(NodeDeployer)
+
+    mockDeployer.use {
+      stubBuilder.use {
+        stubPactBroker.use {
+          runScript("testResources/$jenkinsFile")
+        }
+      }
+    }
+
+    stubBuilder.expect.verify()
+    stubPactBroker.expect.verify()
+  }
+}
+

--- a/test/withPipeline/onMaster/withNodeJsPipelinePactOnMasterTests.groovy
+++ b/test/withPipeline/onMaster/withNodeJsPipelinePactOnMasterTests.groovy
@@ -1,0 +1,66 @@
+package withPipeline.onMaster
+
+import groovy.mock.interceptor.MockFor
+import groovy.mock.interceptor.StubFor
+import org.junit.Test
+import uk.gov.hmcts.contino.YarnBuilder
+import uk.gov.hmcts.contino.PactBroker
+import uk.gov.hmcts.contino.NodeDeployer
+import withPipeline.BaseCnpPipelineTest
+
+class withNodeJsPipelinePactOnMaster extends BaseCnpPipelineTest {
+  final static jenkinsFile = "exampleNodeJsPipelineForPact.jenkins"
+
+  withNodeJsPipelinePactOnMaster() {
+    super("master", jenkinsFile)
+  }
+
+  @Test
+  void PipelineExecutesExpectedStepsInExpectedOrder() {
+    def stubBuilder = new StubFor(YarnBuilder)
+    def stubPactBroker = new StubFor(PactBroker)
+
+    stubBuilder.demand.with {
+      setupToolVersion(1) {}
+      build(1) {}
+      test(1) {}
+      sonarScan(1) {}
+      securityCheck(1) {}
+      runConsumerTests(1) { url, version -> return null }
+      runProviderVerification(1) { url, version -> return null }
+      smokeTest(1) {} //aat-staging
+      functionalTest(1) {}
+      smokeTest(3) {} // aat-prod, prod-staging, prod-prod
+    }
+
+    stubPactBroker.demand.with {
+      canIDeploy(1) { version -> return null }
+    }
+
+    def mockDeployer = new MockFor(NodeDeployer)
+    mockDeployer.ignore.getServiceUrl() { env, slot -> return null} // we don't care when or how often this is called
+    mockDeployer.demand.with {
+      // aat-staging
+      deploy() {}
+      healthCheck() { env, slot -> return null }
+      // aat-prod
+      healthCheck() { env, slot -> return null }
+      // prod-staging
+      deploy() {}
+      healthCheck() { env, slot -> return null }
+      // prod-prod
+      healthCheck() { env, slot -> return null }
+    }
+
+    stubBuilder.use {
+      stubPactBroker.use {
+        mockDeployer.use {
+          runScript("testResources/$jenkinsFile")
+        }
+      }
+    }
+
+    stubBuilder.expect.verify()
+    stubPactBroker.expect.verify()
+  }
+}

--- a/testResources/exampleNodeJsPipelineForPact.jenkins
+++ b/testResources/exampleNodeJsPipelineForPact.jenkins
@@ -1,0 +1,15 @@
+#!groovy
+
+@Library("Infrastructure")
+import uk.gov.hmcts.contino.AppPipelineDsl.PactRoles as PactRoles
+
+def product = "product"
+
+def app = "app"
+
+withPipeline('nodejs', product, app) {
+  enablePactAs([
+    PactRoles.CONSUMER,
+    PactRoles.PROVIDER
+  ])
+}

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -16,6 +16,7 @@ def call(params) {
   def subscription = params.subscription
   def product = params.product
   def component = params.component
+  def pactBrokerUrl = params.pactBrokerUrl
   def acr
   def dockerImage
   def projectBranch
@@ -116,18 +117,18 @@ def call(params) {
 
       if (config.pactConsumerTestsEnabled) {
         pcr.callAround('pact-consumer-tests') {
-          builder.runConsumerTests()
+          builder.runConsumerTests(pactBrokerUrl)
         }
       }
 
       if (config.pactProviderVerificationsEnabled) {
         pcr.callAround('pact-provider-verification') {
-          builder.runProviderVerification()
+          builder.runProviderVerification(pactBrokerUrl)
         }
       }
 
       pcr.callAround('pact-deployment-verification') {
-        def pactBroker = new PactBroker(this, product, component)
+        def pactBroker = new PactBroker(this, product, component, pactBrokerUrl)
         if (env.CHANGE_BRANCH || env.BRANCH_NAME == 'master') {
           pactBroker.canIDeploy(version)
         }

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -120,7 +120,7 @@ def call(params) {
       env.PACT_BROKER_URL = pactBrokerUrl
 
       /*
-       * These instructions have to be kept in that order
+       * These instructions have to be kept in order
        */
 
       if (config.pactConsumerTestsEnabled) {

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -134,7 +134,7 @@ def call(params) {
       if (config.pactConsumerTestsEnabled) {
         pcr.callAround('pact-deployment-verification') {
           def pactBroker = new PactBroker(this, product, component, pactBrokerUrl)
-          if (env.CHANGE_BRANCH || env.BRANCH_NAME == 'master') {
+          if (env.CHANGE_BRANCH && env.BRANCH_NAME == 'master') {
             pactBroker.canIDeploy(version)
           }
         }

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -122,4 +122,16 @@ def call(params) {
     }
   }
 
+  if (config.pactBrokerEnabled) {
+    stage("Pact verification") {
+      pcr.callAround('pact-verification') {
+        def version = sh(returnStdout: true, script: 'git rev-parse --verify --short HEAD')
+        def pactBroker = new PactBroker(this, product, component)
+        if (env.CHANGE_BRANCH || env.BRANCH_NAME == 'master') {
+          pactBroker.canIDeploy(version)
+        }
+      }
+    }
+  }
+
 }

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -115,6 +115,10 @@ def call(params) {
     stage("Pact verification") {
       def version = sh(returnStdout: true, script: 'git rev-parse --short HEAD')
 
+      /*
+       * These instructions have to be kept in that order
+       */
+
       if (config.pactConsumerTestsEnabled) {
         pcr.callAround('pact-consumer-tests') {
           builder.runConsumerTests(pactBrokerUrl, version)
@@ -127,10 +131,12 @@ def call(params) {
         }
       }
 
-      pcr.callAround('pact-deployment-verification') {
-        def pactBroker = new PactBroker(this, product, component, pactBrokerUrl)
-        if (env.CHANGE_BRANCH || env.BRANCH_NAME == 'master') {
-          pactBroker.canIDeploy(version)
+      if (config.pactConsumerTestsEnabled) {
+        pcr.callAround('pact-deployment-verification') {
+          def pactBroker = new PactBroker(this, product, component, pactBrokerUrl)
+          if (env.CHANGE_BRANCH || env.BRANCH_NAME == 'master') {
+            pactBroker.canIDeploy(version)
+          }
         }
       }
     }

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -112,7 +112,7 @@ def call(params) {
   }
 
   if (config.pactBrokerEnabled) {
-    stage("Pact verification") {
+    stage("Pact") {
       def version = sh(returnStdout: true, script: 'git rev-parse --short HEAD')
       def isOnMaster = (env.BRANCH_NAME == 'master')
 

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -114,6 +114,7 @@ def call(params) {
   if (config.pactBrokerEnabled) {
     stage("Pact verification") {
       def version = sh(returnStdout: true, script: 'git rev-parse --short HEAD')
+      def isOnMaster = (env.BRANCH_NAME == 'master')
 
       /*
        * These instructions have to be kept in that order
@@ -125,7 +126,7 @@ def call(params) {
         }
       }
 
-      if (config.pactProviderVerificationsEnabled) {
+      if (config.pactProviderVerificationsEnabled && isOnMaster) {
         pcr.callAround('pact-provider-verification') {
           builder.runProviderVerification(pactBrokerUrl, version)
         }
@@ -134,9 +135,7 @@ def call(params) {
       if (config.pactConsumerTestsEnabled) {
         pcr.callAround('pact-deployment-verification') {
           def pactBroker = new PactBroker(this, product, component, pactBrokerUrl)
-          if (env.CHANGE_BRANCH && env.BRANCH_NAME == 'master') {
-            pactBroker.canIDeploy(version)
-          }
+          pactBroker.canIDeploy(version)
         }
       }
     }

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -135,7 +135,7 @@ def call(params) {
         }
       }
 
-      if (config.pactConsumerTestsEnabled) {
+      if (config.pactConsumerTestsEnabled && isOnMaster) {
         pcr.callAround('pact-deployment-verification') {
           def pactBroker = new PactBroker(this, product, component, pactBrokerUrl)
           pactBroker.canIDeploy(version)

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -116,6 +116,9 @@ def call(params) {
       def version = sh(returnStdout: true, script: 'git rev-parse --short HEAD')
       def isOnMaster = (env.BRANCH_NAME == 'master')
 
+      env.PACT_BRANCH_NAME = isOnMaster ? env.BRANCH_NAME : env.CHANGE_BRANCH
+      env.PACT_BROKER_URL = pactBrokerUrl
+
       /*
        * These instructions have to be kept in that order
        */

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -113,17 +113,17 @@ def call(params) {
 
   if (config.pactBrokerEnabled) {
     stage("Pact verification") {
-      def version = sh(returnStdout: true, script: 'git rev-parse --verify --short HEAD')
+      def version = sh(returnStdout: true, script: 'git rev-parse --short HEAD')
 
       if (config.pactConsumerTestsEnabled) {
         pcr.callAround('pact-consumer-tests') {
-          builder.runConsumerTests(pactBrokerUrl)
+          builder.runConsumerTests(pactBrokerUrl, version)
         }
       }
 
       if (config.pactProviderVerificationsEnabled) {
         pcr.callAround('pact-provider-verification') {
-          builder.runProviderVerification(pactBrokerUrl)
+          builder.runProviderVerification(pactBrokerUrl, version)
         }
       }
 

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -68,7 +68,8 @@ def call(type, String product, String component, Closure body) {
           subscription: subscription.nonProdName,
           environment: environment.nonProdName,
           product: product,
-          component: component
+          component: component,
+          pactBrokerUrl: environment.pactBrokerUrl
         )
 
         onPR {


### PR DESCRIPTION
Hello, this PR brings a new hook and a new stage on the pipeline, allowing the CI to run some pact-related scripts.

#### Usage example:

```groovy
import uk.gov.hmcts.contino.AppPipelineDsl.PactRoles
as PactRoles

/* … */

withPipeline(product) {

  /* … */

  enablePactAs([
    PactRoles.CONSUMER,
    PactRoles.PROVIDER
  ])
}
```
_(Full description provided in the readme)_

#### Pipeline stage

![screenshot](https://user-images.githubusercontent.com/602143/57921435-3e2b5c00-7895-11e9-8337-dca0b293fc95.png)

#### Pipeline samples using this branch:
- [probate-frontend](https://build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_Probate%2Fprobate-frontend/detail/PR-750/10/pipeline/172)
- [probate-orchestrator-service](https://build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_Probate%2Fprobate-orchestrator-service/detail/PR-66/1/pipeline)

---

Thanks for the reviews.