### PR TITLE
Owasp 4 disable

### DIFF
--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -89,8 +89,8 @@ class GradleBuilder extends AbstractBuilder {
         if (hasPlugin("org.owasp.dependencycheck.gradle.plugin:5")) {
           gradle("-DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v5-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${steps.env.OWASPDB_V5_ACCOUNT}' -Ddata.password='${steps.env.OWASPDB_V5_PASSWORD}' -Dautoupdate='false' -Danalyzer.retirejs.enabled=false dependencyCheckAnalyze")
         } else {
-          // NOTE: delete owasp 4 dependency check and its tests in GradleBuilderTest after 17/07/2019
-          if (new Date() > new Date().parse("dd.MM.yyyy", "17.07.2019")) {
+          // NOTE: delete owasp 4 dependency check and its tests in GradleBuilderTest after 15/07/2019
+          if (new Date() > new Date().parse("dd.MM.yyyy", "15.07.2019")) {
             throw new RuntimeException("Owasp dependency check version 4 is not available anymore. Please update your build to use version 5.")
           }
           gradle("-DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${steps.env.OWASPDB_ACCOUNT}' -Ddata.password='${steps.env.OWASPDB_PASSWORD}' -Dautoupdate='false' dependencyCheckAnalyze")

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -87,7 +87,7 @@ class GradleBuilder extends AbstractBuilder {
     steps.withAzureKeyvault(secrets) {
       try {
         if (hasPlugin("org.owasp.dependencycheck.gradle.plugin:5")) {
-          gradle("-DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v5-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${steps.env.OWASPDB_V5_ACCOUNT}' -Ddata.password='${steps.env.OWASPDB_V5_PASSWORD}' -Dautoupdate='false' dependencyCheckAnalyze")
+          gradle("--info --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v5-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${steps.env.OWASPDB_V5_ACCOUNT}' -Ddata.password='${steps.env.OWASPDB_V5_PASSWORD}' -Dautoupdate='false' dependencyCheckAnalyze")
         } else {
           gradle("-DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${steps.env.OWASPDB_ACCOUNT}' -Ddata.password='${steps.env.OWASPDB_PASSWORD}' -Dautoupdate='false' dependencyCheckAnalyze")
         }

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -87,7 +87,7 @@ class GradleBuilder extends AbstractBuilder {
     steps.withAzureKeyvault(secrets) {
       try {
         if (hasPlugin("org.owasp.dependencycheck.gradle.plugin:5")) {
-          gradle("--info --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v5-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${steps.env.OWASPDB_V5_ACCOUNT}' -Ddata.password='${steps.env.OWASPDB_V5_PASSWORD}' -Dautoupdate='false' dependencyCheckAnalyze")
+          gradle("--info --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v5-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${steps.env.OWASPDB_V5_ACCOUNT}' -Ddata.password='${steps.env.OWASPDB_V5_PASSWORD}' -Dautoupdate='false' -Danalyzer.retirejs.enabled=false dependencyCheckAnalyze")
         } else {
           gradle("-DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${steps.env.OWASPDB_ACCOUNT}' -Ddata.password='${steps.env.OWASPDB_PASSWORD}' -Dautoupdate='false' dependencyCheckAnalyze")
         }

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -91,6 +91,7 @@ class GradleBuilder extends AbstractBuilder {
         if (hasPlugin("org.owasp.dependencycheck.gradle.plugin:5")) {
           gradle("-DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v5-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${steps.env.OWASPDB_V5_ACCOUNT}' -Ddata.password='${steps.env.OWASPDB_V5_PASSWORD}' -Dautoupdate='false' -Danalyzer.retirejs.enabled=false dependencyCheckAnalyze")
         } else {
+          // NOTE: delete owasp 4 dependency check and its tests in GradleBuilderTest after 17/07/2019
           if (new Date() > new Date().parse("dd.MM.yyyy", "17.07.2019")) {
             throw new RuntimeException("Owasp dependency check version 4 is not available anymore. Please update your build to use version 5.")
           }

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -1,7 +1,5 @@
 package uk.gov.hmcts.contino
 
-import org.joda.time.LocalDate
-
 class GradleBuilder extends AbstractBuilder {
 
   def product

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.contino
 
+import org.joda.time.LocalDate
+
 class GradleBuilder extends AbstractBuilder {
 
   def product
@@ -87,8 +89,11 @@ class GradleBuilder extends AbstractBuilder {
     steps.withAzureKeyvault(secrets) {
       try {
         if (hasPlugin("org.owasp.dependencycheck.gradle.plugin:5")) {
-          gradle("--info --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v5-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${steps.env.OWASPDB_V5_ACCOUNT}' -Ddata.password='${steps.env.OWASPDB_V5_PASSWORD}' -Dautoupdate='false' -Danalyzer.retirejs.enabled=false dependencyCheckAnalyze")
+          gradle("-DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v5-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${steps.env.OWASPDB_V5_ACCOUNT}' -Ddata.password='${steps.env.OWASPDB_V5_PASSWORD}' -Dautoupdate='false' -Danalyzer.retirejs.enabled=false dependencyCheckAnalyze")
         } else {
+          if (new Date() > new Date().parse("dd.MM.yyyy", "17.07.2019")) {
+            throw new RuntimeException("Owasp dependency check version 4 is not available anymore. Please update your build to use version 5.")
+          }
           gradle("-DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${steps.env.OWASPDB_ACCOUNT}' -Ddata.password='${steps.env.OWASPDB_PASSWORD}' -Dautoupdate='false' dependencyCheckAnalyze")
         }
       }

--- a/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
@@ -2,8 +2,6 @@ package uk.gov.hmcts.contino
 
 import spock.lang.Specification
 
-import java.time.LocalDate
-
 class GradleBuilderTest extends Specification {
 
   static final String GRADLE_CMD = './gradlew'

--- a/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
@@ -83,7 +83,7 @@ class GradleBuilderTest extends Specification {
       })
   }
 
-  // NOTE: delete this test after 17/07/2019
+  // NOTE: delete this test after 15/07/2019
   def "securityCheck calls 'gradle dependencyCheckAnalyze 4 if not hasPlugin version 5'"() {
     setup:
     def closure
@@ -101,7 +101,7 @@ class GradleBuilderTest extends Specification {
     })
   }
 
-  // NOTE: delete this test after 17/07/2019
+  // NOTE: delete this test after 15/07/2019
   def "securityCheck throws Exception if 'gradle dependencyCheckAnalyze 4 is called after 17.07.2019'"() {
     setup:
     def closure
@@ -110,7 +110,7 @@ class GradleBuilderTest extends Specification {
       hasPlugin(_) >> false
     }
     GroovySpy(Date, global: true)
-    new Date() >> new Date().parse("dd.MM.yyyy", "17.08.2019")
+    new Date() >> new Date().parse("dd.MM.yyyy", "16.07.2019")
 
     when:
       b.securityCheck()

--- a/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
@@ -2,6 +2,8 @@ package uk.gov.hmcts.contino
 
 import spock.lang.Specification
 
+import java.time.LocalDate
+
 class GradleBuilderTest extends Specification {
 
   static final String GRADLE_CMD = './gradlew'
@@ -83,6 +85,7 @@ class GradleBuilderTest extends Specification {
       })
   }
 
+  // NOTE: delete this test after 17/07/2019
   def "securityCheck calls 'gradle dependencyCheckAnalyze 4 if not hasPlugin version 5'"() {
     setup:
     def closure
@@ -98,6 +101,23 @@ class GradleBuilderTest extends Specification {
       GString it -> it.startsWith(GRADLE_CMD) && it.contains('dependencyCheckAnalyze') &&
         it.contains('jdbc:postgresql://owaspdependency-prod')
     })
+  }
+
+  // NOTE: delete this test after 17/07/2019
+  def "securityCheck throws Exception if 'gradle dependencyCheckAnalyze 4 is called after 17.07.2019'"() {
+    setup:
+    def closure
+    steps.withAzureKeyvault(_, { closure = it }) >> { closure.call() }
+    def b = Spy(GradleBuilder, constructorArgs: [steps, 'test']) {
+      hasPlugin(_) >> false
+    }
+    GroovySpy(Date, global: true)
+    new Date() >> new Date().parse("dd.MM.yyyy", "17.08.2019")
+
+    when:
+      b.securityCheck()
+    then:
+      thrown RuntimeException
   }
 
   def "runProviderVerification triggers a gradlew hook"() {


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

[[AB#202](https://dev.azure.com/hmcts/90472b63-dc8d-4ae6-8819-a32bd211e914/_workitems/edit/202)]

- Disable RetireJs analyser in owasp dependency check 5 (not working on jenkins) 
- Disable owasp dependency check 4 after 17/07/2019.


Notes:
*
*
*