### PR TITLE
Fix charts install for java apps using a callback

### DIFF
--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -42,10 +42,10 @@ def call(params) {
     }
   }
 
-  withAksClient(subscription, environment) {
-    withTeamSecrets(config, environment) {
-      stage("AKS deploy - ${environment}") {
-        pcr.callAround('akschartsinstall') {
+  stage("AKS deploy - ${environment}") {
+    pcr.callAround('akschartsinstall') {
+      withAksClient(subscription, environment) {
+        withTeamSecrets(config, environment) {
           timeoutWithMsg(time: 25, unit: 'MINUTES', action: 'Install Charts to AKS') {
             onPR {
               deploymentNumber = githubCreateDeployment()


### PR DESCRIPTION
Callbacks on chart install were running in a container without the JAVA_HOME var set properly

https://build.platform.hmcts.net/job/HMCTS_PCQ/job/pcq-consolidation-service/view/change-requests/job/PR-25/2/console
```
12:05:16  + ./gradlew --no-daemon --init-script init.gradle functionalPostDeploy
12:05:16  
12:05:16  ERROR: JAVA_HOME is set to an invalid directory: /usr/share/jdk-11.0.2
```