### PR TITLE
Fix pending/failed builds not being deleted if a previous one deployed

### DIFF
--- a/src/uk/gov/hmcts/contino/Helm.groovy
+++ b/src/uk/gov/hmcts/contino/Helm.groovy
@@ -130,7 +130,7 @@ class Helm {
     this.execute("history", "${this.chartName}-${imageTag}", null, ["--namespace ${namespace}", "-o json", this.tlsOptions])
   }
 
-  def hasAnyNonDeployed(String imageTag, String namespace) {
+  def hasAnyFailedToDeploy(String imageTag, String namespace) {
     if (!exists(imageTag, namespace)) {
       this.steps.echo "No release deployed for: $imageTag in namespace $namespace"
       return false

--- a/src/uk/gov/hmcts/contino/Helm.groovy
+++ b/src/uk/gov/hmcts/contino/Helm.groovy
@@ -130,14 +130,16 @@ class Helm {
     this.execute("history", "${this.chartName}-${imageTag}", null, ["--namespace ${namespace}", "-o json", this.tlsOptions])
   }
 
-  def hasAnyDeployed(String imageTag, String namespace) {
+  def hasAnyNonDeployed(String imageTag, String namespace) {
     if (!exists(imageTag, namespace)) {
       this.steps.echo "No release deployed for: $imageTag in namespace $namespace"
       return false
     }
     def releases = this.history(imageTag, namespace)
     this.steps.echo releases
-    return !releases || new JsonSlurper().parseText(releases).any { it.status?.toLowerCase() == "deployed" }
+    return !releases || new JsonSlurper().parseText(releases).any { it.status?.toLowerCase() == "failed" ||
+                                                                    it.status?.toLowerCase() == "pending-upgrade" ||
+                                                                    it.status?.toLowerCase() == "pending-install" }
   }
 
   private Object execute(String command, String name) {

--- a/vars/helmInstall.groovy
+++ b/vars/helmInstall.groovy
@@ -118,7 +118,7 @@ def call(DockerImage dockerImage, Map params) {
       }
     }
 
-    // Delete Helm Release if a previous release failed/is pending
+    // // Helm throws error if trying to upgrade when there have only been failed deployments, or if the previous one is in a 'pending' status
     def deleted = false
     if (helm.hasAnyFailedToDeploy(dockerImage.getImageTag(), namespace)) {
 

--- a/vars/helmInstall.groovy
+++ b/vars/helmInstall.groovy
@@ -118,14 +118,13 @@ def call(DockerImage dockerImage, Map params) {
       }
     }
 
-    // Helm throws error if trying to upgrade , when there have only been failed deployments
+    // Helm throws error if trying to upgrade, when there have only been failed deployments
     def deleted = false
-    if (helm.exists(dockerImage.getImageTag(), namespace) &&
-      !helm.hasAnyDeployed(dockerImage.getImageTag(), namespace)) {
+    if (helm.hasAnyNonDeployed(dockerImage.getImageTag(), namespace)) {
 
       deleted = true
       helm.delete(dockerImage.getImageTag(), namespace)
-      echo "Deleted release for ${dockerImage.getImageTag()} as previous release was not 'deployed'"
+      echo "Deleted release for ${dockerImage.getImageTag()} as previous release was not 'deployed' successfully"
     } else {
       echo "Skipping delete for ${dockerImage.getImageTag()} as it doesn't exist or the last version was deployed successfully"
     }

--- a/vars/helmInstall.groovy
+++ b/vars/helmInstall.groovy
@@ -118,9 +118,9 @@ def call(DockerImage dockerImage, Map params) {
       }
     }
 
-    // Helm throws error if trying to upgrade, when there have only been failed deployments
+    // Delete Helm Release if a previous release failed/is pending
     def deleted = false
-    if (helm.hasAnyNonDeployed(dockerImage.getImageTag(), namespace)) {
+    if (helm.hasAnyFailedToDeploy(dockerImage.getImageTag(), namespace)) {
 
       deleted = true
       helm.delete(dockerImage.getImageTag(), namespace)


### PR DESCRIPTION
I've testing with plum frontend (plum pr with this, then add broken part to plum pr, see if it deletes after that)
https://github.com/hmcts/cnp-plum-frontend/pull/117/files - deployed successful builds, then added an issue (secret that didn't exist in keyvault), which created an upgrade-pending release, then reverted back and ran the corrected build again - which now deletes upgrade-pending builds.
DTSPO-2783

Previous logic - new JsonSlurper().parseText(releases).any { it.status?.toLowerCase() == "deployed"
This meant that if `any` previous release had deployed, any currently pending-upgrade releases wouldn't be deleted causing builds to be stuck for teams - and needing platform ops intervention for staging.

Also refactored by removing a repeated "if exists"

