### PR TITLE
fix crossBrowserTest() with SauceConnect

### DIFF
--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -70,7 +70,9 @@ class GradleBuilder extends AbstractBuilder {
     try {
       // By default Gradle will skip task execution if it's already been run (is 'up to date').
       // --rerun-tasks ensures that subsequent calls to tests against different slots are executed.
-      gradle("--rerun-tasks crossbrowser")
+      withSauceConnect("reform_tunnel") {
+        gradle("--rerun-tasks crossbrowser")
+      }
     } finally {
       steps.junit '**/test-results/**/*.xml'
     }


### PR DESCRIPTION
cross-browser tests can only run by connecting to reform_tunnel sauce connect proxy.
