### PR TITLE
Remove unsupported enableDeployToAKS option

### DIFF
--- a/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
@@ -12,7 +12,6 @@ class AppPipelineConfig extends CommonPipelineConfig implements Serializable {
   boolean crossBrowserTest = false
   boolean mutationTest = false
   boolean dockerBuild = false
-  boolean deployToAKS = false
   boolean installCharts = false
   boolean fullFunctionalTest = false
   boolean securityScan = false

--- a/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
@@ -62,16 +62,8 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
     config.dockerBuild = true
   }
 
-  @Deprecated
-  void enableDeployToAKS() {
-    WarningCollector.addPipelineWarning("deprecated_enable_deployto_AKS", "enableDeployToAKS() is deprecated, use installCharts instead ", new Date().parse("dd.MM.yyyy", "27.08.2019"))
-    config.deployToAKS = true
-    config.installCharts = false
-  }
-
   void installCharts() {
     config.installCharts = true
-    config.deployToAKS = false
   }
 
   void enableFullFunctionalTest(int timeout = 30) {

--- a/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
+++ b/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
@@ -28,7 +28,6 @@ class AppPipelineConfigTest extends Specification {
       assertThat(pipelineConfig.crossBrowserTest).isFalse()
       assertThat(pipelineConfig.mutationTest).isFalse()
       assertThat(pipelineConfig.dockerBuild).isFalse()
-      assertThat(pipelineConfig.deployToAKS).isFalse()
       assertThat(pipelineConfig.installCharts).isFalse()
       assertThat(pipelineConfig.fullFunctionalTest).isFalse()
       assertThat(pipelineConfig.securityScan).isFalse()
@@ -104,19 +103,11 @@ class AppPipelineConfigTest extends Specification {
       assertThat(pipelineConfig.dockerBuild).isTrue()
   }
 
-  def "ensure enable deploy to AKS"() {
-    when:
-      dsl.enableDeployToAKS()
-    then:
-      thrown RuntimeException
-  }
-
   def "ensure install charts"() {
     when:
       dsl.installCharts()
     then:
       assertThat(pipelineConfig.installCharts).isTrue()
-      assertThat(pipelineConfig.deployToAKS).isFalse()
   }
 
   def "ensure enable full functional test"() {

--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -45,27 +45,7 @@ def call(params) {
     }
     withAksClient(subscription, environment) {
 
-      if (config.deployToAKS) {
-
-        withTeamSecrets(config, environment) {
-          stage('Deploy to AKS') {
-            pcr.callAround('aksdeploy') {
-              timeoutWithMsg(time: 15, unit: 'MINUTES', action: 'Deploy to AKS') {
-                onPR {
-                  deploymentNumber = githubCreateDeployment()
-                }
-
-                aksUrl = aksDeploy(dockerImage, params)
-                log.info("deployed component URL: ${aksUrl}")
-
-                onPR {
-                  githubUpdateDeploymentStatus(deploymentNumber, aksUrl)
-                }
-              }
-            }
-          }
-        }
-      } else if (config.installCharts) {
+      if (config.installCharts) {
         withTeamSecrets(config, environment) {
           stage("AKS deploy - ${environment}") {
             pcr.callAround('akschartsinstall') {
@@ -87,7 +67,7 @@ def call(params) {
       }
     }
 
-    if ((config.deployToAKS || config.installCharts) && config.serviceApp) {
+    if (config.installCharts && config.serviceApp) {
       withSubscription(subscription) {
         withTeamSecrets(config, environment) {
           stage("Smoke Test - AKS ${environment}") {


### PR DESCRIPTION
Remove legacy code and tech debt in preparation for another pipeline change.