### PR TITLE
Ignore optional yarn dependencies

### DIFF
--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -148,7 +148,7 @@ EOF
 
   def yarn(task) {
     if (!steps.fileExists(INSTALL_CHECK_FILE) && !runYarnQuiet("check")) {
-      runYarn("--mutex network install --frozen-lockfile")
+      runYarn("--mutex network install --frozen-lockfile --ignore-optional")
       steps.sh("touch ${INSTALL_CHECK_FILE}")
     }
     runYarn(task)


### PR DESCRIPTION
I'm having a nightmare of a time with fsevents
One fix is to force upgrade it, but then optional dependencies don't work right,

Forcing it to be optional works but it doesn't work OOTB, needs this flag,
ref:
https://github.com/yarnpkg/yarn/issues/6834
https://github.com/yarnpkg/yarn/issues/6834#issuecomment-559238806