### PR TITLE
Set sonar properties explicitly

### DIFF
--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -2,6 +2,7 @@ package uk.gov.hmcts.contino
 
 import groovy.json.JsonSlurper
 import uk.gov.hmcts.pipeline.CVEPublisher
+import uk.gov.hmcts.pipeline.SonarProperties
 import uk.gov.hmcts.pipeline.deprecation.WarningCollector
 
 class GradleBuilder extends AbstractBuilder {
@@ -33,7 +34,9 @@ class GradleBuilder extends AbstractBuilder {
   }
 
   def sonarScan() {
-      gradle("--info sonarqube")
+      String properties = SonarProperties.get(steps)
+
+      gradle("--info ${properties} sonarqube")
   }
 
   def smokeTest() {

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -2,6 +2,7 @@ package uk.gov.hmcts.contino
 
 import groovy.json.JsonSlurper
 import uk.gov.hmcts.pipeline.CVEPublisher
+import uk.gov.hmcts.pipeline.SonarProperties
 import uk.gov.hmcts.pipeline.deprecation.WarningCollector;
 
 class YarnBuilder extends AbstractBuilder {
@@ -27,7 +28,9 @@ class YarnBuilder extends AbstractBuilder {
   }
 
   def sonarScan() {
-    yarn('sonar-scan')
+    String properties = SonarProperties.get(steps)
+
+    yarn("sonar-scan ${properties}")
   }
 
   def smokeTest() {

--- a/src/uk/gov/hmcts/pipeline/SonarProperties.groovy
+++ b/src/uk/gov/hmcts/pipeline/SonarProperties.groovy
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.pipeline
+
+import uk.gov.hmcts.contino.ProjectBranch
+
+class SonarProperties implements Serializable {
+  static String get(steps) {
+    def env = steps.env
+
+    boolean onPR = new ProjectBranch(env.BRANCH_NAME).isPR()
+    if (onPR) {
+      return """-Dsonar.pullrequest.key=${env.CHANGE_ID} \
+      -Dsonar.pullrequest.base=${env.CHANGE_TARGET} \
+      -Dsonar.pullrequest.branch=${env.CHANGE_BRANCH} \
+      -Dsonar.pullrequest.provider=github"""
+    } else {
+      return ""
+    }
+  }
+}

--- a/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
@@ -14,6 +14,9 @@ class GradleBuilderTest extends Specification {
 
   def setup() {
     steps = Mock(JenkinsStepMock.class)
+    steps.getEnv() >> [
+      BRANCH_NAME: 'master',
+    ]
     builder = new GradleBuilder(steps, 'test')
     sampleCVEReport = new File(this.getClass().getClassLoader().getResource('dependency-check-report.json').toURI()).text
     steps.readFile(_ as String) >> sampleCVEReport

--- a/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
@@ -35,6 +35,9 @@ class YarnBuilderTest extends Specification {
 
     def sampleCVEReport = new File(this.getClass().getClassLoader().getResource('yarn-audit-report-no-issues.txt').toURI()).text
     steps.readFile(_ as String) >> sampleCVEReport
+    steps.getEnv() >> [
+      BRANCH_NAME: 'master',
+    ]
     def closure
     steps.withCredentials(_, { closure = it }) >> { closure.call() }
     steps.withSauceConnect(_, { closure = it }) >> { closure.call() }


### PR DESCRIPTION
Allows us to switch to upstream plugin

Tested in https://github.com/hmcts/cnp-plum-frontend/pull/75 and https://github.com/hmcts/cnp-plum-recipes-service/pull/312 and on plum-frontend master (https://build.platform.hmcts.net/job/HMCTS_CNP/job/cnp-plum-frontend/job/master/44/console)