### PR TITLE
Allow ignoring false positives with ZAP  (security scanner)

### DIFF
--- a/src/uk/gov/hmcts/contino/SecurityScan.groovy
+++ b/src/uk/gov/hmcts/contino/SecurityScan.groovy
@@ -4,6 +4,8 @@ package uk.gov.hmcts.contino
 class SecurityScan implements Serializable {
     public static final String OWASP_ZAP_IMAGE = 'owasp/zap2docker-weekly'
     public static final String OWASP_ZAP_ARGS = '-u 0:0 --name zap -p 1001:1001'
+    public static final String GLUEIMAGE = 'hmcts/zap-glue:latest'
+    public static final String GLUE_ARGS = '-u 0:0 --name=Glue -w $(pwd):/tmp'
     def steps
 
     SecurityScan(steps) {
@@ -14,9 +16,14 @@ class SecurityScan implements Serializable {
         try {
             this.steps.withDocker(OWASP_ZAP_IMAGE, OWASP_ZAP_ARGS) {
                 this.steps.sh '''
-                    echo ${TEST_URL}
                     chmod +x security.sh
                     ./security.sh
+                    '''
+            }
+            this.steps.withDocker(GLUEIMAGE, GLUE_ARGS) {
+                this.steps.sh '''
+                    cd /glue
+                    ./run_glue.sh "$OLDPWD/audit.json" "$OLDPWD/report.json"
                     '''
             }
         } finally {


### PR DESCRIPTION
Resolves # : resolves the problem of removing false positives form nightly security scan using Glue dynamic task.

Notes: please follow this link 
https://tools.hmcts.net/confluence/display/RQA/Integrate+with+Glue+for+ignoring+false+postivies