### PR TITLE
TA-471: Add Pact canideploy hooks for Gradle and Yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ Tenant ID can also be checked from the camunda-bpm repo: https://github.com/hmct
 
 You can activate contract testing lifecycle hooks in the CI using the `enablePactAs()` method.
 
-The different hooks are based on roles that you can assign to your project: `CONSUMER` and/or `PROVIDER` and/or 'CAN_I_DEPLOY' (to be used in conjunction with CONSUMER role). A common broker will be used as well as the naming and tagging conventions.
+The different hooks are based on roles that you can assign to your project: `CONSUMER` and/or `PROVIDER` and/or 'CONSUMER_DEPLOY_CHECK' (to be used in conjunction with CONSUMER role). A common broker will be used as well as the naming and tagging conventions.
 
 Here is an example of a project which acts a consumer and provider (for example a backend-for-frontend):
 
@@ -418,7 +418,7 @@ withPipeline(product) {
   enablePactAs([
     AppPipelineDsl.PactRoles.CONSUMER,
     AppPipelineDsl.PactRoles.PROVIDER,
-    AppPipelineDsl.PactRoles.CAN_I_DEPLOY
+    AppPipelineDsl.PactRoles.CONSUMER_DEPLOY_CHECK
   ])
 }
 ```
@@ -430,7 +430,7 @@ The following hooks will then be ran before the deployment:
 | `CONSUMER`     | 1     | `test:pact:run-and-publish`    | `runAndPublishConsumerPactTests`            | Any branch       |
 | `PROVIDER`     | 2     | `test:pact:verify-and-publish` | `runProviderPactVerification publish true`  | `master` only    |
 | `PROVIDER`     | 2     | `test:pact:verify`             | `runProviderPactVerification publish false` | Any branch       |
-| `CAN_I_DEPLOY` | 3     | `test:can-i-deploy:consumer`   | `canideploy`                                | Any branch       |
+| `CONSUMER_DEPLOY_CHECK` | 3     | `test:can-i-deploy:consumer`   | `canideploy`                                | Any branch       |
 
 #### Notes
 

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ Tenant ID can also be checked from the camunda-bpm repo: https://github.com/hmct
 
 You can activate contract testing lifecycle hooks in the CI using the `enablePactAs()` method.
 
-The different hooks are based on roles that you can assign to your project: `CONSUMER` and/or `PROVIDER`. A common broker will be used as well as the naming and tagging conventions.
+The different hooks are based on roles that you can assign to your project: `CONSUMER` and/or `PROVIDER` and/or 'CAN_I_DEPLOY' (to be used in conjunction with CONSUMER role). A common broker will be used as well as the naming and tagging conventions.
 
 Here is an example of a project which acts a consumer and provider (for example a backend-for-frontend):
 
@@ -417,18 +417,20 @@ withPipeline(product) {
 
   enablePactAs([
     AppPipelineDsl.PactRoles.CONSUMER,
-    AppPipelineDsl.PactRoles.PROVIDER
+    AppPipelineDsl.PactRoles.PROVIDER,
+    AppPipelineDsl.PactRoles.CAN_I_DEPLOY
   ])
 }
 ```
 
 The following hooks will then be ran before the deployment:
 
-| Role       | Order | Yarn                           | Gradle                                      | Active on branch |
-| ---------- | ----- | ------------------------------ | ------------------------------------------- | ---------------- |
-| `PROVIDER` | 1     | `test:pact:verify-and-publish` | `runProviderPactVerification publish true`  | `master` only    |
-| `PROVIDER` | 1     | `test:pact:verify`             | `runProviderPactVerification publish false` | Any branch       |
-| `CONSUMER` | 2     | `test:pact:run-and-publish`    | `runAndPublishConsumerPactTests`            | Any branch       |
+| Role           | Order | Yarn                           | Gradle                                      | Active on branch |
+| -------------- | ----- | ------------------------------ | ------------------------------------------- | ---------------- |
+| `CONSUMER`     | 1     | `test:pact:run-and-publish`    | `runAndPublishConsumerPactTests`            | Any branch       |
+| `PROVIDER`     | 2     | `test:pact:verify-and-publish` | `runProviderPactVerification publish true`  | `master` only    |
+| `PROVIDER`     | 2     | `test:pact:verify`             | `runProviderPactVerification publish false` | Any branch       |
+| `CAN_I_DEPLOY` | 3     | `test:can-i-deploy:consumer`   | `canideploy`                                | Any branch       |
 
 #### Notes
 

--- a/src/uk/gov/hmcts/contino/AbstractBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/AbstractBuilder.groovy
@@ -33,6 +33,9 @@ abstract class AbstractBuilder implements Builder, Serializable {
   def runConsumerTests() {}
 
   @Override
+  def runConsumerCanIDeploy() {}
+
+  @Override
   def setupToolVersion() {
   }
 }

--- a/src/uk/gov/hmcts/contino/AngularBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/AngularBuilder.groovy
@@ -75,6 +75,7 @@ class AngularBuilder extends AbstractBuilder {
     builder.setupToolVersion()
   }
 
+  @Override
   def runProviderVerification(){
     builder.runProviderVerification()
   }
@@ -82,5 +83,10 @@ class AngularBuilder extends AbstractBuilder {
   @Override
   def runConsumerTests(){
     builder.runConsumerTests()
+  }
+
+  @Override
+  def runConsumerCanIDeploy(){
+    builder.runConsumerCanIDeploy()
   }
 }

--- a/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
@@ -21,6 +21,7 @@ class AppPipelineConfig extends CommonPipelineConfig implements Serializable {
   boolean pactBrokerEnabled = false
   boolean pactProviderVerificationsEnabled = false
   boolean pactConsumerTestsEnabled = false
+  boolean pactConsumerCanIDeployEnabled = false
   String s2sServiceName
 
   int crossBrowserTestTimeout

--- a/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
@@ -89,12 +89,12 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
     config.aksStagingDeployment = true
   }
 
-  enum PactRoles { CONSUMER, PROVIDER, CAN_I_DEPLOY}
+  enum PactRoles { CONSUMER, PROVIDER, CONSUMER_DEPLOY_CHECK}
 
   void enablePactAs(List<PactRoles> roles) {
     config.pactBrokerEnabled = true
     config.pactConsumerTestsEnabled = roles.contains(PactRoles.CONSUMER)
     config.pactProviderVerificationsEnabled = roles.contains(PactRoles.PROVIDER)
-    config.pactConsumerCanIDeployEnabled = roles.contains(PactRoles.CAN_I_DEPLOY)
+    config.pactConsumerCanIDeployEnabled = roles.contains(PactRoles.CONSUMER_DEPLOY_CHECK)
   }
 }

--- a/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
@@ -89,11 +89,12 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
     config.aksStagingDeployment = true
   }
 
-  enum PactRoles { CONSUMER, PROVIDER }
+  enum PactRoles { CONSUMER, PROVIDER, CAN_I_DEPLOY}
 
   void enablePactAs(List<PactRoles> roles) {
     config.pactBrokerEnabled = true
     config.pactConsumerTestsEnabled = roles.contains(PactRoles.CONSUMER)
     config.pactProviderVerificationsEnabled = roles.contains(PactRoles.PROVIDER)
+    config.pactConsumerCanIDeployEnabled = roles.contains(PactRoles.CAN_I_DEPLOY)
   }
 }

--- a/src/uk/gov/hmcts/contino/Builder.groovy
+++ b/src/uk/gov/hmcts/contino/Builder.groovy
@@ -16,6 +16,7 @@ interface Builder {
   def securityScan()
   def runProviderVerification()
   def runConsumerTests()
+  def runConsumerCanIDeploy()
 
   /**
    * Setup any required versions of a tool

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -149,6 +149,11 @@ EOF
     gradle("-Dpact.broker.url=${pactBrokerUrl} -Dpact.consumer.version=${version} runAndPublishConsumerPactTests")
   }
 
+  def runConsumerCanIDeploy() {
+    gradle("canideploy")
+  }
+
+
   def gradle(String task) {
     addInitScript()
     steps.sh("./gradlew --no-daemon --init-script init.gradle ${task}")

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -213,6 +213,10 @@ EOF
     steps.sh("PACT_BROKER_URL=${pactBrokerUrl} PACT_CONSUMER_VERSION=${version} yarn test:pact:run-and-publish")
   }
 
+  def runConsumerCanIDeploy() {
+    steps.sh("yarn test:can-i-deploy:consumer")
+  }
+
   private runYarn(task){
     if (steps.fileExists(NVMRC)) {
       steps.sh """

--- a/test/uk/gov/hmcts/contino/AbstractBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/AbstractBuilderTest.groovy
@@ -105,6 +105,11 @@ class AbstractBuilderTest extends Specification {
     }
 
     @Override
+    def runConsumerCanIDeploy() {
+      return null
+    }
+
+    @Override
     def setupToolVersion() {
       return null
     }

--- a/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
+++ b/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
@@ -35,6 +35,7 @@ class AppPipelineConfigTest extends Specification {
       assertThat(pipelineConfig.pactBrokerEnabled).isFalse()
       assertThat(pipelineConfig.pactProviderVerificationsEnabled).isFalse()
       assertThat(pipelineConfig.pactConsumerTestsEnabled).isFalse()
+      assertThat(pipelineConfig.pactConsumerCanIDeployEnabled).isFalse()
   }
 
   def "ensure securityScan can be set in steps"() {
@@ -191,6 +192,15 @@ class AppPipelineConfigTest extends Specification {
       assertThat(pipelineConfig.pactProviderVerificationsEnabled).isTrue()
   }
 
+  def "ensure enable pact can i deploy"() {
+    given:
+    assertThat(pipelineConfig.pactConsumerCanIDeployEnabled).isFalse()
+    when:
+    dsl.enablePactAs([AppPipelineDsl.PactRoles.CAN_I_DEPLOY])
+    then:
+    assertThat(pipelineConfig.pactConsumerCanIDeployEnabled).isTrue()
+  }
+
   def "ensure enable pact consumer tests and provider verification"() {
     given:
       assertThat(pipelineConfig.pactProviderVerificationsEnabled).isFalse()
@@ -203,6 +213,7 @@ class AppPipelineConfigTest extends Specification {
     then:
       assertThat(pipelineConfig.pactProviderVerificationsEnabled).isTrue()
       assertThat(pipelineConfig.pactConsumerTestsEnabled).isTrue()
+      assertThat(pipelineConfig.pactConsumerCanIDeployEnabled).isFalse()
   }
 
 }

--- a/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
+++ b/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
@@ -177,19 +177,23 @@ class AppPipelineConfigTest extends Specification {
   def "ensure enable pact consumer tests"() {
     given:
       assertThat(pipelineConfig.pactConsumerTestsEnabled).isFalse()
+      assertThat(pipelineConfig.pactProviderVerificationsEnabled).isFalse()
     when:
       dsl.enablePactAs([AppPipelineDsl.PactRoles.CONSUMER])
     then:
       assertThat(pipelineConfig.pactConsumerTestsEnabled).isTrue()
+      assertThat(pipelineConfig.pactProviderVerificationsEnabled).isFalse()
   }
 
   def "ensure enable pact provider verification"() {
     given:
       assertThat(pipelineConfig.pactProviderVerificationsEnabled).isFalse()
+      assertThat(pipelineConfig.pactConsumerTestsEnabled).isFalse()
     when:
       dsl.enablePactAs([AppPipelineDsl.PactRoles.PROVIDER])
     then:
       assertThat(pipelineConfig.pactProviderVerificationsEnabled).isTrue()
+      assertThat(pipelineConfig.pactConsumerTestsEnabled).isFalse()
   }
 
   def "ensure enable pact can i deploy"() {

--- a/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
+++ b/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
@@ -200,7 +200,7 @@ class AppPipelineConfigTest extends Specification {
     given:
     assertThat(pipelineConfig.pactConsumerCanIDeployEnabled).isFalse()
     when:
-    dsl.enablePactAs([AppPipelineDsl.PactRoles.CAN_I_DEPLOY])
+    dsl.enablePactAs([AppPipelineDsl.PactRoles.CONSUMER_DEPLOY_CHECK])
     then:
     assertThat(pipelineConfig.pactConsumerCanIDeployEnabled).isTrue()
   }

--- a/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
@@ -107,6 +107,16 @@ class GradleBuilderTest extends Specification {
                     it.contains("-Dpact.broker.url=${PACT_BROKER_URL} -Dpact.consumer.version=${version} runAndPublishConsumerPactTests")})
   }
 
+  def "runConsumerCanIDeploy triggers a gradlew hook"() {
+    setup:
+    def version = "v3r510n"
+    when:
+    builder.runConsumerCanIDeploy()
+    then:
+    1 * steps.sh({it.startsWith(GRADLE_CMD) &&
+            it.contains("canideploy")})
+  }
+
   def "Prepares CVE report for publishing to CosmosDB"() {
     when:
     def result = builder.prepareCVEReport(sampleCVEReport)

--- a/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
@@ -183,6 +183,15 @@ class YarnBuilderTest extends Specification {
       1 * steps.sh({ it.contains("PACT_BROKER_URL=${PACT_BROKER_URL} PACT_CONSUMER_VERSION=${version} yarn test:pact:run-and-publish") })
   }
 
+  def "runConsumerCanIDeploy triggers a yarn hook"() {
+    setup:
+    def version = "v3r510n"
+    when:
+    builder.runConsumerCanIDeploy()
+    then:
+    1 * steps.sh({ it.contains("yarn test:can-i-deploy:consumer") })
+  }
+
   def "prepareCVEReport converts json lines report to groovy object"() {
     given:
       def sampleCVEReport = new File(this.getClass().getClassLoader().getResource('yarn-audit-report.txt').toURI()).text

--- a/test/withPipeline/onMaster/withNodeJsPipelinePactOnMasterTests.groovy
+++ b/test/withPipeline/onMaster/withNodeJsPipelinePactOnMasterTests.groovy
@@ -26,6 +26,7 @@ class withNodeJsPipelinePactOnMaster extends BaseCnpPipelineTest {
       sonarScan(1) {}
       securityCheck(1) {}
       runConsumerTests(1) { url, version -> return null }
+      runConsumerCanIDeploy(1) {}
       runProviderVerification(1) { url, version, publish -> return null }
       smokeTest(1) {} //aat-staging
       functionalTest(1) {}

--- a/testResources/exampleNodeJsPipelineForPact.jenkins
+++ b/testResources/exampleNodeJsPipelineForPact.jenkins
@@ -1,6 +1,6 @@
 #!groovy
 
-@com.lesfurets.jenkins.unit.global.lib.Library("Infrastructure")
+@Library("Infrastructure")
 import uk.gov.hmcts.contino.AppPipelineDsl.PactRoles as PactRoles
 
 def product = "product"

--- a/testResources/exampleNodeJsPipelineForPact.jenkins
+++ b/testResources/exampleNodeJsPipelineForPact.jenkins
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library("Infrastructure")
+@com.lesfurets.jenkins.unit.global.lib.Library("Infrastructure")
 import uk.gov.hmcts.contino.AppPipelineDsl.PactRoles as PactRoles
 
 def product = "product"
@@ -11,6 +11,6 @@ withPipeline('nodejs', product, app) {
   enablePactAs([
     PactRoles.CONSUMER,
     PactRoles.PROVIDER,
-    PactRoles.CAN_I_DEPLOY
+    PactRoles.CONSUMER_DEPLOY_CHECK
   ])
 }

--- a/testResources/exampleNodeJsPipelineForPact.jenkins
+++ b/testResources/exampleNodeJsPipelineForPact.jenkins
@@ -10,6 +10,7 @@ def app = "app"
 withPipeline('nodejs', product, app) {
   enablePactAs([
     PactRoles.CONSUMER,
-    PactRoles.PROVIDER
+    PactRoles.PROVIDER,
+    PactRoles.CAN_I_DEPLOY
   ])
 }

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -145,7 +145,7 @@ def call(params) {
     }
   }
 
-  if (config.pactBrokerEnabled) {
+  if (config.pactBrokerEnabled && config.pactConsumerTestsEnabled) {
     stageWithAgent("Pact Consumer Verification", product) {
       def version = env.GIT_COMMIT.length() > 7 ? env.GIT_COMMIT.substring(0, 7) : env.GIT_COMMIT
       def isOnMaster = new ProjectBranch(env.BRANCH_NAME).isMaster()
@@ -156,13 +156,9 @@ def call(params) {
       /*
        * These instructions have to be kept in order
        */
-
-      if (config.pactConsumerTestsEnabled) {
-        pcr.callAround('pact-consumer-tests') {
-          builder.runConsumerTests(pactBrokerUrl, version)
-        }
+      pcr.callAround('pact-consumer-tests') {
+        builder.runConsumerTests(pactBrokerUrl, version)
       }
     }
   }
-
 }

--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -101,7 +101,7 @@ def call(params) {
               }
             }
           }
-          if (config.pactBrokerEnabled && config.pactConsumerTestsEnabled) {
+          if (config.pactBrokerEnabled && config.pactConsumerCanIDeployEnabled) {
             stageWithAgent("Pact Consumer Can I Deploy", product) {
               builder.runConsumerCanIDeploy()
             }

--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -101,19 +101,18 @@ def call(params) {
               }
             }
           }
-
-          if (config.pactBrokerEnabled) {
+          if (config.pactBrokerEnabled && config.pactConsumerTestsEnabled) {
+            builder.runConsumerCanIDeploy();
+          }
+          if (config.pactBrokerEnabled && config.pactProviderVerificationsEnabled) {
             stageWithAgent("Pact Provider Verification", product) {
               def version = env.GIT_COMMIT.length() > 7 ? env.GIT_COMMIT.substring(0, 7) : env.GIT_COMMIT
               def isOnMaster = new ProjectBranch(env.BRANCH_NAME).isMaster()
 
               env.PACT_BRANCH_NAME = isOnMaster ? env.BRANCH_NAME : env.CHANGE_BRANCH
               env.PACT_BROKER_URL = pactBrokerUrl
-
-              if (config.pactProviderVerificationsEnabled) {
-                pcr.callAround('pact-provider-verification') {
+              pcr.callAround('pact-provider-verification') {
                   builder.runProviderVerification(pactBrokerUrl, version, isOnMaster)
-                }
               }
             }
           }

--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -102,7 +102,9 @@ def call(params) {
             }
           }
           if (config.pactBrokerEnabled && config.pactConsumerTestsEnabled) {
-            builder.runConsumerCanIDeploy();
+            stageWithAgent("Pact Consumer Can I Deploy", product) {
+              builder.runConsumerCanIDeploy()
+            }
           }
           if (config.pactBrokerEnabled && config.pactProviderVerificationsEnabled) {
             stageWithAgent("Pact Provider Verification", product) {

--- a/vars/withPactTestOnlyPipeline.groovy
+++ b/vars/withPactTestOnlyPipeline.groovy
@@ -97,6 +97,8 @@ def call(type, String product, String component, Closure body) {
           }
         }
 
+        if(config.pactConsumerTestsEnabled) {
+
         stageWithAgent("Pact Consumer Verification", product) {
 
           def version = env.GIT_COMMIT.length() > 7 ? env.GIT_COMMIT.substring(0, 7) : env.GIT_COMMIT
@@ -111,6 +113,7 @@ def call(type, String product, String component, Closure body) {
           pcr.callAround('pact-consumer-tests') {
             builder.runConsumerTests(pactBrokerUrl, version)
           }
+        }
       }
       }
     } catch (err) {


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
* Adds Pact hooks for CanIDeploy for gradle and yarn

