### PR TITLE
Switch pipeline build notices to rpe-build-notices

### DIFF
--- a/Jenkinsfile_pipeline_test
+++ b/Jenkinsfile_pipeline_test
@@ -2,7 +2,7 @@
 @Library('Infrastructure') _
 import uk.gov.hmcts.contino.GradleBuilder
 
-def channel = '#cnp-build-status'
+def channel = '#rpe-build-notices'
 GradleBuilder builder = new GradleBuilder(this, 'jenkins-library')
 
 def testBranch = env.CHANGE_BRANCH ?: env.BRANCH_NAME


### PR DESCRIPTION
The current notice channel `cnp-build-status` has only 3 members - only 2 of them active and 1 of them on the platform team.

Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
*
*
*
