### PR TITLE
DTSPO-2880 - adding ithc and perftest subs for SDS

### DIFF
--- a/src/uk/gov/hmcts/contino/Subscription.groovy
+++ b/src/uk/gov/hmcts/contino/Subscription.groovy
@@ -8,6 +8,9 @@ class Subscription implements Serializable {
   def final hmctsDemoName
   def final qaName
   def final ethosLdataName
+  def final ithcName
+  def final perftestName
+
 
   Subscription(Object env) {
     Objects.requireNonNull(env)
@@ -18,6 +21,8 @@ class Subscription implements Serializable {
     previewName = env.PREVIEW_SUBSCRIPTION_NAME ?: 'nonprod'
     hmctsDemoName = env.HMCTSDEMO_SUBSCRIPTION_NAME ?: 'hmctsdemo'
     qaName = env.QA_SUBSCRIPTION_NAME ?: 'qa'
+    ithcName = env.ITHC_SUBSCRIPTION_NAME ?: 'qa'
+    perftestName = env.PERFTEST_SUBSCRIPTION_NAME ?: 'qa'
     ethosLdataName = env.ETHOSLDATA_SUBSCRIPTION_NAME ?: 'ethosldata'
   }
 }

--- a/vars/autoDeployEnvironment.groovy
+++ b/vars/autoDeployEnvironment.groovy
@@ -25,12 +25,12 @@ def call() {
     ],
     perftest: [
       environmentName: environment.perftestName,
-      subscriptionName: subscription.qaName,
+      subscriptionName: subscription.perftestName,
       aksSubscription: aksSubscriptions.perftest
     ],
     ithc: [
       environmentName: environment.ithcName,
-      subscriptionName: subscription.qaName,
+      subscriptionName: subscription.ithcName,
       aksSubscription: aksSubscriptions.ithc
     ],
     ethosldata: [


### PR DESCRIPTION
Existing CFT branches should continue to default to 'qa' as QA_SUBSCRIPTION_NAME does not seem to be used anywhere