### PR TITLE
Camunda Pipeline - fix null as string issue

### DIFF
--- a/resources/uk/gov/hmcts/pipeline/camunda/publish-camunda-processes.sh
+++ b/resources/uk/gov/hmcts/pipeline/camunda/publish-camunda-processes.sh
@@ -7,7 +7,7 @@ s2s_url=$2
 s2s_service=$3
 camunda_url=$4
 product=$5
-tenant_id=${6:-null}
+tenant_id=$6
 filepath="$(realpath "$workspace")/src/main/resources"
 
 for file in $(find "${filepath}" -type f \( -iname "*.bpmn" -o -iname "*.dmn" \))
@@ -34,8 +34,8 @@ do
     -F "deployment-name=$(basename "${file}")" \
     -F "deploy-changed-only=true" \
     -F "deployment-source=$product" \
-    -F "tenant-id=$tenant_id" \
-    -F "file=@${filepath}/$(basename "${file}")")
+    -F "file=@${filepath}/$(basename "${file}")") \
+    ${tenant_id:+"-F" "tenant-id=$tenant_id"}
 
   upload_http_code=$(echo "$uploadResponse" | tail -n1)
   upload_response_content=$(echo "$uploadResponse" | sed '$d')

--- a/resources/uk/gov/hmcts/pipeline/camunda/publish-camunda-processes.sh
+++ b/resources/uk/gov/hmcts/pipeline/camunda/publish-camunda-processes.sh
@@ -34,8 +34,8 @@ do
     -F "deployment-name=$(basename "${file}")" \
     -F "deploy-changed-only=true" \
     -F "deployment-source=$product" \
-    -F "file=@${filepath}/$(basename "${file}")") \
-    ${tenant_id:+"-F" "tenant-id=$tenant_id"}
+    ${tenant_id:+'-F' "tenant-id=$tenant_id"} \
+    -F "file=@${filepath}/$(basename "${file}")")
 
   upload_http_code=$(echo "$uploadResponse" | tail -n1)
   upload_response_content=$(echo "$uploadResponse" | sed '$d')


### PR DESCRIPTION
Although setting null for no value passed into script, it was being converted into a string and passed into camunda as "null".
This now will only set --tenant_id if a value is passed in for it. 

Tested locally
$ ./camunda-example-deploy.sh
"tenantId":null
$ ./camunda-example-deploy.sh ia
tenantId":"ia"


