### PR TITLE
Remove unnecessary DNS registration

### DIFF
--- a/src/uk/gov/hmcts/pipeline/AKSSubscription.groovy
+++ b/src/uk/gov/hmcts/pipeline/AKSSubscription.groovy
@@ -15,18 +15,6 @@ class AKSSubscription implements Serializable {
     this.tlsEnabled = tlsEnabled
   }
 
-  String ingressIp() {
-    def secrets = [
-      [secretType: 'Secret', name: 'ingress-ip-staging', version: '', envVariable: 'INGRESS_IP'],
-    ]
-    steps.withAzureKeyvault(
-      azureKeyVaultSecrets: secrets,
-      keyVaultURLOverride: "https://${keyvaultName}.vault.azure.net"
-    ) {
-      return steps.env.INGRESS_IP
-    }
-  }
-
   String loadBalancerIp() {
     def secrets = [
       [secretType: 'Secret', name: 'internal-lb-ip', version: '', envVariable: 'LB_IP'],

--- a/vars/registerDns.groovy
+++ b/vars/registerDns.groovy
@@ -24,15 +24,6 @@ def call(Map params) {
 
     aksSubscriptionName = params.aksSubscription != null ? params.aksSubscription.name : null
 
-
-    if (config.aksStagingDeployment) {
-      if (aksSubscriptionName) {
-        def ingressIP = params.aksSubscription.ingressIp()
-        registerDns(consul, azPrivateDns, dnsConfigEntry, "${params.product}-${params.component}-staging", ingressIP)
-      } else {
-        echo "Skipping staging dns registration for AKS as this environment is not configured with it: ${aksSubscriptionName}"
-      }
-    }
     // AAT + PROD DNS registration
     def aksEnv = params.aksSubscription != null && params.aksSubscription.envName
 


### PR DESCRIPTION
The `AKSSubscription.ingressIp()` method doesn't respect switching between AKS clusters for staging deployments.

It also seems that the correct registration is also done inside the `helmInstall` block later in the pipeline. The `helmInstall` is wrapped inside an `config.aksStagingDeployment` flag inside `sectionDeployToAKS`
