### PR TITLE
Fix missing Dockerfile in tests

### DIFF
--- a/test/withPipeline/BaseCnpPipelineTest.groovy
+++ b/test/withPipeline/BaseCnpPipelineTest.groovy
@@ -43,7 +43,7 @@ abstract class BaseCnpPipelineTest extends BasePipelineTest {
     helper.registerAllowedMethod("withCredentials", [LinkedHashMap, Closure.class], null)
     helper.registerAllowedMethod("azureServicePrincipal", [LinkedHashMap], null)
     helper.registerAllowedMethod("usernamePassword", [LinkedHashMap], null)
-    helper.registerAllowedMethod('fileExists', [String.class], { c -> c == 'localPath/infrastructure' })
+    helper.registerAllowedMethod('fileExists', [String.class], { c -> c == 'localPath/infrastructure' || c == 'Dockerfile' })
     helper.registerAllowedMethod("withSonarQubeEnv", [String.class, Closure.class], null)
     helper.registerAllowedMethod("waitForQualityGate", { [status: 'OK'] })
     helper.registerAllowedMethod("writeFile", [LinkedHashMap.class], {})


### PR DESCRIPTION
Tests began failing with
```withPipeline.onPreview.withJavaPipelineOnPreviewTests > PipelineExecutesExpectedStepsInExpectedOrder FAILED
    java.lang.RuntimeException: A Dockerfile will be required for all app builds. Docker builds (enableDockerBuild()) wil be enabled by default. This change is enforced from 17/12/2019 00:00```

