### PR TITLE
Setting team config to env vars

### DIFF
--- a/src/uk/gov/hmcts/pipeline/TeamConfig.groovy
+++ b/src/uk/gov/hmcts/pipeline/TeamConfig.groovy
@@ -18,6 +18,18 @@ class TeamConfig {
     this.steps = steps
   }
 
+  def setTeamConfigEnv(String product){
+    def teamNames = getTeamNamesMap()
+    this.steps.env.TEAM_NAME = getName(product)
+    this.steps.env.RAW_PRODUCT_NAME = getRawProductName(product)
+    this.steps.env.TEAM_NAMESPACE = getNameSpace(product)
+    this.steps.env.BUILD_NOTICES_SLACK_CHANNEL = getBuildNoticesSlackChannel(product)
+    this.steps.env.CONTACT_SLACK_CHANNEL = getContactSlackChannel(product)
+    this.steps.env.BUILD_AGENT_TYPE = getBuildAgentType(product)
+    this.steps.env.IS_DOCKER_AGENT = (this.steps.env.BUILD_AGENT_TYPE == DOCKER_AGENT_LABEL)
+
+  }
+
   def getTeamNamesMap() {
     if (teamConfigMap ==null ){
       def response = steps.httpRequest(
@@ -88,9 +100,4 @@ class TeamConfig {
     }
     return DOCKER_AGENT_LABEL
   }
-
-  boolean isDockerBuildAgent(String product) {
-    return getBuildAgentType(product) == DOCKER_AGENT_LABEL
-  }
-
 }

--- a/src/uk/gov/hmcts/pipeline/TeamConfig.groovy
+++ b/src/uk/gov/hmcts/pipeline/TeamConfig.groovy
@@ -27,8 +27,8 @@ class TeamConfig {
     this.steps.env.BUILD_NOTICES_SLACK_CHANNEL = getBuildNoticesSlackChannel(product)
     this.steps.env.CONTACT_SLACK_CHANNEL = getContactSlackChannel(product)
     this.steps.env.BUILD_AGENT_TYPE = getBuildAgentType(product)
-    this.steps.env.IS_DOCKER_BUILD_AGENT = (this.steps.env.BUILD_AGENT_TYPE == DOCKER_AGENT_LABEL)
-
+    this.steps.env.IS_DOCKER_BUILD_AGENT = isDockerBuildAgent(product)
+    this.steps.env.BUILD_AGENT_CONTAINER = getBuildAgentContainer(product)
   }
 
   def getTeamNamesMap() {

--- a/src/uk/gov/hmcts/pipeline/TeamConfig.groovy
+++ b/src/uk/gov/hmcts/pipeline/TeamConfig.groovy
@@ -26,7 +26,7 @@ class TeamConfig {
     this.steps.env.BUILD_NOTICES_SLACK_CHANNEL = getBuildNoticesSlackChannel(product)
     this.steps.env.CONTACT_SLACK_CHANNEL = getContactSlackChannel(product)
     this.steps.env.BUILD_AGENT_TYPE = getBuildAgentType(product)
-    this.steps.env.IS_DOCKER_AGENT = (this.steps.env.BUILD_AGENT_TYPE == DOCKER_AGENT_LABEL)
+    this.steps.env.IS_DOCKER_BUILD_AGENT = (this.steps.env.BUILD_AGENT_TYPE == DOCKER_AGENT_LABEL)
 
   }
 

--- a/test/uk/gov/hmcts/pipeline/TeamConfigTest.groovy
+++ b/test/uk/gov/hmcts/pipeline/TeamConfigTest.groovy
@@ -230,23 +230,4 @@ class TeamConfigTest extends Specification {
     assertThat(agent).isEqualTo("k8s-agent")
   }
 
-  def "isDockerBuildAgent() with non existing product should return false"() {
-
-    when:
-    steps.env >> []
-    def isDocker = teamConfig.isDockerBuildAgent('idontexist')
-
-    then:
-    assertThat(isDocker).isFalse()
-  }
-
-  def "isDockerBuildAgent() with valid product name and agent should return true"() {
-    def productName = 'bulk-scan'
-
-    when:
-    def isDocker = teamConfig.isDockerBuildAgent(productName)
-
-    then:
-    assertThat(isDocker).isTrue()
-  }
 }

--- a/vars/dockerAgentSetup.groovy
+++ b/vars/dockerAgentSetup.groovy
@@ -1,9 +1,7 @@
-import uk.gov.hmcts.pipeline.TeamConfig
 import uk.gov.hmcts.contino.azure.KeyVault
 
 def call(String product) {
-  def teamConfig = new TeamConfig(this)
-  if (teamConfig.isDockerBuildAgent(product)) {
+  if (env.IS_DOCKER_BUILD_AGENT) {
     def envName = env.JENKINS_SUBSCRIPTION_NAME == "DTS-CFTSBOX-INTSVC" ? "sandbox" : "prod"
     withSubscriptionLogin(envName) {
       def infraVaultName = env.INFRA_VAULT_NAME

--- a/vars/helmInstall.groovy
+++ b/vars/helmInstall.groovy
@@ -3,7 +3,6 @@ import uk.gov.hmcts.contino.HealthChecker
 import uk.gov.hmcts.contino.Kubectl
 import uk.gov.hmcts.contino.Helm
 import uk.gov.hmcts.contino.GithubAPI
-import uk.gov.hmcts.pipeline.TeamConfig
 import uk.gov.hmcts.contino.Environment
 import uk.gov.hmcts.contino.AppPipelineConfig
 import uk.gov.hmcts.contino.AzPrivateDns
@@ -33,7 +32,7 @@ def call(DockerImage dockerImage, Map params) {
   // Get the IP of the Traefik Ingress Controller
   def ingressIP = kubectl.getServiceLoadbalancerIP("traefik", "admin")
 
-  def namespace = new TeamConfig(this).getNameSpace(product)
+  def namespace = env.TEAM_NAMESPACE
 
   def templateEnvVars = [
     "NAMESPACE=${namespace}",

--- a/vars/spinInfra.groovy
+++ b/vars/spinInfra.groovy
@@ -2,7 +2,6 @@
 import groovy.json.JsonSlurperClassic
 import uk.gov.hmcts.contino.ProjectBranch
 import uk.gov.hmcts.contino.TerraformTagMap
-import uk.gov.hmcts.pipeline.TeamConfig
 import uk.gov.hmcts.contino.MetricsPublisher
 
 def call(productName, environment, planOnly, subscription) {
@@ -41,9 +40,8 @@ def call(product, component, environment, planOnly, subscription, deploymentTarg
     lock("${productName}-${environmentDeploymentTarget}") {
       stage("Plan ${productName} in ${environmentDeploymentTarget}") {
 
-        def teamConfig = new TeamConfig(this)
-        teamName = teamConfig.getName(product)
-        def contactSlackChannel = teamConfig.getContactSlackChannel(product)
+        teamName = env.TEAM_NAME
+        def contactSlackChannel = env.CONTACT_SLACK_CHANNEL
 
         def builtFrom = env.GIT_URL ?: 'unknown'
         pipelineTags = new TerraformTagMap([environment: environment, changeUrl: changeUrl, managedBy: teamName, BuiltFrom: builtFrom, contactSlackChannel: contactSlackChannel]).toString()

--- a/vars/withAcrClient.groovy
+++ b/vars/withAcrClient.groovy
@@ -1,9 +1,6 @@
-import uk.gov.hmcts.pipeline.TeamConfig
 
 def call(String subscription, String product, Closure block) {
-  def teamConfig = new TeamConfig(this)
-  def isDockerBuildAgent = teamConfig.isDockerBuildAgent(product)
-  if (isDockerBuildAgent) {
+  if (env.IS_DOCKER_BUILD_AGENT) {
     doAcrOrKubectlTask(subscription, block)
   } else {
     withDocker('hmcts/cnp-aks-client:az-2.3.0-kubectl-1.18.0-helm-3.1.2-rsync', null) {

--- a/vars/withDockerAgent.groovy
+++ b/vars/withDockerAgent.groovy
@@ -1,10 +1,8 @@
-import uk.gov.hmcts.pipeline.TeamConfig
-
 /**
  * Run a closure inside a specific container of a kubernetes agent pod (or skip container altogether)
  */
 def call(String product, Closure body) {
-  String agentContainer = new TeamConfig(this).getBuildAgentContainer(product)
+  String agentContainer = env.BUILD_AGENT_CONTAINER
   if (agentContainer != null && agentContainer != "") {
     echo "Using agent container: ${agentContainer}"
     try {

--- a/vars/withInfraPipeline.groovy
+++ b/vars/withInfraPipeline.groovy
@@ -25,11 +25,11 @@ def call(String product, Closure body) {
   body.delegate = dsl
   body.call() // register pipeline config
 
-  def teamConfig = new TeamConfig(this)
-  String agentType = teamConfig.getBuildAgentType(product)
+  def teamConfig = new TeamConfig(this).setTeamConfigEnv(product)
+  String agentType = env.BUILD_AGENT_TYPE
 
   node(agentType) {
-    def slackChannel = teamConfig.getBuildNoticesSlackChannel(product)
+    def slackChannel = env.BUILD_NOTICES_SLACK_CHANNEL
     try {
       dockerAgentSetup(product)
       env.PATH = "$env.PATH:/usr/local/bin"

--- a/vars/withNightlyPipeline.groovy
+++ b/vars/withNightlyPipeline.groovy
@@ -42,11 +42,11 @@ def call(type,product,component,Closure body) {
     currentBuild.result = "FAILURE"
   }
 
-  def teamConfig = new TeamConfig(this)
-  String agentType = teamConfig.getBuildAgentType(product)
+  def teamConfig = new TeamConfig(this).setTeamConfigEnv(product)
+  String agentType = env.BUILD_AGENT_TYPE
 
   node(agentType) {
-    def slackChannel = teamConfig.getBuildNoticesSlackChannel(product)
+    def slackChannel = env.BUILD_NOTICES_SLACK_CHANNEL
     try {
       dockerAgentSetup(product)
       env.PATH = "$env.PATH:/usr/local/bin"

--- a/vars/withPactTestOnlyPipeline.groovy
+++ b/vars/withPactTestOnlyPipeline.groovy
@@ -57,11 +57,11 @@ def call(type, String product, String component, Closure body) {
 
   Environment environment = new Environment(env)
 
-  def teamConfig = new TeamConfig(this)
-  String agentType = teamConfig.getBuildAgentType(product)
+  def teamConfig = new TeamConfig(this).setTeamConfigEnv(product)
+  String agentType = env.BUILD_AGENT_TYPE
 
   node(agentType) {
-    def slackChannel = teamConfig.getBuildNoticesSlackChannel(product)
+    def slackChannel = env.BUILD_NOTICES_SLACK_CHANNEL
     try {
       dockerAgentSetup(product)
       env.PATH = "$env.PATH:/usr/local/bin"

--- a/vars/withParameterizedInfraPipeline.groovy
+++ b/vars/withParameterizedInfraPipeline.groovy
@@ -28,11 +28,11 @@ def call(String product, String environment, String subscription, String deploym
 
   def deploymentTargetList = (deploymentTargets) ? deploymentTargets.split(',') as List : null
 
-  def teamConfig = new TeamConfig(this)
-  String agentType = teamConfig.getBuildAgentType(product)
+  def teamConfig = new TeamConfig(this).setTeamConfigEnv(product)
+  String agentType = env.BUILD_AGENT_TYPE
 
   node(agentType) {
-    def slackChannel = teamConfig.getBuildNoticesSlackChannel(product)
+    def slackChannel = env.BUILD_NOTICES_SLACK_CHANNEL
     try {
       dockerAgentSetup(product)
       env.PATH = "$env.PATH:/usr/local/bin"

--- a/vars/withParameterizedPipeline.groovy
+++ b/vars/withParameterizedPipeline.groovy
@@ -58,11 +58,11 @@ def call(type, String product, String component, String environment, String subs
   def deploymentTargetList = deploymentTargets.split(',') as List
   AKSSubscriptions aksSubscriptions = new AKSSubscriptions(this)
 
-  def teamConfig = new TeamConfig(this)
-  String agentType = teamConfig.getBuildAgentType(product)
+  def teamConfig = new TeamConfig(this).setTeamConfigEnv(product)
+  String agentType = env.BUILD_AGENT_TYPE
 
   node(agentType) {
-    def slackChannel = teamConfig.getBuildNoticesSlackChannel(product)
+    def slackChannel = env.BUILD_NOTICES_SLACK_CHANNEL
     try {
       dockerAgentSetup(product)
       env.PATH = "$env.PATH:/usr/local/bin"

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -59,11 +59,11 @@ def call(type, String product, String component, Closure body) {
 
   Environment environment = new Environment(env)
 
-  def teamConfig = new TeamConfig(this)
-  String agentType = teamConfig.getBuildAgentType(product)
+  def teamConfig = new TeamConfig(this).setTeamConfigEnv(product)
+  String agentType = env.BUILD_AGENT_TYPE
 
   node(agentType) {
-    def slackChannel = teamConfig.getBuildNoticesSlackChannel(product)
+    def slackChannel = env.BUILD_NOTICES_SLACK_CHANNEL
     try {
       dockerAgentSetup(product)
       env.PATH = "$env.PATH:/usr/local/bin"


### PR DESCRIPTION
AB#1038

Notes:
* We are calling TeamConfig at many places , sometimes for the same thing.
* This will set all the team config as env variables, so we can just access environment variables instead.
