### PR TITLE
Bump chart version before failing the build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
   compile group: 'org.jenkins-ci.plugins.workflow', name: 'workflow-step-api', version: '2.13', ext: 'jar'
   compile group: 'org.jenkinsci.plugins', name: 'pipeline-model-definition', version: '1.3.7', ext: 'jar'
   compile 'org.jenkins-ci.plugins:job-dsl-core:1.65'
+  compile group: 'org.jenkins-ci.plugins', name: 'scm-api', version: '2.6.3', ext: 'jar'
 
   compile 'com.microsoft.azure:azure-documentdb:1.15.2'
   compile 'com.microsoft.azure:azure:1.10.0'

--- a/resources/uk/gov/hmcts/helm/check-helm-version-bumped.sh
+++ b/resources/uk/gov/hmcts/helm/check-helm-version-bumped.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
+set -x
 
 CHART_DIRECTORY=${1}-${2}
+BRANCH=${3}
+USER_NAME=${4}
+BEARER_TOKEN=${5}
+EMAIL_ID=${6}
 
 git fetch origin master:master
 
@@ -43,9 +48,23 @@ if [ $? -eq 0 ]; then
   echo "Chart.yaml version has been bumped :)"
 else
   echo "==================================================================="
-  echo "=====  Please increase the version in your Chart.yaml file    ====="
+  echo "=====  Version is not bumped in Chart.yaml file    ====="
   echo "=====  This is required as you changed something in           ====="
   echo "=====  either values.yaml or requirements.yaml                ====="
+  echo "=====  Jenkins will bump the version and commit for you.      ====="
   echo "==================================================================="
+
+  git fetch origin $BRANCH:$BRANCH
+  git remote set-url origin $(git config remote.origin.url | sed "s/github.com/${USER_NAME}:${BEARER_TOKEN}@github.com/g")
+  git config --global user.name ${USER_NAME}
+  git config --global user.email ${GIT_APP_EMAIL_ID}
+
+  CHART_VERSION=$(cat charts/"${CHART_DIRECTORY}"/Chart.yaml | grep ^version | cut -d ':' -f 2 | sed -e 's/^[[:space:]]*//')
+  NEW_VERSION=$(echo $CHART_VERSION | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g' )
+  sed -i -e "s/^version: $CHART_VERSION/version: $NEW_VERSION/" charts/"${CHART_DIRECTORY}"/Chart.yaml
+
+  git add charts/"${CHART_DIRECTORY}"/Chart.yaml
+  git commit -m "Bumping chart version"
+  git push origin HEAD:$BRANCH
   exit 1
 fi

--- a/vars/checkoutScm.groovy
+++ b/vars/checkoutScm.groovy
@@ -7,14 +7,14 @@ def call() {
     env.GIT_COMMIT = scmVars.GIT_COMMIT
     env.GIT_URL = scmVars.GIT_URL
   }
-  def credentialsId = SCMSource.SourceByItem.findSource(currentBuild.rawBuild.parent).credentialsId
-  env.GIT_CREDENTIALS_ID = credentialsId
   try {
+    def credentialsId = SCMSource.SourceByItem.findSource(currentBuild.rawBuild.parent).credentialsId
+    env.GIT_CREDENTIALS_ID = credentialsId
     //This code assumes it uses GitHub App Authentication
     def response = steps.httpRequest url: "https://api.github.com/users/$credentialsId%5Bbot%5D", httpMode: 'GET', acceptType: 'APPLICATION_JSON'
     def gitUserId = steps.readYaml(text: response.content).id
     env.GIT_APP_EMAIL_ID = gitUserId + "+" + credentialsId + "[bot]@users.noreply.github.com"
   } catch (err) {
-    steps.echo "Unable to find git email Id for the user' ${err}'"
+    echo "Unable to find git email Id for the user' ${err}'"
   }
 }

--- a/vars/checkoutScm.groovy
+++ b/vars/checkoutScm.groovy
@@ -1,8 +1,20 @@
+import jenkins.scm.api.SCMSource;
+
 def call() {
   deleteDir()
   def scmVars = checkout scm
   if (scmVars) {
     env.GIT_COMMIT = scmVars.GIT_COMMIT
     env.GIT_URL = scmVars.GIT_URL
+  }
+  def credentialsId = SCMSource.SourceByItem.findSource(currentBuild.rawBuild.parent).credentialsId
+  env.GIT_CREDENTIALS_ID = credentialsId
+  try {
+    //This code assumes it uses GitHub App Authentication
+    def response = steps.httpRequest url: "https://api.github.com/users/$credentialsId%5Bbot%5D", httpMode: 'GET', acceptType: 'APPLICATION_JSON'
+    def gitUserId = steps.readYaml(text: response.content).id
+    env.GIT_APP_EMAIL_ID = gitUserId + "+" + credentialsId + "[bot]@users.noreply.github.com"
+  } catch (err) {
+    steps.echo "Unable to find git email Id for the user' ${err}'"
   }
 }

--- a/vars/enforceChartVersionBumped.groovy
+++ b/vars/enforceChartVersionBumped.groovy
@@ -2,15 +2,16 @@ def call(Map<String, String> params) {
   def product = params.product
   def component = params.component
   def branch = env.CHANGE_BRANCH
-  def credentialsId= env.GIT_CREDENTIALS_ID
+  def credentialsId = env.GIT_CREDENTIALS_ID
   def gitEmailId = env.GIT_APP_EMAIL_ID
 
   writeFile file: 'check-helm-version-bumped.sh', text: libraryResource('uk/gov/hmcts/helm/check-helm-version-bumped.sh')
 
   withCredentials([usernamePassword(credentialsId: credentialsId, passwordVariable: 'BEARER_TOKEN', usernameVariable: 'APP_ID')]) {
+    def bearerToken = env.BEARER_TOKEN
     sh """
     chmod +x check-helm-version-bumped.sh
-    ./check-helm-version-bumped.sh $product $component $branch $credentialsId $BEARER_TOKEN $gitEmailId
+    ./check-helm-version-bumped.sh $product $component $branch $credentialsId $bearerToken $gitEmailId
   """
   }
 

--- a/vars/enforceChartVersionBumped.groovy
+++ b/vars/enforceChartVersionBumped.groovy
@@ -1,14 +1,18 @@
-
 def call(Map<String, String> params) {
   def product = params.product
   def component = params.component
+  def branch = env.CHANGE_BRANCH
+  def credentialsId= env.GIT_CREDENTIALS_ID
+  def gitEmailId = env.GIT_APP_EMAIL_ID
 
   writeFile file: 'check-helm-version-bumped.sh', text: libraryResource('uk/gov/hmcts/helm/check-helm-version-bumped.sh')
 
-  sh """
+  withCredentials([usernamePassword(credentialsId: credentialsId, passwordVariable: 'BEARER_TOKEN', usernameVariable: 'APP_ID')]) {
+    sh """
     chmod +x check-helm-version-bumped.sh
-    ./check-helm-version-bumped.sh $product $component
+    ./check-helm-version-bumped.sh $product $component $branch $credentialsId $BEARER_TOKEN $gitEmailId
   """
+  }
 
   sh 'rm check-helm-version-bumped.sh'
 }


### PR DESCRIPTION
Notes:
* Bumps patch version of chart before failing build
* Uses Github App authentication used for code checkout to push commit
* Sets  GIT_CREDENTIALS_ID and GIT_APP_EMAIL_ID while checkout step to be reused in other steps.
