### PR TITLE
SIDM-5850: webapps being caught by the stripping of 'idam-'

### DIFF
--- a/vars/spinInfra.groovy
+++ b/vars/spinInfra.groovy
@@ -83,10 +83,14 @@ def call(product, component, environment, tfPlanOnly, subscription, deploymentTa
         env.TF_VAR_deployment_namespace = deploymentNamespace
         env.TF_VAR_subscription = subscription
         env.TF_VAR_component = component
-        if (environment ==~ /^idam-packer-.*/ ) {
-          environmentName = environment.replace("idam-packer-","")
-        } else if (environment ==~ /^idam-.*/ ) {
-          environmentName = environment.replace("idam-","")
+        if (component == "forgerock" ) {
+          if (environment ==~ /^idam-packer-.*/ ) {
+            environmentName = environment.replace("idam-packer-","")
+          } else if (environment ==~ /^idam-.*/ ) {
+            environmentName = environment.replace("idam-","")
+          } else {
+            environmentName = environment
+          }
         } else {
           environmentName = environment
         }


### PR DESCRIPTION
Added check to see if component is set to 'forgerock'
This avoids stripping the 'idam-' from idam webapps

Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
*
*
*
