### PR TITLE
Feature: separate vault value for db migration

### DIFF
--- a/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
@@ -5,6 +5,7 @@ class AppPipelineConfig extends CommonPipelineConfig implements Serializable {
   Map<String, String> vaultEnvironmentOverrides = ['preview':'aat']
   String vaultName
   boolean migrateDb = false
+  String dbMigrationVaultName
 
   boolean performanceTest = false
   boolean apiGatewayTest = false

--- a/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
@@ -30,8 +30,10 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
   }
 
   void enableDbMigration(String dbMigrationVaultName = "") {
-   if (dbMigrationVaultName == "") {
-     WarningCollector.addPipelineWarning("deprecated_enable_db_migration_no_vault)", "enableDbMigration() is deprecated, please use enableDbMigration(<vault-name>)", new Date().parse("dd.MM.yyyy", "05.09.2019"))
+    if (dbMigrationVaultName == "") {
+      WarningCollector.addPipelineWarning("deprecated_enable_db_migration_no_vault)", "enableDbMigration() is deprecated, please use enableDbMigration(<vault-name>)", new Date().parse("dd.MM.yyyy", "05.09.2019"))
+    }
+
     config.migrateDb = true
     config.dbMigrationVaultName = dbMigrationVaultName
   }

--- a/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
@@ -30,6 +30,7 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
   }
 
   void enableDbMigration(String dbMigrationVaultName = "") {
+    WarningCollector.addPipelineWarning("deprecated_enable_db_migration_no_vault)", "enableDbMigration() is deprecated, please use enableDbMigration("<vault-name>")", new Date().parse("dd.MM.yyyy", "05.09.2019"))  
     config.migrateDb = true
     config.dbMigrationVaultName = dbMigrationVaultName
   }

--- a/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
@@ -30,7 +30,7 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
   }
 
   void enableDbMigration(String dbMigrationVaultName = "") {
-    WarningCollector.addPipelineWarning("deprecated_enable_db_migration_no_vault)", "enableDbMigration() is deprecated, please use enableDbMigration("<vault-name>")", new Date().parse("dd.MM.yyyy", "05.09.2019"))  
+    WarningCollector.addPipelineWarning("deprecated_enable_db_migration_no_vault)", "enableDbMigration() is deprecated, please use enableDbMigration(<vault-name>)", new Date().parse("dd.MM.yyyy", "05.09.2019"))
     config.migrateDb = true
     config.dbMigrationVaultName = dbMigrationVaultName
   }

--- a/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
@@ -30,7 +30,8 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
   }
 
   void enableDbMigration(String dbMigrationVaultName = "") {
-    WarningCollector.addPipelineWarning("deprecated_enable_db_migration_no_vault)", "enableDbMigration() is deprecated, please use enableDbMigration(<vault-name>)", new Date().parse("dd.MM.yyyy", "05.09.2019"))
+   if (dbMigrationVaultName == "") {
+     WarningCollector.addPipelineWarning("deprecated_enable_db_migration_no_vault)", "enableDbMigration() is deprecated, please use enableDbMigration(<vault-name>)", new Date().parse("dd.MM.yyyy", "05.09.2019"))
     config.migrateDb = true
     config.dbMigrationVaultName = dbMigrationVaultName
   }

--- a/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
@@ -29,8 +29,9 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
     WarningCollector.addPipelineWarning("deprecated_set_vault_name", "setVaultName() is deprecated, see https://github.com/hmcts/cnp-jenkins-library#secrets-for-functional--smoke-testing ", new Date().parse("dd.MM.yyyy", "27.08.2019"))
   }
 
-  void enableDbMigration() {
+  void enableDbMigration(String dbMigrationVaultName = "") {
     config.migrateDb = true
+    config.dbMigrationVaultName = dbMigrationVaultName
   }
 
   void enablePerformanceTest(int timeout = 15) {

--- a/vars/sectionDeployToEnvironment.groovy
+++ b/vars/sectionDeployToEnvironment.groovy
@@ -54,7 +54,7 @@ def call(params) {
                 pcr.callAround("dbmigrate:${environment}") {
                   builder.dbMigrate(
                     tfOutput.vaultName ? tfOutput.vaultName.value : config.dbMigrationVaultName,
-                    tfOutput.microserviceName.value
+                    component
                   )
                 }
               }

--- a/vars/sectionDeployToEnvironment.groovy
+++ b/vars/sectionDeployToEnvironment.groovy
@@ -52,7 +52,10 @@ def call(params) {
             if (config.migrateDb) {
               stage("DB Migration - ${environment}") {
                 pcr.callAround("dbmigrate:${environment}") {
-                  builder.dbMigrate(tfOutput.vaultName.value, tfOutput.microserviceName.value)
+                  builder.dbMigrate(
+                    tfOutput.vaultName ? tfOutput.vaultName.value : config.dbMigrationVaultName,
+                    tfOutput.microserviceName.value
+                  )
                 }
               }
             }

--- a/vars/sectionDeployToEnvironment.groovy
+++ b/vars/sectionDeployToEnvironment.groovy
@@ -53,7 +53,7 @@ def call(params) {
               stage("DB Migration - ${environment}") {
                 pcr.callAround("dbmigrate:${environment}") {
                   builder.dbMigrate(
-                    tfOutput.vaultName ? tfOutput.vaultName.value : config.dbMigrationVaultName,
+                    tfOutput.vaultName ? tfOutput.vaultName.value : "${config.dbMigrationVaultName}-${environment}",
                     component
                   )
                 }


### PR DESCRIPTION
In order to migrate from deprecated features, particularly [this](https://github.com/hmcts/cnp-jenkins-library#secrets-for-functional--smoke-testing) guideline on _howto_, some projects might use multiple vaults to load secrets - as suggested in the link previously. This feature requires `vaultName` to be removed from terraform output file. Which then causes null pointer in case project has db migration step in the pipeline.

Introducing separate config just for that and securing from null value