### PR TITLE
SIDM-3120 Allow for unique names for pull request migrations

### DIFF
--- a/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
@@ -5,6 +5,7 @@ class AppPipelineConfig extends CommonPipelineConfig implements Serializable {
   Map<String, String> vaultEnvironmentOverrides = ['preview':'aat']
   String vaultName
   boolean migrateDb = false
+  boolean uniqueDbMigrateSecretNames = false;
   String dbMigrationVaultName
 
   boolean performanceTest = false

--- a/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
@@ -29,13 +29,14 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
     WarningCollector.addPipelineWarning("deprecated_set_vault_name", "setVaultName() is deprecated, see https://github.com/hmcts/cnp-jenkins-library#secrets-for-functional--smoke-testing ", new Date().parse("dd.MM.yyyy", "27.08.2019"))
   }
 
-  void enableDbMigration(String dbMigrationVaultName = "") {
+  void enableDbMigration(String dbMigrationVaultName = "", boolean uniqueSecretNames = false) {
     if (dbMigrationVaultName == "") {
       WarningCollector.addPipelineWarning("deprecated_enable_db_migration_no_vault)", "enableDbMigration() is deprecated, please use enableDbMigration(<vault-name>)", new Date().parse("dd.MM.yyyy", "05.09.2019"))
     }
 
     config.migrateDb = true
     config.dbMigrationVaultName = dbMigrationVaultName
+    config.uniqueDbMigrateSecretNames = uniqueSecretNames
   }
 
   void enablePerformanceTest(int timeout = 15) {

--- a/vars/sectionDeployToEnvironment.groovy
+++ b/vars/sectionDeployToEnvironment.groovy
@@ -60,7 +60,7 @@ def call(params) {
                   
                   builder.dbMigrate(
                     tfOutput.vaultName ? tfOutput.vaultName.value : "${config.dbMigrationVaultName}-${environment}",
-                    tfOutput.microserviceName? tfOutput.microserviceName.value : component
+                    config.uniqueDbMigrateSecretNames? "${product}-${component}" : component
                   )
                 }
               }


### PR DESCRIPTION
Currently in idam our pull requests have unique databases but do not have a unique vault, they share the same vault for their secrets.

We currently cannot build our pull requests as all of our secrets follow **product-component-POSTGRES-ETC** format

This should allow us to maintain this functionality with the removal of microserviceName output
