### PR TITLE
Pipeline warnings for deprecated helm chart config

### DIFF
--- a/resources/uk/gov/hmcts/helm/check-deprecated-charts.sh
+++ b/resources/uk/gov/hmcts/helm/check-deprecated-charts.sh
@@ -8,12 +8,12 @@ MIN_NODEJS_VERSION="2.3.0"
 JAVA_VERSION=$(helm dependency ls charts/${CHART_DIRECTORY}/ | grep "java" |awk '{ print $2}' | sed "s/~//g")
 NODEJS_VERSION=$(helm dependency ls charts/${CHART_DIRECTORY}/ | grep "nodejs" |awk '{ print $2}' | sed "s/~//g")
 
-if [[ $JAVA_VERSION < $MIN_JAVA_VERSION ]]; then
+if [[ -n $JAVA_VERSION ]] &&  [[ $JAVA_VERSION < $MIN_JAVA_VERSION ]]; then
     echo "Java chart version $JAVA_VERSION is deprecated, please upgrade"
     exit 1
 fi
 
-if [[ $NODEJS_VERSION < $MIN_NODEJS_VERSION ]]; then
+if [[ -n $NODEJS_VERSION ]] && [[ $NODEJS_VERSION < $MIN_NODEJS_VERSION ]]; then
     echo "Nodejs chart version $NODEJS_VERSION is deprecated, please upgrade"
     exit 1
 fi

--- a/resources/uk/gov/hmcts/helm/check-deprecated-charts.sh
+++ b/resources/uk/gov/hmcts/helm/check-deprecated-charts.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -x
+
+CHART_DIRECTORY=${1}-${2}
+MIN_JAVA_VERSION="3.4.0"
+MIN_NODEJS_VERSION="2.3.0"
+
+JAVA_VERSION=$(helm dependency ls charts/${CHART_DIRECTORY}/ | grep "java" |awk '{ print $2}' | sed "s/~//g")
+NODEJS_VERSION=$(helm dependency ls charts/${CHART_DIRECTORY}/ | grep "nodejs" |awk '{ print $2}' | sed "s/~//g")
+
+if [[ $JAVA_VERSION < $MIN_JAVA_VERSION ]]; then
+    echo "Java chart version $JAVA_VERSION is deprecated, please upgrade"
+    exit 1
+fi
+
+if [[ $NODEJS_VERSION < $MIN_NODEJS_VERSION ]]; then
+    echo "Nodejs chart version $NODEJS_VERSION is deprecated, please upgrade"
+    exit 1
+fi

--- a/resources/uk/gov/hmcts/helm/check-helm-api-version.sh
+++ b/resources/uk/gov/hmcts/helm/check-helm-api-version.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -x
+
+CHART_DIRECTORY=${1}-${2}
+CHART_API_VERSION=$(cat charts/"${CHART_DIRECTORY}"/Chart.yaml | grep ^apiVersion | cut -d ':' -f 2 | sed -e 's/^[[:space:]]*//')
+
+if [[ ${CHART_API_VERSION} == "v1" ]]; then
+  echo "Chart Api version  ${CHART_API_VERSION} is not supported"
+  exit 1
+fi
+
+if [[ -f charts/"${CHART_DIRECTORY}"/requirements.yaml ]]; then
+  echo "requirements.yaml file is not supported"
+  exit 1
+fi

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -43,8 +43,6 @@ def call(params) {
       warnAboutAADIdentityPreviewHack product: product, component: component
     }
 
-    warnAboutDeprecatedChartConfig product: product, component: component
-
     builder.setupToolVersion()
 
     if (!fileExists('Dockerfile')) {

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -43,6 +43,8 @@ def call(params) {
       warnAboutAADIdentityPreviewHack product: product, component: component
     }
 
+    warnAboutDeprecatedChartConfig product: product, component: component
+
     builder.setupToolVersion()
 
     if (!fileExists('Dockerfile')) {

--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -53,6 +53,7 @@ def call(params) {
             onPR {
               deploymentNumber = githubCreateDeployment()
             }
+            warnAboutDeprecatedChartConfig product: product, component: component
             aksUrl = helmInstall(dockerImage, params)
             log.info("deployed component URL: ${aksUrl}")
             onPR {

--- a/vars/warnAboutDeprecatedChartConfig.groovy
+++ b/vars/warnAboutDeprecatedChartConfig.groovy
@@ -1,6 +1,9 @@
 import uk.gov.hmcts.pipeline.deprecation.WarningCollector
 
-def call() {
+def call(Map<String, String> params) {
+
+  def product = params.product
+  def component = params.component
 
   writeFile file: 'check-helm-api-version.sh', text: libraryResource('uk/gov/hmcts/helm/check-helm-api-version.sh')
   writeFile file: 'check-deprecated-charts.sh', text: libraryResource('uk/gov/hmcts/helm/check-deprecated-charts.sh')
@@ -8,7 +11,7 @@ def call() {
   try {
     sh """
     chmod +x check-helm-api-version.sh
-    ./check-helm-api-version.sh
+    ./check-helm-api-version.sh $product $component
     """
   } catch(ignored) {
     WarningCollector.addPipelineWarning("deprecated_helmapiversion", "Please upgrade helm chart api version to v2. For examples see: https://github.com/hmcts/service-auth-provider-app/pull/255 and https://github.com/hmcts/draft-store/pull/611/files", new Date().parse("dd.MM.yyyy", "22.02.2021"))
@@ -19,7 +22,7 @@ def call() {
   try {
     sh """
     chmod +x check-deprecated-charts.sh
-    ./check-deprecated-charts.sh
+    ./check-deprecated-charts.sh $product $component
     """
   } catch(ignored) {
     WarningCollector.addPipelineWarning("deprecated_helmcharts", "Please upgrade base helm charts to latest. See https://github.com/hmcts/chart-java/releases, https://github.com/hmcts/chart-nodejs/releases", new Date().parse("dd.MM.yyyy", "22.02.2021"))

--- a/vars/warnAboutDeprecatedChartConfig.groovy
+++ b/vars/warnAboutDeprecatedChartConfig.groovy
@@ -1,0 +1,30 @@
+import uk.gov.hmcts.pipeline.deprecation.WarningCollector
+
+def call() {
+
+  writeFile file: 'check-helm-api-version.sh', text: libraryResource('uk/gov/hmcts/helm/check-helm-api-version.sh')
+  writeFile file: 'check-deprecated-charts.sh', text: libraryResource('uk/gov/hmcts/helm/check-deprecated-charts.sh')
+
+  try {
+    sh """
+    chmod +x check-helm-api-version.sh
+    ./check-helm-api-version.sh
+    """
+  } catch(ignored) {
+    WarningCollector.addPipelineWarning("deprecated_helmapiversion", "Please upgrade helm chart api version to v2. For examples see: https://github.com/hmcts/service-auth-provider-app/pull/255 and https://github.com/hmcts/draft-store/pull/611/files", new Date().parse("dd.MM.yyyy", "22.02.2021"))
+  } finally {
+    sh 'rm -f check-helm-api-version.sh'
+  }
+
+  try {
+    sh """
+    chmod +x check-deprecated-charts.sh
+    ./check-deprecated-charts.sh
+    """
+  } catch(ignored) {
+    WarningCollector.addPipelineWarning("deprecated_helmcharts", "Please upgrade base helm charts to latest. See https://github.com/hmcts/chart-java/releases, https://github.com/hmcts/chart-nodejs/releases", new Date().parse("dd.MM.yyyy", "22.02.2021"))
+  } finally {
+    sh 'rm -f check-deprecated-charts.sh'
+  }
+
+}


### PR DESCRIPTION
Notes:
*  Adds check on both PR and master pipeline when deploying to AKS for deprecating chart apiversion, nodejs and java base chart versions.
*  Added in the middle of pipeline as i needed helm commands available.
* Adds 2 separate warnings , apiversion will be one-off but chart version might be needed for forcing rollouts.
