### PR TITLE
Fix filtering of dependencies in CVE reporting

### DIFF
--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -127,7 +127,9 @@ class GradleBuilder extends AbstractBuilder {
   def prepareCVEReport(owaspReportJSON, env) {
     def report = new JsonSlurper().parseText(owaspReportJSON)
     // Only include non-vulnerable dependencies to reduce the report size; Cosmos has a 2MB limit.
-    report.dependencies = report.dependencies.findAll { it.vulnerabilityIds }
+    report.dependencies = report.dependencies.findAll {
+      it.vulnerabilities || it.suppressedVulnerabilities
+    }
 
     def result = [
       build: [

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -126,13 +126,14 @@ class GradleBuilder extends AbstractBuilder {
 
   def prepareCVEReport(owaspReportJSON, env) {
     def report = new JsonSlurper().parseText(owaspReportJSON)
-    // Only include non-vulnerable dependencies to reduce the report size; Cosmos has a 2MB limit.
+    // Only include vulnerable dependencies to reduce the report size; Cosmos has a 2MB limit.
     report.dependencies = report.dependencies.findAll {
       it.vulnerabilities || it.suppressedVulnerabilities
     }
 
     def result = [
       build: [
+        branch_name                  : env.BRANCH_NAME,
         build_display_name           : env.BUILD_DISPLAY_NAME,
         build_tag                    : env.BUILD_TAG,
         git_url                      : env.GIT_URL,

--- a/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
@@ -116,8 +116,12 @@ class GradleBuilderTest extends Specification {
     result = new JsonSlurper().parseText(result)
 
     then:
-    // Only dependencies with vulnerabilities should be reported
-    result.report.dependencies.every { it.vulnerabilityIds }
+    // Report has 2 dependencies with vulnerabilities and 3 with suppressed vulnerabilities.
+    result.report.dependencies.size == 5
+    // Only dependencies with vulnerabilities or suppressed vulnerabilities should be reported
+    result.report.dependencies.every {
+      it.vulnerabilities || it.suppressedVulnerabilities
+    }
     result.build.git_url == 'http://example.com'
   }
 


### PR DESCRIPTION
Include only dependencies with vulnerabilities or suppressed vulnerabilities.

Previous filtering was including large numbers of non-vulnerable dependencies, bloating the reports.