### PR TITLE
add optional component parameter for infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,9 +278,9 @@ withInfraPipeline(product) {
 You have the ability to pass extra parameters to the `withInfraPipeline`.
 
 These parameters include:
-| parameter name | description | example |
+| parameter name | description
 | --- | --- | --- |
-| component | Extra detail to the name of the repository | "extra-detail" |
+| component | https://hmcts.github.io/glossary/#component |
 
 Example `Jenkinsfile` to use the opinionated infrastructure pipeline:
 ```groovy

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Example `Jenkinsfile` to use the opinionated infrastructure pipeline:
 
 @Library("Infrastructure") _
 
-def product = "rhubarb" 
+def product = "rhubarb"
 
 withInfraPipeline(product) {
 

--- a/README.md
+++ b/README.md
@@ -276,6 +276,33 @@ withInfraPipeline(product, component) {
 }
 ```
 
+#### Optional parameters for the opinionated infratructure pipeline
+
+You have the ability to pass extra parameters to the `withInfraPipeline`.
+
+These parameters include:
+| parameter name | description | example |
+| --- | --- | --- |
+| component | Extra detail to the name of the repository | "extra-detail" |
+
+Example `Jenkinsfile` to use the opinionated infrastructure pipeline:
+```groovy
+#!groovy
+
+@Library("Infrastructure") _
+
+def product = "rhubarb"
+
+//Optional
+def component = "extra-detail" 
+
+withInfraPipeline(product, component) {
+
+  enableSlackNotifications('#my-team-builds')
+
+}
+```
+
 #### Extending the opinionated infratructure pipeline
 
 It is not possible to remove stages from the pipeline but it is possible to _add_ extra steps to the existing stages.

--- a/README.md
+++ b/README.md
@@ -264,12 +264,9 @@ Example `Jenkinsfile` to use the opinionated infrastructure pipeline:
 
 @Library("Infrastructure") _
 
-def product = "rhubarb"
+def product = "rhubarb" 
 
-//Optional
-def component = "extra-detail" 
-
-withInfraPipeline(product, component) {
+withInfraPipeline(product) {
 
   enableSlackNotifications('#my-team-builds')
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,10 @@ Example `Jenkinsfile` to use the opinionated infrastructure pipeline:
 
 def product = "rhubarb"
 
-withInfraPipeline(product) {
+//Optional
+def component = "extra-detail" 
+
+withInfraPipeline(product, component) {
 
   enableSlackNotifications('#my-team-builds')
 

--- a/vars/sectionInfraBuild.groovy
+++ b/vars/sectionInfraBuild.groovy
@@ -5,12 +5,13 @@ def call(params) {
   def subscription = params.subscription
   def product = params.product
   def planOnly = params.planOnly ?: false
+  def component = params.component ?: null
 
   MetricsPublisher metricsPublisher = new MetricsPublisher(this, currentBuild, product, "", subscription )
   approvedEnvironmentRepository(environment, metricsPublisher) {
     withSubscription(subscription) {
       // build environment infrastructure once
-      tfOutput = spinInfra(product, null, environment, planOnly, subscription)
+      tfOutput = spinInfra(product, component, environment, planOnly, subscription)
     }
   }
 }

--- a/vars/withInfraPipeline.groovy
+++ b/vars/withInfraPipeline.groovy
@@ -7,7 +7,7 @@ import uk.gov.hmcts.contino.Subscription
 import uk.gov.hmcts.contino.Environment
 import uk.gov.hmcts.pipeline.TeamConfig
 
-def call(String product, String component = "", Closure body) {
+def call(String product, String component = null, Closure body) {
 
   Subscription subscription = new Subscription(env)
   Environment environment = new Environment(env)

--- a/vars/withInfraPipeline.groovy
+++ b/vars/withInfraPipeline.groovy
@@ -7,7 +7,7 @@ import uk.gov.hmcts.contino.Subscription
 import uk.gov.hmcts.contino.Environment
 import uk.gov.hmcts.pipeline.TeamConfig
 
-def call(String product, Closure body) {
+def call(String product, String component = "", Closure body) {
 
   Subscription subscription = new Subscription(env)
   Environment environment = new Environment(env)


### PR DESCRIPTION
Add the optional parameter component to infrastructure pipelines.
When having more then one pipeline that only deploys infrastructure they clash as they use the same state file using the product name. This will give the option to pass in the component name, which is used in the state file location name.