### PR TITLE
Increase timeout for install to AKS

### DIFF
--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -69,7 +69,7 @@ def call(params) {
         withTeamSecrets(config, environment) {
           stage("AKS deploy - ${environment}") {
             pcr.callAround('akschartsinstall') {
-              timeoutWithMsg(time: 15, unit: 'MINUTES', action: 'Install Charts to AKS') {
+              timeoutWithMsg(time: 25, unit: 'MINUTES', action: 'Install Charts to AKS') {
                 onPR {
                   deploymentNumber = githubCreateDeployment()
                 }


### PR DESCRIPTION
We retry the upgrade a couple of times, we quite often hit the timeout on the retry, maybe this will help

Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
*
*
*
