### PR TITLE
Update minimum required chart versions

### DIFF
--- a/resources/uk/gov/hmcts/helm/check-deprecated-charts.sh
+++ b/resources/uk/gov/hmcts/helm/check-deprecated-charts.sh
@@ -2,8 +2,8 @@
 set -x
 
 CHART_DIRECTORY=${1}-${2}
-MIN_JAVA_VERSION="3.4.5"
-MIN_NODEJS_VERSION="2.3.4"
+MIN_JAVA_VERSION="3.6.0"
+MIN_NODEJS_VERSION="2.3.7"
 MIN_JOB_VERSION="0.7.1"
 
 JAVA_VERSION=$(helm dependency ls charts/${CHART_DIRECTORY}/ | grep "java" |awk '{ print $2}' | sed "s/~//g")

--- a/vars/warnAboutDeprecatedChartConfig.groovy
+++ b/vars/warnAboutDeprecatedChartConfig.groovy
@@ -25,7 +25,7 @@ def call(Map<String, String> params) {
     ./check-deprecated-charts.sh $product $component
     """
   } catch(ignored) {
-    WarningCollector.addPipelineWarning("deprecated_helmcharts", "Please upgrade base helm charts to latest. See https://github.com/hmcts/chart-java/releases, https://github.com/hmcts/chart-nodejs/releases, https://github.com/hmcts/chart-job/releases ", new Date().parse("dd.MM.yyyy", "26.04.2021"))
+    WarningCollector.addPipelineWarning("deprecated_helmcharts", "Please upgrade base helm charts to latest. See https://github.com/hmcts/chart-java/releases, https://github.com/hmcts/chart-nodejs/releases, https://github.com/hmcts/chart-job/releases ", new Date().parse("dd.MM.yyyy", "27.08.2021"))
   } finally {
     sh 'rm -f check-deprecated-charts.sh'
   }


### PR DESCRIPTION
The latest version is required for traefik v2 on PR and staging deployments.
It's not required for apps deployed via flux.

This should start getting people updated so their tests work when traefik v2 upgrade happens