### PR TITLE
Fix for idam pack and master on sandbox

### DIFF
--- a/src/uk/gov/hmcts/contino/Environment.groovy
+++ b/src/uk/gov/hmcts/contino/Environment.groovy
@@ -9,6 +9,7 @@ class Environment implements Serializable {
   def final perftestName
   def final ithcName
   def final ethosLdataName
+  def final sandbox
   def final pactBrokerUrl
 
   def final functionalTestEnvironments
@@ -25,6 +26,7 @@ class Environment implements Serializable {
     perftestName = env.PERFTEST_ENVIRONMENT_NAME ?: 'perftest'
     ithcName = env.ITHC_ENVIRONMENT_NAME ?: 'ithc'
     ethosLdataName = env.ETHOSLDATA_ENVIRONMENT_NAME ?: 'ethosldata'
+    sandbox = env.SANDBOX_ENVIRONMENT_NAME ?: 'sandbox'
     pactBrokerUrl = env.PACT_BROKER_URL ?: 'https://pact-broker.platform.hmcts.net'
 
     functionalTestEnvironments = [nonProdName, previewName, 'idam-aat', 'idam-preview']

--- a/src/uk/gov/hmcts/pipeline/AKSSubscriptions.groovy
+++ b/src/uk/gov/hmcts/pipeline/AKSSubscriptions.groovy
@@ -10,6 +10,7 @@ class AKSSubscriptions {
   final AKSSubscription prod
   final AKSSubscription demo
   final AKSSubscription ethosldata
+  final AKSSubscription sandbox
 
   List<AKSSubscription> subscriptionList = new ArrayList<>();
 
@@ -53,6 +54,11 @@ class AKSSubscriptions {
     def ethosLdataName = steps.env.AKS_ETHOS_LDATA_SUBSCRIPTION_NAME ?: 'DCD-ETHOS-MIGRATION-LDATA'
     def ethosId = steps.env.AKS_ETHOS_LDATA_SUBSCRIPTION_ID ?: '4da0ce99-35c5-491f-8a0b-56c39f7278fa'
     ethosldata = new AKSSubscription(steps, ethosLdataName, 'ethos-ldata', environment.ethosLdataName.toString(), ethosId)
+
+    def sandboxName = steps.env.AKS_SANDBOX_SUBSCRIPTION_NAME ?: 'DCD-CFTAPPS-SBOX'
+    def sandboxId = steps.env.AKS_SANDBOX_SUBSCRIPTION_ID ?: 'b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb'
+    sandbox = new AKSSubscription(steps, sandboxName, '', environment.sandbox.toString(), sandboxId)
+
     subscriptionList.add(ethosldata)
 
   }


### PR DESCRIPTION
cnp-idam-packer and cnp-idam-master run on sandbox to build the forgerock images but cannot pass the step in **_spinInfra.groovy_** that does:

```groovy
        env.TF_VAR_aks_subscription_id = new AKSSubscriptions(this).getAKSSubscriptionByEnvName(environment).id
```

It doesn't require sandbox aks auto deploy to work, it just needs that line not to fail with a nullpointer on the id field