### PR TITLE
Chore: Mount ZAP directory for SecurityScan

### DIFF
--- a/src/uk/gov/hmcts/contino/SecurityScan.groovy
+++ b/src/uk/gov/hmcts/contino/SecurityScan.groovy
@@ -3,7 +3,7 @@ package uk.gov.hmcts.contino
 
 class SecurityScan implements Serializable {
     public static final String OWASP_ZAP_IMAGE = 'owasp/zap2docker-weekly'
-    public static final String OWASP_ZAP_ARGS = '-u 0:0 --name zap -p 1001:1001 -w $(pwd):/zap/wrk/:rw'
+    public static final String OWASP_ZAP_ARGS = '-u 0:0 --name zap -p 1001:1001 -v $WORKSPACE:/zap/wrk/:rw'
     public static final String GLUEIMAGE = 'hmcts/zap-glue:latest'
     public static final String GLUE_ARGS = '-u 0:0 --name=Glue -w $(pwd):/tmp'
     def steps

--- a/src/uk/gov/hmcts/contino/SecurityScan.groovy
+++ b/src/uk/gov/hmcts/contino/SecurityScan.groovy
@@ -3,7 +3,7 @@ package uk.gov.hmcts.contino
 
 class SecurityScan implements Serializable {
     public static final String OWASP_ZAP_IMAGE = 'owasp/zap2docker-weekly'
-    public static final String OWASP_ZAP_ARGS = '-u 0:0 --name zap -p 1001:1001 -v $(pwd):/zap/wrk/:rw'
+    public static final String OWASP_ZAP_ARGS = '-u 0:0 --name zap -p 1001:1001 -w $(pwd):/zap/wrk/:rw'
     public static final String GLUEIMAGE = 'hmcts/zap-glue:latest'
     public static final String GLUE_ARGS = '-u 0:0 --name=Glue -w $(pwd):/tmp'
     def steps

--- a/src/uk/gov/hmcts/contino/SecurityScan.groovy
+++ b/src/uk/gov/hmcts/contino/SecurityScan.groovy
@@ -3,7 +3,7 @@ package uk.gov.hmcts.contino
 
 class SecurityScan implements Serializable {
     public static final String OWASP_ZAP_IMAGE = 'owasp/zap2docker-weekly'
-    public static final String OWASP_ZAP_ARGS = '-u 0:0 --name zap -p 1001:1001'
+    public static final String OWASP_ZAP_ARGS = '-u 0:0 --name zap -p 1001:1001 -v $(pwd):/zap/wrk/:rw'
     public static final String GLUEIMAGE = 'hmcts/zap-glue:latest'
     public static final String GLUE_ARGS = '-u 0:0 --name=Glue -w $(pwd):/tmp'
     def steps


### PR DESCRIPTION
To support ZAP daemon generating the required reports as part of it's scan instead of needing to use `zap-cli`, `/zap/wrk/` folder needs to be mounted for ZAP daemon to save those reports into it.

This has been tested for backwards compatiblility, and does not appear to impact the original way of generating reports using `zap-cli`:
<img width="765" alt="Screenshot 2021-08-03 at 09 41 46" src="https://user-images.githubusercontent.com/11600884/128011810-f55b00b8-aaa6-4f3e-b624-ca4a55954318.png">


Notes:
- FPLA PR depending on this change https://github.com/hmcts/fpl-ccd-configuration/pull/2952