### PR TITLE
DTSPO-6559 - Remove appInsightsInstrumentationKey env variable

### DIFF
--- a/src/uk/gov/hmcts/contino/azure/ProductVaultEntries.groovy
+++ b/src/uk/gov/hmcts/contino/azure/ProductVaultEntries.groovy
@@ -1,7 +1,0 @@
-package uk.gov.hmcts.contino.azure
-
-class ProductVaultEntries {
-
-  static APP_INSIGHTS_INSTRUMENTATION_KEY = 'AppInsightsInstrumentationKey'
-
-}

--- a/vars/collectAdditionalInfrastructureVariablesFor.groovy
+++ b/vars/collectAdditionalInfrastructureVariablesFor.groovy
@@ -6,10 +6,5 @@ def call(subscription, product, environment) {
   KeyVault keyVault = new KeyVault(this, subscription, "${product}-${environment}")
   def environmentVariables = []
 
-  def appInsightsInstrumentationKey = keyVault.find(ProductVaultEntries.APP_INSIGHTS_INSTRUMENTATION_KEY)
-  if (appInsightsInstrumentationKey) {
-    environmentVariables.add("TF_VAR_appinsights_instrumentation_key=${appInsightsInstrumentationKey}")
-  }
-
   return environmentVariables
 }

--- a/vars/collectAdditionalInfrastructureVariablesFor.groovy
+++ b/vars/collectAdditionalInfrastructureVariablesFor.groovy
@@ -1,6 +1,5 @@
 #!groovy
 import uk.gov.hmcts.contino.azure.KeyVault
-import uk.gov.hmcts.contino.azure.ProductVaultEntries
 
 def call(subscription, product, environment) {
   KeyVault keyVault = new KeyVault(this, subscription, "${product}-${environment}")

--- a/vars/collectAdditionalInfrastructureVariablesFor.groovy
+++ b/vars/collectAdditionalInfrastructureVariablesFor.groovy
@@ -1,9 +1,0 @@
-#!groovy
-import uk.gov.hmcts.contino.azure.KeyVault
-
-def call(subscription, product, environment) {
-  KeyVault keyVault = new KeyVault(this, subscription, "${product}-${environment}")
-  def environmentVariables = []
-
-  return environmentVariables
-}

--- a/vars/sectionDeployToEnvironment.groovy
+++ b/vars/sectionDeployToEnvironment.groovy
@@ -33,7 +33,6 @@ def call(params) {
 
           withSubscription(subscription) {
             dir('infrastructure') {
-              {
                 sectionInfraBuild(
                   subscription: subscription,
                   environment: environment,
@@ -42,7 +41,6 @@ def call(params) {
                   pipelineCallbacksRunner: pcr,
                   planOnly: tfPlanOnly,
                 )
-              }
             }
 
             if(!tfPlanOnly){

--- a/vars/sectionDeployToEnvironment.groovy
+++ b/vars/sectionDeployToEnvironment.groovy
@@ -32,7 +32,18 @@ def call(params) {
           }
 
           withSubscription(subscription) {
-            dir('infrastructure') {}
+            dir('infrastructure') {
+              {
+                sectionInfraBuild(
+                  subscription: subscription,
+                  environment: environment,
+                  product: product,
+                  component: component,
+                  pipelineCallbacksRunner: pcr,
+                  planOnly: tfPlanOnly,
+                )
+              }
+            }
 
             if(!tfPlanOnly){
 

--- a/vars/sectionDeployToEnvironment.groovy
+++ b/vars/sectionDeployToEnvironment.groovy
@@ -32,19 +32,7 @@ def call(params) {
           }
 
           withSubscription(subscription) {
-            dir('infrastructure') {
-              def additionalInfrastructureVariables = collectAdditionalInfrastructureVariablesFor(subscription, product, environment)
-              withEnv(additionalInfrastructureVariables) {
-                sectionInfraBuild(
-                  subscription: subscription,
-                  environment: environment,
-                  product: product,
-                  component: component,
-                  pipelineCallbacksRunner: pcr,
-                  planOnly: tfPlanOnly,
-                )
-              }
-            }
+            dir('infrastructure') {}
 
             if(!tfPlanOnly){
 

--- a/vars/sharedInfrastructurePipeline.groovy
+++ b/vars/sharedInfrastructurePipeline.groovy
@@ -1,5 +1,4 @@
 import uk.gov.hmcts.contino.azure.KeyVault
-import uk.gov.hmcts.contino.azure.ProductVaultEntries
 
 @Deprecated
 def call(String product, String environment, String subscription) {


### PR DESCRIPTION
Remove app insights instrumentation key from environment variables

Development teams should use azure keyvault data resources instead