### PR TITLE
Fix missing stage from pipeline metrics collection

### DIFF
--- a/src/uk/gov/hmcts/contino/PipelineCallbacksRunner.groovy
+++ b/src/uk/gov/hmcts/contino/PipelineCallbacksRunner.groovy
@@ -8,11 +8,11 @@ class PipelineCallbacksRunner implements Serializable {
   }
 
   void callAfter(String stage) {
-    nullSafeCall('after:' + stage)
+    nullSafeCall('after:' + stage, stage)
   }
 
   void callBefore(String stage) {
-    nullSafeCall('before:' + stage)
+    nullSafeCall('before:' + stage, stage)
   }
 
   void callAround(String stage, Closure body) {
@@ -20,11 +20,11 @@ class PipelineCallbacksRunner implements Serializable {
     try {
       body.call()
     } catch (err) {
-      call('onStageFailure')
+      call('onStageFailure', stage)
       throw err
     } finally {
       callAfter(stage)
-      nullSafeCall('after:all')
+      nullSafeCall('after:all', stage)
     }
   }
 
@@ -36,14 +36,14 @@ class PipelineCallbacksRunner implements Serializable {
     }
   }
 
-  void call(String callback) {
-    nullSafeCall(callback)
+  void call(String callback, String stage = null) {
+    nullSafeCall(callback, stage)
   }
 
-  private def nullSafeCall(String key) {
+  private def nullSafeCall(String key, String stage) {
     def body = config.bodies.get(key)
     if (body != null) {
-      body.call()
+      body.call(stage)
     }
   }
 }

--- a/test/uk/gov/hmcts/contino/PipelineCallbacksRunnerTest.groovy
+++ b/test/uk/gov/hmcts/contino/PipelineCallbacksRunnerTest.groovy
@@ -1,0 +1,126 @@
+package uk.gov.hmcts.contino
+
+import spock.lang.Specification
+
+import static org.assertj.core.api.Assertions.assertThat
+
+class PipelineCallBacksRunnerTest extends Specification {
+
+  def "ensure correctly registered call before is called before body"() {
+    given:
+      PipelineCallbacksConfig config = new PipelineCallbacksConfig()
+      StringBuilder text = new StringBuilder()
+      config.registerBefore('build') {
+        text.append('callback')
+      }
+      PipelineCallbacksRunner pcr = new PipelineCallbacksRunner(config)
+    when:
+      pcr.callAround('build') {
+          text.append('body')
+      }
+    then:
+      assertThat(text.toString()).isEqualTo('callbackbody')
+  }
+
+  def "ensure correctly registered call after is called after body"() {
+    given:
+      PipelineCallbacksConfig config = new PipelineCallbacksConfig()
+      StringBuilder text = new StringBuilder()
+      config.registerAfter('build') {
+        text.append('callback')
+      }
+      PipelineCallbacksRunner pcr = new PipelineCallbacksRunner(config)
+    when:
+      pcr.callAround('build') {
+          text.append('body')
+      }
+    then:
+      assertThat(text.toString()).isEqualTo('bodycallback')
+  }
+
+  def "ensure that both callbacks are called correctly" () {
+    given:
+      PipelineCallbacksConfig config = new PipelineCallbacksConfig()
+      StringBuilder text = new StringBuilder()
+      config.registerAfter('build') {
+        text.append('after')
+      }
+      config.registerBefore('build') {
+        text.append('before')
+      }
+      PipelineCallbacksRunner pcr = new PipelineCallbacksRunner(config)
+    when:
+      pcr.callAround('build') {
+          text.append('body')
+      }
+    then:
+      assertThat(text.toString()).isEqualTo('beforebodyafter')
+  }
+
+  def "ensure that afterAll callbacks are called correctly" () {
+    given:
+      PipelineCallbacksConfig config = new PipelineCallbacksConfig()
+      StringBuilder text = new StringBuilder()
+      config.registerAfterAll() { stage ->
+        text.append('afterAll')
+      }
+      PipelineCallbacksRunner pcr = new PipelineCallbacksRunner(config)
+    when:
+      pcr.callAround('checkout') {
+          text.append('checkout')
+      }
+      pcr.callAround('build') {
+          text.append('build')
+      }
+    then:
+      assertThat(text.toString()).isEqualTo('checkoutafterAllbuildafterAll')
+  }
+
+  def "ensure that callbacks with different names are not called" () {
+    given:
+      PipelineCallbacksConfig config = new PipelineCallbacksConfig()
+      StringBuilder text = new StringBuilder()
+      config.registerAfter('build') {
+        text.append('callback')
+      }
+      config.registerBefore('build') {
+        text.append('callback')
+      }
+      PipelineCallbacksRunner pcr = new PipelineCallbacksRunner(config)
+    when:
+      pcr.callAround('checkout') {
+          text.append('body')
+      }
+    then:
+      assertThat(text.toString()).isEqualTo('body')
+  }
+
+  def "ensure stage name is passed into callback"() {
+    given:
+      PipelineCallbacksConfig config = new PipelineCallbacksConfig()
+      StringBuilder text = new StringBuilder()
+      config.registerBefore('build') { stage ->
+        text.append(stage.toUpperCase())
+      }
+      PipelineCallbacksRunner pcr = new PipelineCallbacksRunner(config)
+    when:
+      pcr.callAround('build') {
+          text.append('body')
+      }
+    then:
+      assertThat(text.toString()).isEqualTo('BUILDbody')
+  }
+
+  def "ensure callbacks aren't called during registration"() {
+    given:
+      PipelineCallbacksConfig config = new PipelineCallbacksConfig()
+      boolean beforeBuildCalled = false
+    when:
+      config.registerBefore('build') {
+        beforeBuildCalled = true
+      }
+    then:
+      assertThat(beforeBuildCalled).isFalse()    
+  }
+
+}


### PR DESCRIPTION
Some refactoring a while ago stripped the `stage` value from the metric collection. This PR fixes that regression and adds a unit test for the pipeline callbacks runner.