### PR TITLE
Ensure resources exist during terraform state import

### DIFF
--- a/vars/importTerraformModules.groovy
+++ b/vars/importTerraformModules.groovy
@@ -16,7 +16,8 @@ def call(String subscription, String environment, String product, tags) {
         def child_modules = stateJsonObj.values.root_module.child_modules
 
         // Get All resources to be imported
-        def templateResources = child_modules.findAll { it.resources[0].type == 'azurerm_template_deployment' && 
+        def templateResources = child_modules.findAll { it.resources &&
+                                                        it.resources[0].type == 'azurerm_template_deployment' && 
                                                         (it.resources[0].name == "namespace" || 
                                                         it.resources[0].name == "topic" || 
                                                         it.resources[0].name == "queue" || 


### PR DESCRIPTION
In Terraform 1.0.0 there is an additional object that does not have resources

``` 
{
    "address": "module.policy"
  }
```

