### PR TITLE
Remove nvm use default

### DIFF
--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -131,7 +131,6 @@ EOF
         set +ex
         source /opt/nvm/nvm.sh || true
         nvm install
-        nvm use default
         set -ex
 
         yarn ${task}


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Remove `nvm use default`.  `nvm install` already set the node version needed by the project.


