### PR TITLE
Add parallel crossbrowser testing for Java projects

### DIFF
--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -68,12 +68,12 @@ class GradleBuilder extends AbstractBuilder {
     }
   }
 
-  def crossBrowserTest() {
+  def crossBrowserTest(String browser = "") {
     try {
       // By default Gradle will skip task execution if it's already been run (is 'up to date').
       // --rerun-tasks ensures that subsequent calls to tests against different slots are executed.
       steps.withSauceConnect("reform_tunnel") {
-        gradle("--rerun-tasks crossbrowser")
+        gradle("--rerun-tasks crossbrowser", "BROWSER_GROUP=$browser")
       }
     } finally {
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**/*'
@@ -150,9 +150,9 @@ EOF
   }
 
 
-  def gradle(String task) {
+  def gradle(String task, String prepend = "") {
     addInitScript()
-    steps.sh("./gradlew --no-daemon --init-script init.gradle ${task}")
+    steps.sh("${prepend} ./gradlew --no-daemon --init-script init.gradle ${task}")
   }
 
   private String gradleWithOutput(String task) {

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -68,7 +68,20 @@ class GradleBuilder extends AbstractBuilder {
     }
   }
 
-  def crossBrowserTest(String browser = "") {
+  def crossBrowserTest() {
+    try {
+      // By default Gradle will skip task execution if it's already been run (is 'up to date').
+      // --rerun-tasks ensures that subsequent calls to tests against different slots are executed.
+      steps.withSauceConnect("reform_tunnel") {
+        gradle("--rerun-tasks crossbrowser")
+      }
+    } finally {
+      steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**/*'
+      steps.saucePublisher()
+    }
+  }
+
+  def crossBrowserTest(String browser) {
     try {
       // By default Gradle will skip task execution if it's already been run (is 'up to date').
       // --rerun-tasks ensures that subsequent calls to tests against different slots are executed.

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -151,8 +151,11 @@ EOF
 
 
   def gradle(String task, String prepend = "") {
+    if (prepend && !prepend.endsWith(' ')) {
+      prepend += ' '
+    }
     addInitScript()
-    steps.sh("${prepend} ./gradlew --no-daemon --init-script init.gradle ${task}")
+    steps.sh("${prepend}./gradlew --no-daemon --init-script init.gradle ${task}")
   }
 
   private String gradleWithOutput(String task) {

--- a/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
@@ -73,6 +73,38 @@ class GradleBuilderTest extends Specification {
     1 * steps.sh({ it.startsWith(GRADLE_CMD) && it.contains('apiGateway') && it.contains('--rerun-tasks') })
   }
 
+  def "crossBrowserTest calls 'gradle crossbrowser'"() {
+    when:
+    builder.crossBrowserTest()
+    then:
+    1 * steps.saucePublisher()
+    1 * steps.withSauceConnect({ it.startsWith('reform_tunnel') }, _ as Closure)
+    1 * steps.archiveArtifacts(['allowEmptyArchive':true, 'artifacts':'functional-output/**/*'])
+    when:
+    builder.gradle('--rerun-tasks crossbrowser')
+    then:
+    1 * steps.sh({ it.startsWith(GRADLE_CMD) && it.contains('--rerun-tasks crossbrowser') })
+    1 * steps.writeFile(['file':'init.gradle', 'text':null])
+    1 * steps.libraryResource('uk/gov/hmcts/gradle/init.gradle')
+  }
+
+  def "crossBrowserTest calls 'gradle crossbrowser' with 'BROWSER_GROUP' environment variable prepended"() {
+    String browser = 'chrome'
+    String browserGroup = "BROWSER_GROUP=${browser}"
+    when:
+    builder.crossBrowserTest(browser)
+    then:
+    1 * steps.saucePublisher()
+    1 * steps.withSauceConnect({ it.startsWith('reform_tunnel') }, _ as Closure)
+    1 * steps.archiveArtifacts(['allowEmptyArchive':true, 'artifacts':'functional-output/**/*'])
+    when:
+    builder.gradle('--rerun-tasks crossbrowser', browserGroup)
+    then:
+    1 * steps.sh({ it.startsWith("${browserGroup} ${GRADLE_CMD}") && it.contains('--rerun-tasks crossbrowser') })
+    1 * steps.writeFile(['file':'init.gradle', 'text':null])
+    1 * steps.libraryResource('uk/gov/hmcts/gradle/init.gradle')
+  }
+
   def "securityCheck calls 'gradle dependencyCheckAggregate"() {
     setup:
       def closure


### PR DESCRIPTION
This change extends the recent [parallel crossBrowserTest() feature](https://github.com/hmcts/cnp-jenkins-library/blob/master/vars/sectionNightlyTests.groovy#L53-L70) to run nightly crossbrowser tests in parallel Jenkins steps for Java projects. The feature can be used by adding the browser groups that are to run in parallel in the service's Jenkinsfile_nightly (i.e. extending the existing enableCrossBrowserTest() call), like so:
```
enableCrossBrowserTest(['chrome', 'firefox', 'safari', 'microsoft'])
```

The existing functionality takes this array of strings and makes individual calls to the builder for each string
```
      browsers.each { browser ->
        crossBrowserStages.put(browser.capitalize(), {
          warnError('Failure in crossBrowserTest') {
            pcr.callAround('crossBrowserTest') {
              timeoutWithMsg(time: config.crossBrowserTestTimeout, unit: 'MINUTES', action: 'Cross browser test') {
                builder.crossBrowserTest(browser)
              }
            }
          }
        })
```

However, until this change, there was only a compatible method in the Yarn builder. Now this will work with Java projects too.

**Notes:**
* The new step can be overridden to run any browser / browser group command that the service requires