### PR TITLE
Remove dependency checker v4 check

### DIFF
--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -84,12 +84,7 @@ class GradleBuilder extends AbstractBuilder {
     ]
     steps.withAzureKeyvault(secrets) {
       try {
-        if (hasPlugin("org.owasp.dependencycheck.gradle.plugin:5")) {
-          gradle("-DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v5-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${steps.env.OWASPDB_V5_ACCOUNT}' -Ddata.password='${steps.env.OWASPDB_V5_PASSWORD}' -Dautoupdate='false' -Danalyzer.retirejs.enabled=false dependencyCheckAnalyze")
-        } else {
-          // NOTE: delete owasp 4 dependency check and its tests in GradleBuilderTest some time after 15/07/2019
-            throw new RuntimeException("Owasp dependency check version 4 is not available anymore. Please update your build to use version 5.")
-        }
+        gradle("-DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v5-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${steps.env.OWASPDB_V5_ACCOUNT}' -Ddata.password='${steps.env.OWASPDB_V5_PASSWORD}' -Dautoupdate='false' -Danalyzer.retirejs.enabled=false dependencyCheckAnalyze")
       }
       finally {
         steps.archiveArtifacts 'build/reports/dependency-check-report.html'

--- a/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
@@ -66,38 +66,18 @@ class GradleBuilderTest extends Specification {
     1 * steps.sh({ it.startsWith(GRADLE_CMD) && it.contains('apiGateway') && it.contains('--rerun-tasks') })
   }
 
-  def "securityCheck calls 'gradle dependencyCheckAnalyze 5 if hasPlugin version 5'"() {
+  def "securityCheck calls 'gradle dependencyCheckAnalyze"() {
     setup:
       def closure
       steps.withAzureKeyvault(_, { closure = it }) >> { closure.call() }
-      def b = Spy(GradleBuilder, constructorArgs: [steps, 'test']) {
-        hasPlugin(_) >> true
-      }
 
     when:
-      b.securityCheck()
+      builder.securityCheck()
     then:
       1 * steps.sh({
         GString it -> it.startsWith(GRADLE_CMD) && it.contains('dependencyCheckAnalyze') &&
         it.contains('jdbc:postgresql://owaspdependency-v5-prod')
       })
-  }
-
-  // NOTE: delete this test some time after 15/07/2019 together with the related code in GradleBuilder
-  def "securityCheck throws Exception if 'gradle dependencyCheckAnalyze 4 is called after 15.07.2019'"() {
-    setup:
-    def closure
-    steps.withAzureKeyvault(_, { closure = it }) >> { closure.call() }
-    def b = Spy(GradleBuilder, constructorArgs: [steps, 'test']) {
-      hasPlugin(_) >> false
-    }
-    GroovySpy(Date, global: true)
-    new Date() >> new Date().parse("dd.MM.yyyy", "16.07.2019")
-
-    when:
-      b.securityCheck()
-    then:
-      thrown RuntimeException
   }
 
   def "runProviderVerification triggers a gradlew hook"() {


### PR DESCRIPTION
Notes:

The check for OWASP dependency checker version 4 breaks when the dependency checker is a transitive plugin dependency. Removing this check since it is now obsolete according to the comments accompanying it.
