### PR TITLE
DTSPO-2880 - Adding gradlePluginPortal to init.gradle

### DIFF
--- a/resources/uk/gov/hmcts/gradle/init.gradle
+++ b/resources/uk/gov/hmcts/gradle/init.gradle
@@ -36,6 +36,7 @@ settingsEvaluated { settings ->
       maven {
         url mirrorUrl
       }
+      gradlePluginPortal()
     }
   }
 }


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
*
*
*
