### PR TITLE
Allow for preview branch to be tagged as preview-commit

### DIFF
--- a/src/uk/gov/hmcts/contino/DockerImage.groovy
+++ b/src/uk/gov/hmcts/contino/DockerImage.groovy
@@ -11,6 +11,7 @@ class DockerImage {
     PR('pr'),
     STAGING('staging'),
     AAT('aat'),
+    PREVIEW('preview'),
     PROD('prod'),
     LATEST('latest')
 

--- a/src/uk/gov/hmcts/contino/azure/Acr.groovy
+++ b/src/uk/gov/hmcts/contino/azure/Acr.groovy
@@ -128,6 +128,7 @@ class Acr extends Az {
     def additionalTag = dockerImage.getShortName(stage)
     def baseTag = (stage == DockerImage.DeploymentStage.PR  || dockerImage.imageTag == 'staging') ? dockerImage.getBaseTaggedName() : dockerImage.getTaggedName()
     if (stage == DockerImage.DeploymentStage.PREVIEW) {
+      // Non-master builds will only have the base branch name as the tag
       baseTag = dockerImage.getBaseShortName();
     }
     this.az "acr import --force -n ${registryName} -g ${resourceGroup} --subscription ${registrySubscription} --source ${baseTag} -t ${additionalTag}"?.trim()

--- a/src/uk/gov/hmcts/contino/azure/Acr.groovy
+++ b/src/uk/gov/hmcts/contino/azure/Acr.groovy
@@ -127,6 +127,9 @@ class Acr extends Az {
   def retagForStage(DockerImage.DeploymentStage stage, DockerImage dockerImage) {
     def additionalTag = dockerImage.getShortName(stage)
     def baseTag = (stage == DockerImage.DeploymentStage.PR  || dockerImage.imageTag == 'staging') ? dockerImage.getBaseTaggedName() : dockerImage.getTaggedName()
+    if (stage == DockerImage.DeploymentStage.PREVIEW) {
+      baseTag = dockerImage.getBaseShortName();
+    }
     this.az "acr import --force -n ${registryName} -g ${resourceGroup} --subscription ${registrySubscription} --source ${baseTag} -t ${additionalTag}"?.trim()
   }
 

--- a/vars/onPathToLive.groovy
+++ b/vars/onPathToLive.groovy
@@ -11,7 +11,7 @@ import uk.gov.hmcts.contino.ProjectBranch
  */
 def call(block) {
   def branch = new ProjectBranch(env.BRANCH_NAME)
-  if (branch.isPR() || branch.isMaster()) {
+  if (branch.isPR() || branch.isMaster() || branch.isPreview()) {
     return block.call()
   }
 }

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -89,6 +89,17 @@ def call(type, String product, String component, Closure body) {
             component: component
           )
         }
+
+        sectionPromoteBuildToStage(
+          appPipelineConfig: pipelineConfig,
+          pipelineCallbacksRunner: callbacksRunner,
+          pipelineType: pipelineType,
+          subscription: subscription.nonProdName,
+          product: product,
+          component: component,
+          stage: DockerImage.DeploymentStage.PREVIEW,
+          environment: environment.nonProdName
+        )
       }
 
       onPR {


### PR DESCRIPTION
Preview will be tagged only with branch name as the tag.
This change allows it to be re-tagged to also contain the commit tag, i.e preview-ab56cf22