### PR TITLE
Fix init script when dependency checker applied in subproject

### DIFF
--- a/resources/uk/gov/hmcts/gradle/init.gradle
+++ b/resources/uk/gov/hmcts/gradle/init.gradle
@@ -42,7 +42,7 @@ settingsEvaluated { settings ->
 // Enable JSON dependency check reports for monitoring of CVEs and suppressions.
 allprojects {
   afterEvaluate { project ->
-    if (project.dependencyCheck) {
+    if (project.hasProperty('dependencyCheck')) {
       project.dependencyCheck.formats += 'json'
     }
   }


### PR DESCRIPTION
Attempting to access a non existent project property throws an exception.