### PR TITLE
Show info and stacktrace for OWASP dependency check execution

### DIFF
--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -117,7 +117,7 @@ class GradleBuilder extends AbstractBuilder {
     ]
     steps.withAzureKeyvault(secrets) {
       try {
-          gradle("-DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${steps.env.OWASPDB_V6_ACCOUNT}' -Ddata.password='${steps.env.OWASPDB_V6_PASSWORD}'  -Danalyzer.retirejs.enabled=false dependencyCheckAggregate")
+          gradle("-is -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${steps.env.OWASPDB_V6_ACCOUNT}' -Ddata.password='${steps.env.OWASPDB_V6_PASSWORD}'  -Danalyzer.retirejs.enabled=false dependencyCheckAggregate")
       }
       finally {
         steps.archiveArtifacts 'build/reports/dependency-check-report.html'

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -117,7 +117,7 @@ class GradleBuilder extends AbstractBuilder {
     ]
     steps.withAzureKeyvault(secrets) {
       try {
-          gradle("-is -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${steps.env.OWASPDB_V6_ACCOUNT}' -Ddata.password='${steps.env.OWASPDB_V6_PASSWORD}'  -Danalyzer.retirejs.enabled=false dependencyCheckAggregate")
+          gradle("--stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${steps.env.OWASPDB_V6_ACCOUNT}' -Ddata.password='${steps.env.OWASPDB_V6_PASSWORD}'  -Danalyzer.retirejs.enabled=false dependencyCheckAggregate")
       }
       finally {
         steps.archiveArtifacts 'build/reports/dependency-check-report.html'

--- a/test/uk/gov/hmcts/pipeline/deprecation/WarningCollectorTest.groovy
+++ b/test/uk/gov/hmcts/pipeline/deprecation/WarningCollectorTest.groovy
@@ -9,7 +9,8 @@ class WarningCollectorTest extends Specification {
 
   Date nextDay = DateUtils.addDays(new Date(),1)
   Date now = new Date()
-  Date nextWeek = DateUtils.addDays(new Date(),7)
+  Date nextWeek = DateUtils.addHours(DateUtils.addDays(new Date(),7), -1)
+
   String nextWeekFormattedDate = nextWeek.format("dd/MM/yyyy HH:mm aa", TimeZone.getTimeZone("UTC"))
   String nextDayFormattedDate = nextDay.format("dd/MM/yyyy HH:mm aa", TimeZone.getTimeZone("UTC"))
 


### PR DESCRIPTION
To investigate current and future internal failures of the dependency checking task.