### PR TITLE
SIDM-6338:

### DIFF
--- a/src/uk/gov/hmcts/contino/Environment.groovy
+++ b/src/uk/gov/hmcts/contino/Environment.groovy
@@ -50,6 +50,7 @@ class Environment implements Serializable {
           return "testing"
         case "stg":
         case "aat":
+        case "aat2":
           return "staging"
         case "prod":
           return "production"


### PR DESCRIPTION
Adding aat2 as build giving error 'unknown environment'

Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
*
*
*
