### PR TITLE
Actually record junit results for yarn projects

### DIFF
--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -44,7 +44,7 @@ class YarnBuilder extends AbstractBuilder {
     try {
       yarn("test:smoke")
     } finally {
-      steps.junit allowEmptyResults: true, testResults: './smoke-output/**/*result.xml'
+      steps.junit allowEmptyResults: true, testResults: 'smoke-output/**/*result.xml'
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'smoke-output/**'
     }
   }
@@ -53,7 +53,7 @@ class YarnBuilder extends AbstractBuilder {
     try {
       yarn("test:functional")
     } finally {
-      steps.junit allowEmptyResults: true, testResults: './functional-output/**/*result.xml'
+      steps.junit allowEmptyResults: true, testResults: 'functional-output/**/*result.xml'
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**'
     }
   }
@@ -62,7 +62,7 @@ class YarnBuilder extends AbstractBuilder {
     try {
       yarn("test:apiGateway")
     } finally {
-      steps.junit allowEmptyResults: true, testResults: './api-output/*result.xml'
+      steps.junit allowEmptyResults: true, testResults: 'api-output/*result.xml'
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'api-output/*'
     }
   }
@@ -96,7 +96,7 @@ class YarnBuilder extends AbstractBuilder {
       yarn("test:fullfunctional")
     }
     finally {
-      steps.junit allowEmptyResults: true, testResults: './functional-output/**/*result.xml'
+      steps.junit allowEmptyResults: true, testResults: 'functional-output/**/*result.xml'
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**'
     }
   }


### PR DESCRIPTION
Tested locally with @louisehuyton, with `./` it doesn't work.
I assume this has never worked...
