### PR TITLE
Extend withCamundaOnlyPipeline() to be able to use syncBranchesWithMaster()

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ The Pact broker url and other parameters are passed to these hooks as following:
 
 The environment specific branches such as demo, ithc and perftest can be automatically synced with master branch.
 
-This can be achieved by using the `syncBranchesWithMaster()` method in Application and Infrastructure pipelines. This method will be invoked in the master build and execute as the last stage in the build.
+This can be achieved by using the `syncBranchesWithMaster()` method in Application, Infrastructure and Camunda pipelines. This method will be invoked in the master build and execute as the last stage in the build.
 
 Example of usage
 ```groovy

--- a/vars/withCamundaOnlyPipeline.groovy
+++ b/vars/withCamundaOnlyPipeline.groovy
@@ -117,7 +117,12 @@ def call(type, String product, String component, String s2sServiceName, String t
         def prodEnv = new Environment(env).prodName
         camundaPublish(s2sServiceName, nonProdEnv, product, tenantId)
         camundaPublish(s2sServiceName, prodEnv, product, tenantId)
-       }
+
+        sectionSyncBranchesWithMaster(
+            branchestoSync: pipelineConfig.branchesToSyncWithMaster,
+            product: product
+        )
+      }
 
     } catch (err) {
       currentBuild.result = 'FAILURE'


### PR DESCRIPTION
Notes:
* Extend withCamundaOnlyPipeline() to be able to use syncBranchesWithMaster()