### PR TITLE
added dependencies on blobstorage & servicebus versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
   implementation 'com.microsoft.azure:azure-documentdb:1.16.4'
 
   testImplementation group: 'org.spockframework', name: 'spock-core', version: '2.1-groovy-2.5'
-  testImplementation group: 'com.lesfurets', name: 'jenkins-pipeline-unit', version: '1.1'
+  testImplementation group: 'com.lesfurets', name: 'jenkins-pipeline-unit', version: '1.14'
   testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.23.1'
   testImplementation group: 'net.javacrumbs.json-unit', name: 'json-unit-fluent', version: '2.35.0'
 

--- a/resources/uk/gov/hmcts/helm/check-deprecated-charts.sh
+++ b/resources/uk/gov/hmcts/helm/check-deprecated-charts.sh
@@ -5,8 +5,8 @@ CHART_DIRECTORY=${1}-${2}
 MIN_JAVA_VERSION="3.7.2"
 MIN_NODEJS_VERSION="2.4.1"
 MIN_JOB_VERSION="0.7.3"
-MIN_BLOBSTORAGE_VERSION="0.2.2"
-MIN_SERVICEBUS_VERSION="0.3.3"
+MIN_BLOBSTORAGE_VERSION="0.3.0"
+MIN_SERVICEBUS_VERSION="0.4.0"
 
 JAVA_VERSION=$(helm dependency ls charts/${CHART_DIRECTORY}/ | grep "java" |awk '{ print $2}' | sed "s/~//g")
 NODEJS_VERSION=$(helm dependency ls charts/${CHART_DIRECTORY}/ | grep "nodejs" |awk '{ print $2}' | sed "s/~//g")

--- a/resources/uk/gov/hmcts/helm/check-deprecated-charts.sh
+++ b/resources/uk/gov/hmcts/helm/check-deprecated-charts.sh
@@ -5,10 +5,14 @@ CHART_DIRECTORY=${1}-${2}
 MIN_JAVA_VERSION="3.7.2"
 MIN_NODEJS_VERSION="2.4.1"
 MIN_JOB_VERSION="0.7.3"
+MIN_BLOBSTORAGE_VERSION="0.2.2"
+MIN_SERVICEBUS_VERSION="0.3.3"
 
 JAVA_VERSION=$(helm dependency ls charts/${CHART_DIRECTORY}/ | grep "java" |awk '{ print $2}' | sed "s/~//g")
 NODEJS_VERSION=$(helm dependency ls charts/${CHART_DIRECTORY}/ | grep "nodejs" |awk '{ print $2}' | sed "s/~//g")
 JOB_VERSION=$(helm dependency ls charts/${CHART_DIRECTORY}/ | grep "job" |awk '{ print $2}' | sed "s/~//g")
+BLOBSTORAGE_VERSION=$(helm dependency ls charts/${CHART_DIRECTORY}/ | grep "blobstorage" |awk '{ print $2}' | sed "s/~//g")
+SERVICEBUS_VERSION=$(helm dependency ls charts/${CHART_DIRECTORY}/ | grep "servicebus" |awk '{ print $2}' | sed "s/~//g")
 
 if [[ -n $JAVA_VERSION ]] &&  [[ $JAVA_VERSION < $MIN_JAVA_VERSION ]]; then
     echo "Java chart version $JAVA_VERSION is deprecated, please upgrade"
@@ -22,5 +26,15 @@ fi
 
 if [[ -n $JOB_VERSION ]] && [[ $JOB_VERSION < $MIN_JOB_VERSION ]]; then
     echo "Job chart version $MIN_JOB_VERSION is deprecated, please upgrade"
+    exit 1
+fi
+
+if [[ -n $BLOBSTORAGE_VERSION ]] && [[ $BLOBSTORAGE_VERSION < $MIN_BLOBSTORAGE_VERSION ]]; then
+    echo "Job chart version $BLOBSTORAGE_VERSION is deprecated, please upgrade"
+    exit 1
+fi
+
+if [[ -n $STORAGEBUS_VERSION ]] && [[ $STORAGEBUS_VERSION < $MIN_STORAGEBUS_VERSION ]]; then
+    echo "Job chart version $MIN_STORAGEBUS_VERSION is deprecated, please upgrade"
     exit 1
 fi

--- a/resources/uk/gov/hmcts/helm/check-deprecated-charts.sh
+++ b/resources/uk/gov/hmcts/helm/check-deprecated-charts.sh
@@ -34,7 +34,7 @@ if [[ -n $BLOBSTORAGE_VERSION ]] && [[ $BLOBSTORAGE_VERSION < $MIN_BLOBSTORAGE_V
     exit 1
 fi
 
-if [[ -n $STORAGEBUS_VERSION ]] && [[ $STORAGEBUS_VERSION < $MIN_STORAGEBUS_VERSION ]]; then
-    echo "Job chart version $MIN_STORAGEBUS_VERSION is deprecated, please upgrade"
+if [[ -n $SERVICEBUS_VERSION ]] && [[ $SERVICEBUS_VERSION < $MIN_SERVICEBUS_VERSION ]]; then
+    echo "Job chart version $MIN_SERVICEBUS_VERSION is deprecated, please upgrade"
     exit 1
 fi

--- a/vars/warnAboutDeprecatedChartConfig.groovy
+++ b/vars/warnAboutDeprecatedChartConfig.groovy
@@ -23,7 +23,7 @@ def call(Map<String, String> params) {
     ./check-deprecated-charts.sh $product $component
     """
   } catch(ignored) {
-    WarningCollector.addPipelineWarning("deprecated_helmcharts", "Please upgrade base helm charts to latest. See https://github.com/hmcts/chart-java/releases, https://github.com/hmcts/chart-nodejs/releases, https://github.com/hmcts/chart-job/releases ", new Date().parse("dd.MM.yyyy", "14.03.2022"))
+    WarningCollector.addPipelineWarning("deprecated_helmcharts", "Please upgrade base helm charts to latest. See https://github.com/hmcts/chart-java/releases, https://github.com/hmcts/chart-nodejs/releases, https://github.com/hmcts/chart-job/releases, https://github.com/hmcts/chart-blobstorage/releases, https://github.com/hmcts/chart-servicebus/releases ", new Date().parse("dd.MM.yyyy", "21.06.2022"))
   } finally {
     sh 'rm -f check-deprecated-charts.sh'
   }

--- a/vars/warnAboutDeprecatedChartConfig.groovy
+++ b/vars/warnAboutDeprecatedChartConfig.groovy
@@ -23,7 +23,7 @@ def call(Map<String, String> params) {
     ./check-deprecated-charts.sh $product $component
     """
   } catch(ignored) {
-    WarningCollector.addPipelineWarning("deprecated_helmcharts", "Please upgrade base helm charts to latest. See https://github.com/hmcts/chart-java/releases, https://github.com/hmcts/chart-nodejs/releases, https://github.com/hmcts/chart-job/releases, https://github.com/hmcts/chart-blobstorage/releases, https://github.com/hmcts/chart-servicebus/releases ", new Date().parse("dd.MM.yyyy", "24.06.2022"))
+    WarningCollector.addPipelineWarning("deprecated_helmcharts", "Please upgrade base helm charts to latest. See https://github.com/hmcts/chart-java/releases, https://github.com/hmcts/chart-nodejs/releases, https://github.com/hmcts/chart-job/releases, https://github.com/hmcts/chart-blobstorage/releases, https://github.com/hmcts/chart-servicebus/releases ", new Date().parse("dd.MM.yyyy", "08.07.2022"))
   } finally {
     sh 'rm -f check-deprecated-charts.sh'
   }

--- a/vars/warnAboutDeprecatedChartConfig.groovy
+++ b/vars/warnAboutDeprecatedChartConfig.groovy
@@ -23,7 +23,7 @@ def call(Map<String, String> params) {
     ./check-deprecated-charts.sh $product $component
     """
   } catch(ignored) {
-    WarningCollector.addPipelineWarning("deprecated_helmcharts", "Please upgrade base helm charts to latest. See https://github.com/hmcts/chart-java/releases, https://github.com/hmcts/chart-nodejs/releases, https://github.com/hmcts/chart-job/releases, https://github.com/hmcts/chart-blobstorage/releases, https://github.com/hmcts/chart-servicebus/releases ", new Date().parse("dd.MM.yyyy", "21.06.2022"))
+    WarningCollector.addPipelineWarning("deprecated_helmcharts", "Please upgrade base helm charts to latest. See https://github.com/hmcts/chart-java/releases, https://github.com/hmcts/chart-nodejs/releases, https://github.com/hmcts/chart-job/releases, https://github.com/hmcts/chart-blobstorage/releases, https://github.com/hmcts/chart-servicebus/releases ", new Date().parse("dd.MM.yyyy", "24.06.2022"))
   } finally {
     sh 'rm -f check-deprecated-charts.sh'
   }


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

As part of https://tools.hmcts.net/jira/browse/DTSPO-7852 the servicebus and blobstorage charts have been updated to include tags. As a result, anyone who uses those charts needs to update their code to use the latest versions.

Notes:
*
*
*
