### PR TITLE
Added support to disable high level data setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,21 @@ Branch | HighDataSetup Stage
 `demo` | `demo`
 `ithc` | `ithc`
 
+To disable high level data setup for an environment use
+```
+#!groovy
+
+@Library("Infrastructure")
+
+def type = "java"
+def product = "rhubarb"
+def component = "recipe-backend"
+
+withPipeline(type, product, component) {
+  disableHighLevelDataSetup()
+}
+
+```
 #### Extending the opinionated pipeline
 
 It is not possible to remove stages from the pipeline but it is possible to _add_ extra steps to the existing stages.

--- a/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
@@ -101,4 +101,8 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
   void enableHighLevelDataSetup() {
     config.highLevelDataSetup = true
   }
+
+  void disableHighLevelDataSetup() {
+    config.highLevelDataSetup = false
+  }
 }

--- a/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
+++ b/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
@@ -163,6 +163,13 @@ class AppPipelineConfigTest extends Specification {
     assertThat(pipelineConfig.highLevelDataSetup).isTrue()
   }
 
+  def "ensure disable high level data setup"() {
+    when:
+    dsl.disableHighLevelDataSetup()
+    then:
+    assertThat(pipelineConfig.highLevelDataSetup).isFalse()
+  }
+
   def "ensure enable slack notifications"() {
     def slackChannel = "#donotdisturb"
     when:
@@ -226,5 +233,4 @@ class AppPipelineConfigTest extends Specification {
       assertThat(pipelineConfig.pactConsumerTestsEnabled).isTrue()
       assertThat(pipelineConfig.pactConsumerCanIDeployEnabled).isFalse()
   }
-
 }


### PR DESCRIPTION

* Currently if we enable high level data setup it enables it for AAT and PROD and expects key vaults to be present in prod else it fails for reference https://build.platform.hmcts.net/view/NFDIV/job/HMCTS_NFDIV/job/nfdiv-case-api/job/master/503/console
* For services such which are not in prod and only in AAT this fails the build hence adding support to disable the high level data setup.
