### PR TITLE
Point artifactory in sandbox to new domain

### DIFF
--- a/Jenkinsfile_pipeline_test
+++ b/Jenkinsfile_pipeline_test
@@ -1,5 +1,5 @@
 #!groovy
-@Library('Infrastructure') _
+@Library('Infrastructure@repoint-sandbox-artifactory') _
 import uk.gov.hmcts.contino.GradleBuilder
 
 def channel = '#rpe-build-notices'

--- a/Jenkinsfile_pipeline_test
+++ b/Jenkinsfile_pipeline_test
@@ -1,5 +1,5 @@
 #!groovy
-@Library('Infrastructure@repoint-sandbox-artifactory') _
+@Library('Infrastructure') _
 import uk.gov.hmcts.contino.GradleBuilder
 
 def channel = '#rpe-build-notices'

--- a/resources/uk/gov/hmcts/gradle/init.gradle
+++ b/resources/uk/gov/hmcts/gradle/init.gradle
@@ -1,4 +1,4 @@
-def mirrorHost = (System.getenv("NONPROD_SUBSCRIPTION_NAME") == "sandbox") ? 'sandbox-artifactory' : 'artifactory'
+def mirrorHost = (System.getenv("NONPROD_SUBSCRIPTION_NAME") == "sandbox") ? 'artifactory.sandbox' : 'artifactory'
 def mirrorUrl = "https://${mirrorHost}.platform.hmcts.net/artifactory/maven-remotes"
 
 allprojects {


### PR DESCRIPTION
As part of tactical decommissioning we need to remove the proxyin server that this service is using,
domain name needs to change as the ingress controller is only setup with .sandbox.platform.hmcts.net atm and it makes sense to change it