### PR TITLE
Cache results of getLabels() to reduce API calls

### DIFF
--- a/src/uk/gov/hmcts/contino/GithubAPI.groovy
+++ b/src/uk/gov/hmcts/contino/GithubAPI.groovy
@@ -150,15 +150,22 @@ class GithubAPI {
   }
 
   /**
+   * Check for Pull Request
+   */
+  private isPR(String branch_name) {
+    def isPr = new ProjectBranch(branch_name).isPR()
+    this.steps.echo "Is ${branch_name} a PR?: ${isPr}"
+    return isPr
+  }
+
+  /**
    * Check Pull Request for label by a pattern in name.
    */
   def getLabelsbyPattern(String branch_name, String key) {
     this.steps.echo "Getting Labels for Branch: ${branch_name} by Pattern: ${key}"
-    def isPR = new ProjectBranch(branch_name).isPR()
-    this.steps.echo "Is this a PR?: ${isPR}"
-    if (isPR) {
+    if (isPR(branch_name)) {
       this.steps.echo "PR Confirmed.  Calling getLabels()."
-      def foundLabels = getLabels().findAll{it.contains(key)}
+      def foundLabels = getLabels(branch_name).findAll{it.contains(key)}
       this.steps.echo "Returning Labels: ${foundLabels}"
       return foundLabels
     } else {
@@ -180,9 +187,15 @@ class GithubAPI {
   /**
    * Get all labels from an issue or pull request
    */
-  def getLabels() {
-    this.steps.echo "Getting All Labels.  Calling getLabelsFromCache()."
-    return this.getLabelsFromCache()
+  def getLabels(String branch_name) {
+    this.steps.echo "Getting All Labels for ${branch_name}."
+    if (isPR(branch_name)) {
+      this.steps.echo "PR Confirmed.  Calling getLabelsFromCache()."
+      return this.getLabelsFromCache()
+    } else {
+      this.steps.echo "Negative PR.  Returning Empty List."
+      return []
+    }
   }
 
   def currentProject() {

--- a/src/uk/gov/hmcts/contino/GithubAPI.groovy
+++ b/src/uk/gov/hmcts/contino/GithubAPI.groovy
@@ -195,15 +195,9 @@ class GithubAPI {
    */
   def getLabelsbyPattern(String branch_name, String key) {
     this.steps.echo "Getting Labels for Branch: ${branch_name} by Pattern: ${key}"
-    if (isPR(branch_name)) {
-      this.steps.echo "PR Confirmed.  Calling getLabels()."
-      def foundLabels = getLabels(branch_name).findAll{it.contains(key)}
-      this.steps.echo "Returning Labels: ${foundLabels}"
-      return foundLabels
-    } else {
-      this.steps.echo "Negative PR.  Returning Empty List."
-      return []
-    }
+    def foundLabels = getLabels(branch_name).findAll{it.contains(key)}
+    this.steps.echo "Returning Labels: ${foundLabels}"
+    return foundLabels
   }
 
   /**

--- a/src/uk/gov/hmcts/contino/GithubAPI.groovy
+++ b/src/uk/gov/hmcts/contino/GithubAPI.groovy
@@ -62,6 +62,7 @@ class GithubAPI {
       if (this.cachedLabelList.isValid) {
         this.steps.echo "Cache is Valid.  Adding new labels to cache."
         this.cachedLabelList.cache.addAll(labels)
+        this.cachedLabelList.cache.unique()
         this.steps.echo "Updated Cache Contents: ${this.cachedLabelList.cache}"
       } else {
         this.steps.echo "Cache is Invalid.  Refreshing Cache."

--- a/src/uk/gov/hmcts/contino/GithubAPI.groovy
+++ b/src/uk/gov/hmcts/contino/GithubAPI.groovy
@@ -85,6 +85,20 @@ class GithubAPI {
   }
 
   /**
+   * Return whether the cache is valid
+   */
+  def isCacheValid() {
+    return this.cachedLabelList.isValid
+  }
+
+  /**
+   * Return whether the chache is empty
+   */
+  def isCacheEmpty() {
+    return this.cachedLabelList.cache.isEmpty()
+  }
+
+  /**
    * Refreshes this.cachedLabelList
    */
   def refreshLabelCache() {

--- a/src/uk/gov/hmcts/contino/GithubAPI.groovy
+++ b/src/uk/gov/hmcts/contino/GithubAPI.groovy
@@ -99,6 +99,13 @@ class GithubAPI {
   }
 
   /**
+   * Return cache contents as list
+   */
+  def getCache() {
+    return this.cachedLabelList.cache
+  }
+
+  /**
    * Refreshes this.cachedLabelList
    */
   def refreshLabelCache() {

--- a/src/uk/gov/hmcts/contino/GithubAPI.groovy
+++ b/src/uk/gov/hmcts/contino/GithubAPI.groovy
@@ -38,22 +38,22 @@ class GithubAPI {
   /**
    * Return whether the cache is valid
    */
-  def isCacheValid() {
-    return this.cachedLabelList.isValid
+  def static isCacheValid() {
+    return cachedLabelList.isValid
   }
 
   /**
-   * Return whether the chache is empty
+   * Return whether the cache is empty
    */
-  def isCacheEmpty() {
-    return this.cachedLabelList.cache.isEmpty()
+  def static isCacheEmpty() {
+    return cachedLabelList.cache.isEmpty()
   }
 
   /**
    * Return cache contents as list
    */
-  def getCache() {
-    return this.cachedLabelList.cache
+  def static getCache() {
+    return cachedLabelList.cache
   }
 
   /**
@@ -61,8 +61,8 @@ class GithubAPI {
    */
   void clearLabelCache() {
     this.steps.echo "Clearing Label Cache."
-    this.cachedLabelList.cache = []
-    this.cachedLabelList.isValid = false
+    cachedLabelList.cache = []
+    cachedLabelList.isValid = false
     this.steps.echo "Cleared Cache Contents: ${getCache()}"
     this.steps.echo "Cleared Cache Valid?: ${isCacheValid()}"
   }
@@ -87,8 +87,8 @@ class GithubAPI {
     if (response.status == 200) {
       this.steps.echo "Response Ok."
       def json_response = new JsonSlurper().parseText(response.content)
-      this.cachedLabelList.cache = json_response.collect({ label -> label['name'] })
-      this.cachedLabelList.isValid = true
+      cachedLabelList.cache = json_response.collect({ label -> label['name'] })
+      cachedLabelList.isValid = true
       this.steps.echo "Cache Contents: ${getCache()}"
       this.steps.echo "Cache Valid?: ${isCacheValid()}"
     } else {
@@ -128,8 +128,8 @@ class GithubAPI {
       this.steps.echo "Response Ok."
       if (isCacheValid()) {
         this.steps.echo "Cache is Valid.  Adding new labels to cache."
-        this.cachedLabelList.cache.addAll(labels)
-        this.cachedLabelList.cache.unique()
+        cachedLabelList.cache.addAll(labels)
+        cachedLabelList.cache.unique()
         this.steps.echo "Updated Cache Contents: ${getCache()}"
       } else {
         this.steps.echo "Cache is Invalid.  Refreshing Cache."

--- a/src/uk/gov/hmcts/contino/GithubAPI.groovy
+++ b/src/uk/gov/hmcts/contino/GithubAPI.groovy
@@ -55,9 +55,9 @@ class GithubAPI {
       consoleLogResponseBody: true,
       validResponseCodes: '200')
 
-    this.steps.echo "Response Status Code: ${response.status}"
+    this.steps.echo "Response Status Code: ${response.getStatus()}"
 
-    if (response.status == 200) {
+    if (response.getStatus() == 200) {
       this.steps.echo "Response Ok."
       if (this.cachedLabelList.isValid) {
         this.steps.echo "Cache is Valid.  Adding new labels to cache."
@@ -69,7 +69,7 @@ class GithubAPI {
         this.refreshLabelCache()
       }
     } else {
-      this.steps.echo "Failed to Add Labels.  Server returned ${response.status} response."
+      this.steps.echo "Failed to Add Labels.  Server returned ${response.getStatus()} response."
     }
   }
 

--- a/src/uk/gov/hmcts/contino/GithubAPI.groovy
+++ b/src/uk/gov/hmcts/contino/GithubAPI.groovy
@@ -55,9 +55,9 @@ class GithubAPI {
       consoleLogResponseBody: true,
       validResponseCodes: '200')
 
-    this.steps.echo "Response Status Code: ${response.getStatus()}"
+    this.steps.echo "Response Status Code: ${response.status}"
 
-    if (response.getStatus() == 200) {
+    if (response.status == 200) {
       this.steps.echo "Response Ok."
       if (this.cachedLabelList.isValid) {
         this.steps.echo "Cache is Valid.  Adding new labels to cache."
@@ -69,7 +69,7 @@ class GithubAPI {
         this.refreshLabelCache()
       }
     } else {
-      this.steps.echo "Failed to Add Labels.  Server returned ${response.getStatus()} response."
+      this.steps.echo "Failed to Add Labels.  Server returned ${response.status} response."
     }
   }
 

--- a/src/uk/gov/hmcts/contino/GithubAPI.groovy
+++ b/src/uk/gov/hmcts/contino/GithubAPI.groovy
@@ -50,7 +50,7 @@ class GithubAPI {
       authentication: this.steps.env.GIT_CREDENTIALS_ID,
       acceptType: 'APPLICATION_JSON',
       contentType: 'APPLICATION_JSON',
-      url: "${API_URL}/${project}/issues/${issueNumber}/labels",
+      url: API_URL + "/${project}/issues/${issueNumber}/labels",
       requestBody: "${body}",
       consoleLogResponseBody: true,
       validResponseCodes: '200')
@@ -95,7 +95,7 @@ class GithubAPI {
       authentication: this.steps.env.GIT_CREDENTIALS_ID,
       acceptType: 'APPLICATION_JSON',
       contentType: 'APPLICATION_JSON',
-      url: "${API_URL}/${project}/issues/${issueNumber}/labels",
+      url: API_URL + "/${project}/issues/${issueNumber}/labels",
       consoleLogResponseBody: true,
       validResponseCodes: '200')
 

--- a/src/uk/gov/hmcts/contino/GithubAPI.groovy
+++ b/src/uk/gov/hmcts/contino/GithubAPI.groovy
@@ -207,11 +207,21 @@ class GithubAPI {
   }
 
   /**
+   * Check Pull Request for specified label.
+   */
+  def checkForLabel(String branch_name, String key) {
+    this.steps.echo "Checking ${branch_name} Labels for: ${key}"
+    def labelExists = getLabels(branch_name).contains(key)
+    this.steps.echo "Found ${key} Label?: ${labelExists}"
+    return labelExists
+  }
+
+  /**
    * Check Pull Request for dependencies label.
    */
   def checkForDependenciesLabel(branch_name) {
-    this.steps.echo "Checking for Dependencies Label by calling getLabelsbyPattern()."
-    def depLabel = getLabelsbyPattern(branch_name, "dependencies").contains("dependencies")
+    this.steps.echo "Checking for Dependencies Label by calling checkForLabel()."
+    def depLabel = checkForLabel(branch_name, "dependencies")
     this.steps.echo "Found Dependencies Label?: ${depLabel}"
     return depLabel
   }

--- a/src/uk/gov/hmcts/contino/GithubAPI.groovy
+++ b/src/uk/gov/hmcts/contino/GithubAPI.groovy
@@ -82,12 +82,20 @@ class GithubAPI {
       consoleLogResponseBody: true,
       validResponseCodes: '200')
 
-    def json_response = new JsonSlurper().parseText(response.content)
-    this.cachedLabelList.cache = json_response.collect( { label -> label['name'] } )
-    this.cachedLabelList.isValid = true
-    this.steps.echo "Cache Contents: ${this.cachedLabelList.cache}"
-    this.steps.echo "Cache Valid?: ${this.cachedLabelList.isValid}"
-    return this.cachedLabelList.cache
+    this.steps.echo "Response Status Code: ${response.status}"
+
+    if (response.status == 200) {
+      this.steps.echo "Response Ok."
+      def json_response = new JsonSlurper().parseText(response.content)
+      this.cachedLabelList.cache = json_response.collect({ label -> label['name'] })
+      this.cachedLabelList.isValid = true
+      this.steps.echo "Cache Contents: ${this.cachedLabelList.cache}"
+      this.steps.echo "Cache Valid?: ${this.cachedLabelList.isValid}"
+      return this.cachedLabelList.cache
+    } else {
+      this.steps.echo "Failed to Update cache.  Server returned ${response.status} response."
+      return this.cachedLabelList.cache
+    }
   }
 
   /**

--- a/src/uk/gov/hmcts/contino/GithubAPI.groovy
+++ b/src/uk/gov/hmcts/contino/GithubAPI.groovy
@@ -129,20 +129,13 @@ class GithubAPI {
   }
 
   /**
-   * Check if we are working with a PR
-   */
-  def checkPR(String branch_name) {
-    def isPR = new ProjectBranch(branch_name).isPR()
-    this.steps.echo "Is ${branch_name} a PR?: ${isPR}"
-    return isPR
-  }
-
-  /**
    * Check Pull Request for label by a pattern in name.
    */
   def getLabelsbyPattern(String branch_name, String key) {
     this.steps.echo "Getting Labels for Branch: ${branch_name} by Pattern: ${key}"
-    if (checkPR(branch_name)) {
+    def isPR = new ProjectBranch(branch_name).isPR()
+    this.steps.echo "Is this a PR?: ${isPR}"
+    if (isPR) {
       this.steps.echo "PR Confirmed.  Calling getLabels()."
       def foundLabels = getLabels().findAll{it.contains(key)}
       this.steps.echo "Returning Labels: ${foundLabels}"

--- a/src/uk/gov/hmcts/contino/GithubAPI.groovy
+++ b/src/uk/gov/hmcts/contino/GithubAPI.groovy
@@ -76,7 +76,7 @@ class GithubAPI {
   /**
    * Clears this.cachedLabelList
    */
-  private void clearLabelCache() {
+  void clearLabelCache() {
     this.steps.echo "Clearing Label Cache."
     this.cachedLabelList.cache = []
     this.cachedLabelList.isValid = false

--- a/src/uk/gov/hmcts/contino/GithubAPI.groovy
+++ b/src/uk/gov/hmcts/contino/GithubAPI.groovy
@@ -63,8 +63,8 @@ class GithubAPI {
     this.steps.echo "Clearing Label Cache."
     this.cachedLabelList.cache = []
     this.cachedLabelList.isValid = false
-    this.steps.echo "Cleared Cache Contents: ${this.cachedLabelList.cache}"
-    this.steps.echo "Cleared Cache Valid?: ${this.cachedLabelList.isValid}"
+    this.steps.echo "Cleared Cache Contents: ${getCache()}"
+    this.steps.echo "Cleared Cache Valid?: ${isCacheValid()}"
   }
 
   /**
@@ -89,13 +89,13 @@ class GithubAPI {
       def json_response = new JsonSlurper().parseText(response.content)
       this.cachedLabelList.cache = json_response.collect({ label -> label['name'] })
       this.cachedLabelList.isValid = true
-      this.steps.echo "Cache Contents: ${this.cachedLabelList.cache}"
-      this.steps.echo "Cache Valid?: ${this.cachedLabelList.isValid}"
-      return this.cachedLabelList.cache
+      this.steps.echo "Cache Contents: ${getCache()}"
+      this.steps.echo "Cache Valid?: ${isCacheValid()}"
     } else {
       this.steps.echo "Failed to Update cache.  Server returned ${response.status} response."
-      return this.cachedLabelList.cache
     }
+
+    return getCache()
   }
 
   /**
@@ -126,11 +126,11 @@ class GithubAPI {
 
     if (response.status == 200) {
       this.steps.echo "Response Ok."
-      if (this.cachedLabelList.isValid) {
+      if (isCacheValid()) {
         this.steps.echo "Cache is Valid.  Adding new labels to cache."
         this.cachedLabelList.cache.addAll(labels)
         this.cachedLabelList.cache.unique()
-        this.steps.echo "Updated Cache Contents: ${this.cachedLabelList.cache}"
+        this.steps.echo "Updated Cache Contents: ${getCache()}"
       } else {
         this.steps.echo "Cache is Invalid.  Refreshing Cache."
         return this.refreshLabelCache()
@@ -138,7 +138,8 @@ class GithubAPI {
     } else {
       this.steps.echo "Failed to Add Labels.  Server returned ${response.status} response."
     }
-    return this.cachedLabelList.cache
+
+    return getCache()
   }
 
   /**
@@ -159,20 +160,20 @@ class GithubAPI {
    */
   private getLabelsFromCache() {
     this.steps.echo "Getting Labels From Cache"
-    this.steps.echo "Cache Valid?: ${this.cachedLabelList.isValid}"
-    if (!this.cachedLabelList.isValid) {
+    this.steps.echo "Cache Valid?: ${isCacheValid()}"
+    if (!isCacheValid()) {
       this.steps.echo "Cache Invalid.  Calling Refresh."
       return refreshLabelCache()
     }
 
-    this.steps.echo "Cache Empty?: ${this.cachedLabelList.cache.isEmpty()}"
-    if (this.cachedLabelList.cache.isEmpty() && this.cachedLabelList.isValid) {
+    this.steps.echo "Cache Empty?: ${isCacheEmpty()}"
+    if (isCacheEmpty() && isCacheValid()) {
       this.steps.echo "Cache is Empty and Valid.  Returning Empty List."
       return []
     }
 
-    this.steps.echo "Cache is Valid.  Returning Cache Content: ${this.cachedLabelList.cache}"
-    return this.cachedLabelList.cache
+    this.steps.echo "Cache is Valid.  Returning Cache Content: ${getCache()}"
+    return getCache()
   }
 
   /**

--- a/src/uk/gov/hmcts/contino/GithubAPI.groovy
+++ b/src/uk/gov/hmcts/contino/GithubAPI.groovy
@@ -129,13 +129,20 @@ class GithubAPI {
   }
 
   /**
+   * Check if we are working with a PR
+   */
+  def checkPR(String branch_name) {
+    def isPR = new ProjectBranch(branch_name).isPR()
+    this.steps.echo "Is ${branch_name} a PR?: ${isPR}"
+    return isPR
+  }
+
+  /**
    * Check Pull Request for label by a pattern in name.
    */
   def getLabelsbyPattern(String branch_name, String key) {
     this.steps.echo "Getting Labels for Branch: ${branch_name} by Pattern: ${key}"
-    def isPR = new ProjectBranch(branch_name).isPR()
-    this.steps.echo "Is this a PR?: ${isPR}"
-    if (isPR) {
+    if (checkPR(branch_name)) {
       this.steps.echo "PR Confirmed.  Calling getLabels()."
       def foundLabels = getLabels().findAll{it.contains(key)}
       this.steps.echo "Returning Labels: ${foundLabels}"

--- a/src/uk/gov/hmcts/contino/GithubAPI.groovy
+++ b/src/uk/gov/hmcts/contino/GithubAPI.groovy
@@ -133,11 +133,12 @@ class GithubAPI {
         this.steps.echo "Updated Cache Contents: ${this.cachedLabelList.cache}"
       } else {
         this.steps.echo "Cache is Invalid.  Refreshing Cache."
-        this.refreshLabelCache()
+        return this.refreshLabelCache()
       }
     } else {
       this.steps.echo "Failed to Add Labels.  Server returned ${response.status} response."
     }
+    return this.cachedLabelList.cache
   }
 
   /**
@@ -150,7 +151,7 @@ class GithubAPI {
     def project = currentProject()
     def pullRequestNumber = currentPullRequestNumber()
     this.steps.echo "Adding Labels to current PR (${project} / ${pullRequestNumber})"
-    addLabels(project, pullRequestNumber, labels)
+    return addLabels(project, pullRequestNumber, labels)
   }
 
   /**

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -62,11 +62,20 @@ class GithubAPITest extends Specification {
         "description": "pr-values:xui",
         "color": "a2eeef",
         "default": false
+      },
+      {
+        "id": 208045947,
+        "node_id": "MDU6TGFiZWwyMDgwNDU5NDc=",
+        "url": "https://api.github.com/repos/hmcts/some-project/labels/dependencies",
+        "name": "dependencies",
+        "description": "dependencies",
+        "color": "a2eeef",
+        "default": false
       }
     ]'''
   ]
 
-  static def prValuesResponseLabels = ["pr-values:ccd", "random", "pr-values:xui"]
+  static def prValuesResponseLabels = ["pr-values:ccd", "random", "pr-values:xui", "dependencies"]
 
   static def invalidResponse = ["status": 500]
 
@@ -245,5 +254,31 @@ class GithubAPITest extends Specification {
       assertThat(prLabelsNotMatching).isEqualTo([])
       assertThat(prLabels).isEqualTo(["pr-values:ccd"])
       assertThat(multiplePRLabels).isEqualTo(["pr-values:ccd","pr-values:xui"])
+  }
+
+  def "checkForLabel"() {
+    given:
+      steps.httpRequest(_) >> prValuesResponse
+
+    when:
+      def masterLabelExists = githubApi.checkForLabel("master", "pr-values")
+      def prLabelExists = githubApi.checkForLabel("PR-123", "pr-values:ccd")
+
+    then:
+      assertThat(masterLabelExists).isFalse()
+      assertThat(prLabelExists).isTrue()
+  }
+
+  def "checkForDependenciesLabel"() {
+    given:
+      steps.httpRequest(_) >> prValuesResponse
+
+    when:
+      def masterLabelExists = githubApi.checkForDependenciesLabel("master")
+      def prLabelExists = githubApi.checkForDependenciesLabel("PR-123")
+
+    then:
+      assertThat(masterLabelExists).isFalse()
+      assertThat(prLabelExists).isTrue()
   }
 }

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -75,9 +75,6 @@ class GithubAPITest extends Specification {
 
     def expectedUrl = 'https://api.github.com/repos/hmcts/some-project/issues/68/labels'
 
-    given:
-      response.getStatus() >> 200
-
     when:
       githubApi.addLabelsToCurrentPR(labels)
 

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -68,13 +68,16 @@ class GithubAPITest extends Specification {
     steps = Mock(JenkinsStepMock.class)
     steps.env >> [CHANGE_URL: "https://github.com/hmcts/some-project/pull/68",
                   CHANGE_ID: "68", GIT_CREDENTIALS_ID:"test-app-id"]
-    steps.httpRequest(_) >> response
     githubApi = new GithubAPI(steps)
   }
 
   def "AddLabelsToCurrentPR"() {
 
     def expectedUrl = 'https://api.github.com/repos/hmcts/some-project/issues/68/labels'
+
+    given:
+      steps.httpRequest(_) >> response
+      response.status >> 200
 
     when:
       githubApi.addLabelsToCurrentPR(labels)

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -83,14 +83,16 @@ class GithubAPITest extends Specification {
       githubApi.addLabelsToCurrentPR(labels)
 
     then:
-      steps.httpRequest({it.get('httpMode').equals('POST') &&
-                             it.get('authentication').equals("test-app-id") &&
-                             it.get('acceptType').equals('APPLICATION_JSON') &&
-                             it.get('contentType').equals('APPLICATION_JSON') &&
-                             it.get('url').equals("${expectedUrl}") &&
-                             it.get('requestBody').equals("${expectedLabels}") &&
-                             it.get('consoleLogResponseBody').equals(true) &&
-                             it.get('validResponseCodes').equals('200')})
+      steps.httpRequest({
+        it.get('httpMode').equals('POST') &&
+        it.get('authentication').equals("test-app-id") &&
+        it.get('acceptType').equals('APPLICATION_JSON') &&
+        it.get('contentType').equals('APPLICATION_JSON') &&
+        it.get('url').equals("${expectedUrl}") &&
+        it.get('requestBody').equals("${expectedLabels}") &&
+        it.get('consoleLogResponseBody').equals(true) &&
+        it.get('validResponseCodes').equals('200')
+      })
   }
 
   def "AddLabels"() {
@@ -104,21 +106,24 @@ class GithubAPITest extends Specification {
       githubApi.addLabels('evilcorp/my-project', '89', labels)
 
     then:
-      steps.httpRequest({it.get('httpMode').equals('POST') &&
+      steps.httpRequest({
+        it.get('httpMode').equals('POST') &&
         it.get('authentication').equals("test-app-id") &&
         it.get('acceptType').equals('APPLICATION_JSON') &&
         it.get('contentType').equals('APPLICATION_JSON') &&
         it.get('url').equals("${expectedUrl}") &&
         it.get('requestBody').equals("${expectedLabels}") &&
         it.get('consoleLogResponseBody').equals(true) &&
-        it.get('validResponseCodes').equals('200')})
+        it.get('validResponseCodes').equals('200')
+      })
   }
 
   // Attempt to check filtering is working on returned labels
 
   def "getLabelsbyPattern"() {
 
-    steps.httpRequest(_) >> prValuesResponse
+    given:
+      steps.httpRequest(_) >> prValuesResponse
 
     when:
       def masterLabels = githubApi.getLabelsbyPattern("master", "pr-values")

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -121,7 +121,6 @@ class GithubAPITest extends Specification {
   // Attempt to check filtering is working on returned labels
 
   def "getLabelsbyPattern"() {
-
     given:
       steps.httpRequest(_) >> prValuesResponse
 
@@ -139,7 +138,6 @@ class GithubAPITest extends Specification {
   }
 
   def "clearLabelCache"() {
-
     given:
       // Ensure cache is populated and valid
       steps.httpRequest(_) >> response
@@ -171,5 +169,37 @@ class GithubAPITest extends Specification {
 
     then:
       assertThat(prNumber).isEqualTo('68')
+  }
+
+  def "isCacheValid"() {
+    given:
+      // Ensure cache is populated and valid
+      steps.httpRequest(_) >> response
+      githubApi.addLabelsToCurrentPR(labels)
+
+    when:
+      def validTrue = githubApi.isCacheValid()
+      githubApi.clearLabelCache()
+      def validFalse = githubApi.isCacheValid()
+
+    then:
+      assertThat(validTrue).isTrue()
+      assertThat(validFalse).isFalse()
+  }
+
+  def "isCacheEmpty"() {
+    given:
+      // Ensure cache is populated and valid
+      steps.httpRequest(_) >> response
+      githubApi.addLabelsToCurrentPR(labels)
+
+    when:
+      def emptyFalse = githubApi.isCacheEmpty()
+      githubApi.clearLabelCache()
+      def emptyTrue = githubApi.isCacheEmpty()
+
+    then:
+      assertThat(emptyFalse).isFalse()
+      assertThat(emptyTrue).isTrue()
   }
 }

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -65,7 +65,7 @@ class GithubAPITest extends Specification {
   ]
 
   void setup() {
-    steps = Spy(JenkinsStepMock.class)
+    steps = Mock(JenkinsStepMock.class)
     steps.env >> [CHANGE_URL: "https://github.com/hmcts/some-project/pull/68",
                   CHANGE_ID: "68", GIT_CREDENTIALS_ID:"test-app-id"]
     githubApi = new GithubAPI(steps)

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -140,8 +140,8 @@ class GithubAPITest extends Specification {
 
   def "clearLabelCache"() {
     when:
-      def isValid = gitHubApi.isCacheValid()
-      def isEmpty = gitHubApi.isCacheEmpty()
+      def isValid = githubApi.isCacheValid()
+      def isEmpty = githubApi.isCacheEmpty()
 
     then:
       assertThat(isValid).isFalse()

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -125,7 +125,7 @@ class GithubAPITest extends Specification {
     then:
       assertThat(masterLabels).isEqualTo([])
       assertThat(prLabelsNotMatching).isEqualTo([])
-      assertThat(prLabels).isEqualTo([])
+      assertThat(prLabels).isEqualTo(["pr-values:ccd"])
       assertThat(multiplePRLabels).isEqualTo(["pr-values:ccd","pr-values:xui"])
   }
 

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -112,18 +112,6 @@ class GithubAPITest extends Specification {
 //        it.get('validResponseCodes').equals('200')})
 //  }
 
-  // Check test for PR status is working
-  def "checkPR"() {
-
-    when:
-      def notPr = githubApi.checkPR("master")
-      def pr = githubApi.checkPR("PR-123")
-
-    then:
-      assertThat(notPr).isFalse()
-      assertThat(pr).isTrue()
-  }
-
   // Attempt to check filtering is working on returned labels
 
   def "getLabelsbyPattern"() {

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -66,7 +66,7 @@ class GithubAPITest extends Specification {
 
   void setup() {
     steps = Mock(JenkinsStepMock.class)
-    steps.httpRequest(_) >> ["status": 200]
+    steps.httpRequest(_) >> response
     steps.env >> [CHANGE_URL: "https://github.com/hmcts/some-project/pull/68",
                   CHANGE_ID: "68", GIT_CREDENTIALS_ID:"test-app-id"]
     githubApi = new GithubAPI(steps)

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -125,7 +125,7 @@ class GithubAPITest extends Specification {
     then:
       assertThat(masterLabels).isEqualTo([])
       assertThat(prLabelsNotMatching).isEqualTo([])
-      assertThat(prLabels).isEqualTo(["pr-values:ccd"])
+      assertThat(prLabels).isEqualTo([])
       assertThat(multiplePRLabels).isEqualTo(["pr-values:ccd","pr-values:xui"])
   }
 

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -65,7 +65,7 @@ class GithubAPITest extends Specification {
   ]
 
   void setup() {
-    steps = Mock(JenkinsStepMock.class)
+    steps = Spy(JenkinsStepMock.class)
     steps.env >> [CHANGE_URL: "https://github.com/hmcts/some-project/pull/68",
                   CHANGE_ID: "68", GIT_CREDENTIALS_ID:"test-app-id"]
     githubApi = new GithubAPI(steps)

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -68,7 +68,7 @@ class GithubAPITest extends Specification {
     steps = Mock(JenkinsStepMock.class)
     steps.env >> [CHANGE_URL: "https://github.com/hmcts/some-project/pull/68",
                   CHANGE_ID: "68", GIT_CREDENTIALS_ID:"test-app-id"]
-    GithubAPI githubApi = Spy(constructorArgs: [steps])
+    githubApi = Spy(new GithubAPI(steps))
   }
 
   def "AddLabelsToCurrentPR"() {

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -76,7 +76,7 @@ class GithubAPITest extends Specification {
     def expectedUrl = 'https://api.github.com/repos/hmcts/some-project/issues/68/labels'
 
     given:
-      steps.httpRequest(_) >> prValuesResponse
+      steps.httpRequest(_) >> response
 
     when:
       githubApi.addLabelsToCurrentPR(labels)

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -76,8 +76,7 @@ class GithubAPITest extends Specification {
     def expectedUrl = 'https://api.github.com/repos/hmcts/some-project/issues/68/labels'
 
     given:
-      response = Stub()
-      response.status = 200
+      response.status >> 200
 
     when:
       githubApi.addLabelsToCurrentPR(labels)

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -68,7 +68,7 @@ class GithubAPITest extends Specification {
     steps = Mock(JenkinsStepMock.class)
     steps.env >> [CHANGE_URL: "https://github.com/hmcts/some-project/pull/68",
                   CHANGE_ID: "68", GIT_CREDENTIALS_ID:"test-app-id"]
-    githubApi = Spy(GithubAPI, constructorArgs: [steps])
+    githubApi = Spy(new GithubAPI(steps))
   }
 
   def "AddLabelsToCurrentPR"() {

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -64,8 +64,6 @@ class GithubAPITest extends Specification {
     ]'''
   ]
 
-  static def prValuesFromResponse = ["pr-values:ccd", "random", "pr-values:xui"]
-
   void setup() {
     steps = Mock(JenkinsStepMock.class)
     steps.env >> [CHANGE_URL: "https://github.com/hmcts/some-project/pull/68",
@@ -116,9 +114,7 @@ class GithubAPITest extends Specification {
 
   def "getLabelsbyPattern"() {
 
-    given:
-      steps.httpRequest(_) >> prValuesResponse
-      githubApi.getLabels() >> prValuesFromResponse
+    steps.httpRequest(_) >> prValuesResponse
 
     when:
       def masterLabels = githubApi.getLabelsbyPattern("master", "pr-values")

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -75,7 +75,7 @@ class GithubAPITest extends Specification {
 
     def expectedUrl = 'https://api.github.com/repos/hmcts/some-project/issues/68/labels'
 
-    setup:
+    given:
       steps.httpRequest(_) >> ["status": 200]
 
     when:

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -117,6 +117,19 @@ class GithubAPITest extends Specification {
       assertThat(multiplePRLabels).isEqualTo(["pr-values:ccd","pr-values:xui"])
   }
 
+  def "getLabels"() {
+    given:
+      steps.httpRequest(_) >> prValuesResponse
+
+    when:
+      def masterLabels = githubApi.getLabels("master")
+      def prLabels = githubApi.getLabels("PR-123")
+
+    then:
+      assertThat(masterLabels).isEqualTo([])
+      assertThat(prLabels).isEqualTo(prValuesResponseLabels)
+  }
+
   def "clearLabelCache"() {
     given:
       // Ensure cache is populated and valid

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -68,6 +68,8 @@ class GithubAPITest extends Specification {
 
   static def prValuesResponseLabels = ["pr-values:ccd", "random", "pr-values:xui"]
 
+  static def invalidResponse = ["status": 500]
+
   void setup() {
     steps = Mock(JenkinsStepMock.class)
     steps.env >> [CHANGE_URL: "https://github.com/hmcts/some-project/pull/68",
@@ -87,7 +89,7 @@ class GithubAPITest extends Specification {
       assertThat(cache).isEqualTo(responseLabels)
   }
 
-  def "AddLabels"() {
+  def "AddLabels [200 response]"() {
     given:
       steps.httpRequest(_) >> response
 
@@ -96,6 +98,17 @@ class GithubAPITest extends Specification {
 
     then:
       assertThat(cache).isEqualTo(responseLabels)
+  }
+
+  def "AddLabels [Invalid response]"() {
+    given:
+      steps.httpRequest(_) >> invalidResponse
+
+    when:
+      def cache = githubApi.addLabels('evilcorp/my-project', '89', labels)
+
+    then:
+      assertThat(cache).isEqualTo([])
   }
 
   // Attempt to check filtering is working on returned labels
@@ -148,7 +161,7 @@ class GithubAPITest extends Specification {
       assertThat(isEmpty).isTrue()
   }
 
-  def "refreshLabelCache"() {
+  def "refreshLabelCache [200 response]"() {
     given:
       steps.httpRequest(_) >> prValuesResponse
 
@@ -157,6 +170,17 @@ class GithubAPITest extends Specification {
 
     then:
       assertThat(cache).isEqualTo(prValuesResponseLabels)
+  }
+
+  def "refreshLabelCache [Invalid response]"() {
+    given:
+      steps.httpRequest(_) >> invalidResponse
+
+    when:
+      def cache = githubApi.refreshLabelCache()
+
+    then:
+      assertThat(cache).isEqualTo([])
   }
 
   def "CurrentProject"() {

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -126,7 +126,7 @@ class GithubAPITest extends Specification {
       assertThat(masterLabels).isEqualTo([])
       assertThat(prLabelsNotMatching).isEqualTo([])
       assertThat(prLabels).isEqualTo([])
-      assertThat(multiplePRLabels).isEqualTo([])
+      assertThat(multiplePRLabels).isEqualTo(["pr-values:ccd","pr-values:xui"])
   }
 
   def "CurrentProject"() {

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -75,6 +75,9 @@ class GithubAPITest extends Specification {
 
     def expectedUrl = 'https://api.github.com/repos/hmcts/some-project/issues/68/labels'
 
+    given:
+      response.getStatus() >> 200
+
     when:
       githubApi.addLabelsToCurrentPR(labels)
 

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -71,24 +71,24 @@ class GithubAPITest extends Specification {
     githubApi = new GithubAPI(steps)
   }
 
-//  def "AddLabelsToCurrentPR"() {
-//
-//    def expectedUrl = 'https://api.github.com/repos/hmcts/some-project/issues/68/labels'
-//
-//    when:
-//      githubApi.addLabelsToCurrentPR(labels)
-//
-//    then:
-//      1 * steps.httpRequest({it.get('httpMode').equals('POST') &&
-//                             it.get('authentication').equals("test-app-id") &&
-//                             it.get('acceptType').equals('APPLICATION_JSON') &&
-//                             it.get('contentType').equals('APPLICATION_JSON') &&
-//                             it.get('url').equals("${expectedUrl}") &&
-//                             it.get('requestBody').equals("${expectedLabels}") &&
-//                             it.get('consoleLogResponseBody').equals(true) &&
-//                             it.get('validResponseCodes').equals('200')})
-//  }
-//
+  def "AddLabelsToCurrentPR"() {
+
+    def expectedUrl = 'https://api.github.com/repos/hmcts/some-project/issues/68/labels'
+
+    when:
+      githubApi.addLabelsToCurrentPR(labels)
+
+    then:
+      1 * steps.httpRequest({it.get('httpMode').equals('POST') &&
+                             it.get('authentication').equals("test-app-id") &&
+                             it.get('acceptType').equals('APPLICATION_JSON') &&
+                             it.get('contentType').equals('APPLICATION_JSON') &&
+                             it.get('url').equals("${expectedUrl}") &&
+                             it.get('requestBody').equals("${expectedLabels}") &&
+                             it.get('consoleLogResponseBody').equals(true) &&
+                             it.get('validResponseCodes').equals('200')})
+  }
+
 //  def "AddLabels"() {
 //
 //    def expectedUrl = 'https://api.github.com/repos/evilcorp/my-project/issues/89/labels'

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -68,7 +68,7 @@ class GithubAPITest extends Specification {
     steps = Mock(JenkinsStepMock.class)
     steps.env >> [CHANGE_URL: "https://github.com/hmcts/some-project/pull/68",
                   CHANGE_ID: "68", GIT_CREDENTIALS_ID:"test-app-id"]
-    githubApi = Spy(new GithubAPI(steps))
+    githubApi = Spy(GithubAPI, constructorArgs: [steps])
   }
 
   def "AddLabelsToCurrentPR"() {

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -33,7 +33,7 @@ class GithubAPITest extends Specification {
     ]'''
   ]
 
-  static def prValuesResponse = ["content": '''[
+  static def prValuesResponse = ["status": 200, "content": '''[
       {
         "id": 208045946,
         "node_id": "MDU6TGFiZWwyMDgwNDU5NDY=",

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -68,7 +68,7 @@ class GithubAPITest extends Specification {
     steps = Mock(JenkinsStepMock.class)
     steps.env >> [CHANGE_URL: "https://github.com/hmcts/some-project/pull/68",
                   CHANGE_ID: "68", GIT_CREDENTIALS_ID:"test-app-id"]
-    githubApi = Spy(new GithubAPI(steps))
+    GithubAPI githubApi = Spy(constructorArgs: [steps])
   }
 
   def "AddLabelsToCurrentPR"() {

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -193,4 +193,20 @@ class GithubAPITest extends Specification {
       assertThat(emptyFalse).isFalse()
       assertThat(emptyTrue).isTrue()
   }
+
+  def "getCache"() {
+    given:
+      // Ensure cache is populated and valid
+      steps.httpRequest(_) >> response
+      githubApi.addLabelsToCurrentPR(labels)
+
+    when:
+      def cache = githubApi.getCache()
+      githubApi.clearLabelCache()
+      def emptyCache = githubApi.getCache()
+
+    then:
+      assertThat(cache).isEqualTo(responseLabels)
+      assertThat(emptyCache).isEqualTo([])
+  }
 }

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -11,7 +11,7 @@ class GithubAPITest extends Specification {
   def labels = ['label1', 'label2']
   def expectedLabels = '["label1","label2"]'
 
-  static def response = ["content": '''[
+  static def response = ["status": 200, "content": '''[
       {
         "id": 208045946,
         "node_id": "MDU6TGFiZWwyMDgwNDU5NDY=",
@@ -75,7 +75,8 @@ class GithubAPITest extends Specification {
 
     def expectedUrl = 'https://api.github.com/repos/hmcts/some-project/issues/68/labels'
 
-    steps.httpRequest(_) >> response
+    given:
+      steps.httpRequest(_) >> response
 
     when:
       githubApi.addLabelsToCurrentPR(labels)

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -138,6 +138,16 @@ class GithubAPITest extends Specification {
       assertThat(multiplePRLabels).isEqualTo(["pr-values:ccd","pr-values:xui"])
   }
 
+  def "clearLabelCache"() {
+    when:
+      def isValid = gitHubApi.isCacheValid()
+      def isEmpty = gitHubApi.isCacheEmpty()
+
+    then:
+      assertThat(isValid).isFalse()
+      assertThat(isEmpty).isTrue()
+  }
+
   def "CurrentProject"() {
     when:
       def project = githubApi.currentProject()

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -75,6 +75,10 @@ class GithubAPITest extends Specification {
 
     def expectedUrl = 'https://api.github.com/repos/hmcts/some-project/issues/68/labels'
 
+    given:
+      response = Stub()
+      response.status = 200
+
     when:
       githubApi.addLabelsToCurrentPR(labels)
 

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -68,7 +68,7 @@ class GithubAPITest extends Specification {
     steps = Mock(JenkinsStepMock.class)
     steps.env >> [CHANGE_URL: "https://github.com/hmcts/some-project/pull/68",
                   CHANGE_ID: "68", GIT_CREDENTIALS_ID:"test-app-id"]
-    githubApi = Spy(new GithubAPI(steps))
+    githubApi = new GithubAPI(steps)
   }
 
   def "AddLabelsToCurrentPR"() {

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -33,6 +33,8 @@ class GithubAPITest extends Specification {
     ]'''
   ]
 
+  static def responseLabels = ["bug", "enhancement"]
+
   static def prValuesResponse = ["status": 200, "content": '''[
       {
         "id": 208045946,
@@ -64,6 +66,8 @@ class GithubAPITest extends Specification {
     ]'''
   ]
 
+  static def prValuesResponseLabels = ["pr-values:ccd", "random", "pr-values:xui"]
+
   void setup() {
     steps = Mock(JenkinsStepMock.class)
     steps.env >> [CHANGE_URL: "https://github.com/hmcts/some-project/pull/68",
@@ -73,49 +77,25 @@ class GithubAPITest extends Specification {
   }
 
   def "AddLabelsToCurrentPR"() {
-
-    def expectedUrl = 'https://api.github.com/repos/hmcts/some-project/issues/68/labels'
-
     given:
       steps.httpRequest(_) >> response
 
     when:
-      githubApi.addLabelsToCurrentPR(labels)
+      def cache = githubApi.addLabelsToCurrentPR(labels)
 
     then:
-      steps.httpRequest({
-        it.get('httpMode').equals('POST') &&
-        it.get('authentication').equals("test-app-id") &&
-        it.get('acceptType').equals('APPLICATION_JSON') &&
-        it.get('contentType').equals('APPLICATION_JSON') &&
-        it.get('url').equals("${expectedUrl}") &&
-        it.get('requestBody').equals("${expectedLabels}") &&
-        it.get('consoleLogResponseBody').equals(true) &&
-        it.get('validResponseCodes').equals('200')
-      })
+      assertThat(cache).isEqualTo(responseLabels)
   }
 
   def "AddLabels"() {
-
-    def expectedUrl = 'https://api.github.com/repos/evilcorp/my-project/issues/89/labels'
-
     given:
       steps.httpRequest(_) >> response
 
     when:
-      githubApi.addLabels('evilcorp/my-project', '89', labels)
+      def cache = githubApi.addLabels('evilcorp/my-project', '89', labels)
 
     then:
-      steps.httpRequest({
-        it.get('httpMode').equals('POST') &&
-        it.get('authentication').equals("test-app-id") &&
-        it.get('acceptType').equals('APPLICATION_JSON') &&
-        it.get('contentType').equals('APPLICATION_JSON') &&
-        it.get('url').equals("${expectedUrl}") &&
-        it.get('requestBody').equals("${expectedLabels}") &&
-        it.get('consoleLogResponseBody').equals(true) &&
-        it.get('validResponseCodes').equals('200')
-      })
+      assertThat(cache).isEqualTo(responseLabels)
   }
 
   // Attempt to check filtering is working on returned labels

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -93,23 +93,26 @@ class GithubAPITest extends Specification {
                              it.get('validResponseCodes').equals('200')})
   }
 
-//  def "AddLabels"() {
-//
-//    def expectedUrl = 'https://api.github.com/repos/evilcorp/my-project/issues/89/labels'
-//
-//    when:
-//      githubApi.addLabels('evilcorp/my-project', '89', labels)
-//
-//    then:
-//      1 * steps.httpRequest({it.get('httpMode').equals('POST') &&
-//        it.get('authentication').equals("test-app-id") &&
-//        it.get('acceptType').equals('APPLICATION_JSON') &&
-//        it.get('contentType').equals('APPLICATION_JSON') &&
-//        it.get('url').equals("${expectedUrl}") &&
-//        it.get('requestBody').equals("${expectedLabels}") &&
-//        it.get('consoleLogResponseBody').equals(true) &&
-//        it.get('validResponseCodes').equals('200')})
-//  }
+  def "AddLabels"() {
+
+    def expectedUrl = 'https://api.github.com/repos/evilcorp/my-project/issues/89/labels'
+
+    given:
+      steps.httpRequest(_) >> response
+
+    when:
+      githubApi.addLabels('evilcorp/my-project', '89', labels)
+
+    then:
+      steps.httpRequest({it.get('httpMode').equals('POST') &&
+        it.get('authentication').equals("test-app-id") &&
+        it.get('acceptType').equals('APPLICATION_JSON') &&
+        it.get('contentType').equals('APPLICATION_JSON') &&
+        it.get('url').equals("${expectedUrl}") &&
+        it.get('requestBody').equals("${expectedLabels}") &&
+        it.get('consoleLogResponseBody').equals(true) &&
+        it.get('validResponseCodes').equals('200')})
+  }
 
   // Attempt to check filtering is working on returned labels
 

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -66,7 +66,6 @@ class GithubAPITest extends Specification {
 
   void setup() {
     steps = Mock(JenkinsStepMock.class)
-    steps.httpRequest(_) >> response
     steps.env >> [CHANGE_URL: "https://github.com/hmcts/some-project/pull/68",
                   CHANGE_ID: "68", GIT_CREDENTIALS_ID:"test-app-id"]
     githubApi = new GithubAPI(steps)
@@ -75,6 +74,8 @@ class GithubAPITest extends Specification {
   def "AddLabelsToCurrentPR"() {
 
     def expectedUrl = 'https://api.github.com/repos/hmcts/some-project/issues/68/labels'
+
+    steps.httpRequest(_) >> response
 
     when:
       githubApi.addLabelsToCurrentPR(labels)

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -75,9 +75,6 @@ class GithubAPITest extends Specification {
 
     def expectedUrl = 'https://api.github.com/repos/hmcts/some-project/issues/68/labels'
 
-    given:
-      response.status >> 200
-
     when:
       githubApi.addLabelsToCurrentPR(labels)
 
@@ -89,7 +86,7 @@ class GithubAPITest extends Specification {
                              it.get('url').equals("${expectedUrl}") &&
                              it.get('requestBody').equals("${expectedLabels}") &&
                              it.get('consoleLogResponseBody').equals(true) &&
-                             it.get('validResponseCodes').equals('200')})
+                             it.get('validResponseCodes').equals('200')}) >> ["status" : 200]
   }
 
 //  def "AddLabels"() {

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -76,7 +76,7 @@ class GithubAPITest extends Specification {
     def expectedUrl = 'https://api.github.com/repos/hmcts/some-project/issues/68/labels'
 
     given:
-      steps.httpRequest(_) >> response
+      steps.httpRequest(_) >> prValuesResponse
 
     when:
       githubApi.addLabelsToCurrentPR(labels)

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -68,6 +68,7 @@ class GithubAPITest extends Specification {
     steps = Mock(JenkinsStepMock.class)
     steps.env >> [CHANGE_URL: "https://github.com/hmcts/some-project/pull/68",
                   CHANGE_ID: "68", GIT_CREDENTIALS_ID:"test-app-id"]
+    steps.httpRequest(_) >> response
     githubApi = new GithubAPI(steps)
   }
 
@@ -86,7 +87,7 @@ class GithubAPITest extends Specification {
                              it.get('url').equals("${expectedUrl}") &&
                              it.get('requestBody').equals("${expectedLabels}") &&
                              it.get('consoleLogResponseBody').equals(true) &&
-                             it.get('validResponseCodes').equals('200')}) >> ["status" : 200]
+                             it.get('validResponseCodes').equals('200')})
   }
 
 //  def "AddLabels"() {

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -78,111 +78,6 @@ class GithubAPITest extends Specification {
     githubApi.clearLabelCache()
   }
 
-  def "AddLabelsToCurrentPR"() {
-    given:
-      steps.httpRequest(_) >> response
-
-    when:
-      def cache = githubApi.addLabelsToCurrentPR(labels)
-
-    then:
-      assertThat(cache).isEqualTo(responseLabels)
-  }
-
-  def "AddLabels [200 response]"() {
-    given:
-      steps.httpRequest(_) >> response
-
-    when:
-      def cache = githubApi.addLabels('evilcorp/my-project', '89', labels)
-
-    then:
-      assertThat(cache).isEqualTo(responseLabels)
-  }
-
-  def "AddLabels [Invalid response]"() {
-    given:
-      steps.httpRequest(_) >> invalidResponse
-
-    when:
-      def cache = githubApi.addLabels('evilcorp/my-project', '89', labels)
-
-    then:
-      assertThat(cache).isEqualTo([])
-  }
-
-  // Attempt to check filtering is working on returned labels
-
-  def "getLabelsbyPattern"() {
-    given:
-      steps.httpRequest(_) >> prValuesResponse
-
-    when:
-      def masterLabels = githubApi.getLabelsbyPattern("master", "pr-values")
-      def prLabels = githubApi.getLabelsbyPattern("PR-123", "pr-values:ccd")
-      def prLabelsNotMatching = githubApi.getLabelsbyPattern("PR-123", "doesntexist")
-      def multiplePRLabels = githubApi.getLabelsbyPattern("PR-123", "pr-values")
-
-    then:
-      assertThat(masterLabels).isEqualTo([])
-      assertThat(prLabelsNotMatching).isEqualTo([])
-      assertThat(prLabels).isEqualTo(["pr-values:ccd"])
-      assertThat(multiplePRLabels).isEqualTo(["pr-values:ccd","pr-values:xui"])
-  }
-
-  def "getLabels"() {
-    given:
-      steps.httpRequest(_) >> prValuesResponse
-
-    when:
-      def masterLabels = githubApi.getLabels("master")
-      def prLabels = githubApi.getLabels("PR-123")
-
-    then:
-      assertThat(masterLabels).isEqualTo([])
-      assertThat(prLabels).isEqualTo(prValuesResponseLabels)
-  }
-
-  def "clearLabelCache"() {
-    given:
-      // Ensure cache is populated and valid
-      steps.httpRequest(_) >> response
-      githubApi.addLabelsToCurrentPR(labels)
-
-      // Clear the cache
-      githubApi.clearLabelCache()
-
-    when:
-      def isValid = githubApi.isCacheValid()
-      def isEmpty = githubApi.isCacheEmpty()
-
-    then:
-      assertThat(isValid).isFalse()
-      assertThat(isEmpty).isTrue()
-  }
-
-  def "refreshLabelCache [200 response]"() {
-    given:
-      steps.httpRequest(_) >> prValuesResponse
-
-    when:
-      def cache = githubApi.refreshLabelCache()
-
-    then:
-      assertThat(cache).isEqualTo(prValuesResponseLabels)
-  }
-
-  def "refreshLabelCache [Invalid response]"() {
-    given:
-      steps.httpRequest(_) >> invalidResponse
-
-    when:
-      def cache = githubApi.refreshLabelCache()
-
-    then:
-      assertThat(cache).isEqualTo([])
-  }
-
   def "CurrentProject"() {
     when:
       def project = githubApi.currentProject()
@@ -245,5 +140,110 @@ class GithubAPITest extends Specification {
     then:
       assertThat(cache).isEqualTo(responseLabels)
       assertThat(emptyCache).isEqualTo([])
+  }
+
+  def "clearLabelCache"() {
+    given:
+      // Ensure cache is populated and valid
+      steps.httpRequest(_) >> response
+      githubApi.addLabelsToCurrentPR(labels)
+
+    when:
+      // Clear the cache
+      githubApi.clearLabelCache()
+
+      def isValid = githubApi.isCacheValid()
+      def isEmpty = githubApi.isCacheEmpty()
+
+    then:
+      assertThat(isValid).isFalse()
+      assertThat(isEmpty).isTrue()
+  }
+
+  def "refreshLabelCache [200 response]"() {
+    given:
+      steps.httpRequest(_) >> prValuesResponse
+
+    when:
+      def cache = githubApi.refreshLabelCache()
+
+    then:
+      assertThat(cache).isEqualTo(prValuesResponseLabels)
+  }
+
+  def "refreshLabelCache [Invalid response]"() {
+    given:
+      steps.httpRequest(_) >> invalidResponse
+
+    when:
+      def cache = githubApi.refreshLabelCache()
+
+    then:
+      assertThat(cache).isEqualTo([])
+  }
+
+  def "AddLabels [200 response]"() {
+    given:
+      steps.httpRequest(_) >> response
+
+    when:
+      def cache = githubApi.addLabels('evilcorp/my-project', '89', labels)
+
+    then:
+      assertThat(cache).isEqualTo(responseLabels)
+  }
+
+  // Attempt to check filtering is working on returned labels
+
+  def "AddLabels [Invalid response]"() {
+    given:
+      steps.httpRequest(_) >> invalidResponse
+
+    when:
+      def cache = githubApi.addLabels('evilcorp/my-project', '89', labels)
+
+    then:
+      assertThat(cache).isEqualTo([])
+  }
+
+  def "AddLabelsToCurrentPR"() {
+    given:
+      steps.httpRequest(_) >> response
+
+    when:
+      def cache = githubApi.addLabelsToCurrentPR(labels)
+
+    then:
+      assertThat(cache).isEqualTo(responseLabels)
+  }
+
+  def "getLabels"() {
+    given:
+      steps.httpRequest(_) >> prValuesResponse
+
+    when:
+      def masterLabels = githubApi.getLabels("master")
+      def prLabels = githubApi.getLabels("PR-123")
+
+    then:
+      assertThat(masterLabels).isEqualTo([])
+      assertThat(prLabels).isEqualTo(prValuesResponseLabels)
+  }
+
+  def "getLabelsbyPattern"() {
+    given:
+      steps.httpRequest(_) >> prValuesResponse
+
+    when:
+      def masterLabels = githubApi.getLabelsbyPattern("master", "pr-values")
+      def prLabels = githubApi.getLabelsbyPattern("PR-123", "pr-values:ccd")
+      def prLabelsNotMatching = githubApi.getLabelsbyPattern("PR-123", "doesntexist")
+      def multiplePRLabels = githubApi.getLabelsbyPattern("PR-123", "pr-values")
+
+    then:
+      assertThat(masterLabels).isEqualTo([])
+      assertThat(prLabelsNotMatching).isEqualTo([])
+      assertThat(prLabels).isEqualTo(["pr-values:ccd"])
+      assertThat(multiplePRLabels).isEqualTo(["pr-values:ccd","pr-values:xui"])
   }
 }

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -139,6 +139,15 @@ class GithubAPITest extends Specification {
   }
 
   def "clearLabelCache"() {
+
+    given:
+      // Ensure cache is populated and valid
+      steps.httpRequest(_) >> response
+      githubApi.addLabelsToCurrentPR(labels)
+
+      // Clear the cache
+      githubApi.clearLabelCache()
+
     when:
       def isValid = githubApi.isCacheValid()
       def isEmpty = githubApi.isCacheEmpty()

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -75,9 +75,8 @@ class GithubAPITest extends Specification {
 
     def expectedUrl = 'https://api.github.com/repos/hmcts/some-project/issues/68/labels'
 
-    given:
-      steps.httpRequest(_) >> response
-      response.status >> 200
+    setup:
+      steps.httpRequest(_) >> ["status": 200]
 
     when:
       githubApi.addLabelsToCurrentPR(labels)

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -68,7 +68,7 @@ class GithubAPITest extends Specification {
     steps = Mock(JenkinsStepMock.class)
     steps.env >> [CHANGE_URL: "https://github.com/hmcts/some-project/pull/68",
                   CHANGE_ID: "68", GIT_CREDENTIALS_ID:"test-app-id"]
-    githubApi = new GithubAPI(steps)
+    githubApi = Spy(new GithubAPI(steps))
   }
 
   def "AddLabelsToCurrentPR"() {

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -135,6 +135,17 @@ class GithubAPITest extends Specification {
       assertThat(isEmpty).isTrue()
   }
 
+  def "refreshLabelCache"() {
+    given:
+      steps.httpRequest(_) >> prValuesResponse
+
+    when:
+      def cache = githubApi.refreshLabelCache()
+
+    then:
+      assertThat(cache).isEqualTo(prValuesResponseLabels)
+  }
+
   def "CurrentProject"() {
     when:
       def project = githubApi.currentProject()

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -66,6 +66,7 @@ class GithubAPITest extends Specification {
 
   void setup() {
     steps = Mock(JenkinsStepMock.class)
+    steps.httpRequest(_) >> ["status": 200]
     steps.env >> [CHANGE_URL: "https://github.com/hmcts/some-project/pull/68",
                   CHANGE_ID: "68", GIT_CREDENTIALS_ID:"test-app-id"]
     githubApi = new GithubAPI(steps)
@@ -74,9 +75,6 @@ class GithubAPITest extends Specification {
   def "AddLabelsToCurrentPR"() {
 
     def expectedUrl = 'https://api.github.com/repos/hmcts/some-project/issues/68/labels'
-
-    given:
-      steps.httpRequest(_) >> ["status": 200]
 
     when:
       githubApi.addLabelsToCurrentPR(labels)

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -69,6 +69,7 @@ class GithubAPITest extends Specification {
     steps.env >> [CHANGE_URL: "https://github.com/hmcts/some-project/pull/68",
                   CHANGE_ID: "68", GIT_CREDENTIALS_ID:"test-app-id"]
     githubApi = new GithubAPI(steps)
+    githubApi.clearLabelCache()
   }
 
   def "AddLabelsToCurrentPR"() {

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -112,6 +112,18 @@ class GithubAPITest extends Specification {
 //        it.get('validResponseCodes').equals('200')})
 //  }
 
+  // Check test for PR status is working
+  def "checkPR"() {
+
+    when:
+      def notPr = githubApi.checkPR("master")
+      def pr = githubApi.checkPR("PR-123")
+
+    then:
+      assertThat(notPr).isFalse()
+      assertThat(pr).isTrue()
+  }
+
   // Attempt to check filtering is working on returned labels
 
   def "getLabelsbyPattern"() {

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -82,7 +82,7 @@ class GithubAPITest extends Specification {
       githubApi.addLabelsToCurrentPR(labels)
 
     then:
-      1 * steps.httpRequest({it.get('httpMode').equals('POST') &&
+      steps.httpRequest({it.get('httpMode').equals('POST') &&
                              it.get('authentication').equals("test-app-id") &&
                              it.get('acceptType').equals('APPLICATION_JSON') &&
                              it.get('contentType').equals('APPLICATION_JSON') &&

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -64,6 +64,8 @@ class GithubAPITest extends Specification {
     ]'''
   ]
 
+  static def prValuesFromResponse = ["pr-values:ccd", "random", "pr-values:xui"]
+
   void setup() {
     steps = Mock(JenkinsStepMock.class)
     steps.env >> [CHANGE_URL: "https://github.com/hmcts/some-project/pull/68",
@@ -114,7 +116,9 @@ class GithubAPITest extends Specification {
 
   def "getLabelsbyPattern"() {
 
-    steps.httpRequest(_) >> prValuesResponse
+    given:
+      steps.httpRequest(_) >> prValuesResponse
+      githubApi.getLabels() >> prValuesFromResponse
 
     when:
       def masterLabels = githubApi.getLabelsbyPattern("master", "pr-values")

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -126,7 +126,7 @@ class GithubAPITest extends Specification {
       assertThat(masterLabels).isEqualTo([])
       assertThat(prLabelsNotMatching).isEqualTo([])
       assertThat(prLabels).isEqualTo([])
-      assertThat(multiplePRLabels).isEqualTo(["pr-values:ccd","pr-values:xui"])
+      assertThat(multiplePRLabels).isEqualTo([])
   }
 
   def "CurrentProject"() {


### PR DESCRIPTION
Cache labels to reduce API calls.

refreshLabelCache() makes an API call to update the cache.  Called automatically if cache is deemed invalid.

clearLabelCache() empties the cache.  The next getLabelsXXX() or addLabelsXXX() call will trigger a refresh.  It should not be necessary to call this method.

Private method getLabelsFromCache() either returns the cached list, or if empty, calls refreshLabelCache().

getLabels() calls getLabelsFromCache() instead of making a direct API call.

getLabelsbyPattern(branch_name, key) should be utilised when an ArrayList of multiple labels is required/expected.  Returns an ArrayList of results.

checkForLabel(branch_name, key) should be utilised when a single label is required.  Returns whether the label is present (boolean)