### PR TITLE
Scan only runtime dependencies with OWSAP dependency checker

### DIFF
--- a/resources/uk/gov/hmcts/gradle/init.gradle
+++ b/resources/uk/gov/hmcts/gradle/init.gradle
@@ -41,19 +41,22 @@ settingsEvaluated { settings ->
 allprojects {
   afterEvaluate { project ->
     if (project.hasProperty('dependencyCheck')) {
-      // Any CVE should fail the build.
-      project.dependencyCheck.failBuildOnCVSS = 0
+      configure(project) {
+        dependencyCheck {
+          // Any CVE should fail the build.
+          failBuildOnCVSS = 0
 
-      // JSON dependency check reports are logged to cosmos for reporting.
-      project.dependencyCheck.formats += 'json'
+          // JSON dependency check reports are logged to cosmos for reporting.
+          formats += 'json'
 
-      // Scan only the dependencies used at application runtime.
-      // See https://docs.gradle.org/current/userguide/java_plugin.html#sec:java_plugin_and_dependency_management
-      project.dependencyCheck.scanConfigurations += 'runtimeClasspath'
-      // Scan and skip configurations are mutually exclusive,
-      // so we must clear any skipped configurations the build may have configured.
-      project.dependencyCheck.skipConfigurations = []
+          // Scan only the dependencies used at application runtime.
+          // See https://docs.gradle.org/current/userguide/java_plugin.html#sec:java_plugin_and_dependency_management
+          scanConfigurations += 'runtimeClasspath'
+          // Scan and skip configurations are mutually exclusive,
+          // so we must clear any skipped configurations the build may have configured.
+          skipConfigurations = []
+        }
+      }
     }
   }
 }
-

--- a/resources/uk/gov/hmcts/gradle/init.gradle
+++ b/resources/uk/gov/hmcts/gradle/init.gradle
@@ -51,7 +51,9 @@ allprojects {
 
           // Scan only the dependencies used at application runtime.
           // See https://docs.gradle.org/current/userguide/java_plugin.html#sec:java_plugin_and_dependency_management
-          scanConfigurations += 'runtimeClasspath'
+          if (!('runtimeClasspath' in it.scanConfigurations)) {
+            scanConfigurations += 'runtimeClasspath'
+          }
           // Scan and skip configurations are mutually exclusive,
           // so we must clear any skipped configurations the build may have configured.
           skipConfigurations = []

--- a/resources/uk/gov/hmcts/gradle/init.gradle
+++ b/resources/uk/gov/hmcts/gradle/init.gradle
@@ -38,11 +38,21 @@ settingsEvaluated { settings ->
   }
 }
 
-// Enable JSON dependency check reports for monitoring of CVEs and suppressions.
 allprojects {
   afterEvaluate { project ->
     if (project.hasProperty('dependencyCheck')) {
+      // Any CVE should fail the build.
+      project.dependencyCheck.failBuildOnCVSS = 0
+
+      // JSON dependency check reports are logged to cosmos for reporting.
       project.dependencyCheck.formats += 'json'
+
+      // Scan only the dependencies used at application runtime.
+      // See https://docs.gradle.org/current/userguide/java_plugin.html#sec:java_plugin_and_dependency_management
+      project.dependencyCheck.scanConfigurations += 'runtimeClasspath'
+      // Scan and skip configurations are mutually exclusive,
+      // so we must clear any skipped configurations the build may have configured.
+      project.dependencyCheck.skipConfigurations = []
     }
   }
 }


### PR DESCRIPTION
Many projects are running with default OWASP checker settings which means a lot of non runtime configurations are scanned and a lot of noise is generated.

I have also directly configured the checker to fail the build if a CVE is found, rather than passing a flag to the project build script and relying on the project to respect it.

Related PR for the RSE Gradle plugin: https://github.com/hmcts/rse-gradle-java-plugin/pull/29/files