### PR TITLE
Remove importTerraformModules method call

### DIFF
--- a/vars/spinInfra.groovy
+++ b/vars/spinInfra.groovy
@@ -92,11 +92,6 @@ def call(product, component, environment, tfPlanOnly, subscription, deploymentTa
 
         sh 'env|grep "TF_VAR\\|AZURE\\|ARM\\|STORE" | grep -v ARM_ACCESS_KEY'
 
-        // Do not attempt to import during PR build
-        // if (!tfPlanOnly) {
-        //   importTerraformModules(subscription, environment, product, pipelineTags)
-        // }
-
         sh "terraform get -update=true"
         sh "terraform plan -out tfplan -var 'common_tags=${pipelineTags}' -var 'env=${environment}' -var 'product=${product}'" +
           (fileExists("${environment}.tfvars") ? " -var-file=${environment}.tfvars" : "")


### PR DESCRIPTION
Resolves # 

Resolves the errors like "Failed to marshal state to json: unsupported attribute "enable_rbac_authorization"". Which can occur when AzureRM version is upgraded.