### PR TITLE
override hmctspublic alias as not supported in flux v2

### DIFF
--- a/resources/uk/gov/hmcts/helm/check-helm-version-bumped.sh
+++ b/resources/uk/gov/hmcts/helm/check-helm-version-bumped.sh
@@ -28,6 +28,7 @@ else
 fi
 
 sed -i -e 's/@hmctspublic/https\:\/\/hmctspublic.azurecr.io\/helm\/v1\/repo\//g' charts/"${CHART_DIRECTORY}"/Chart.yaml
+git status charts/"${CHART_DIRECTORY}"/Chart.yaml | grep --quiet charts/"${CHART_DIRECTORY}"/Chart.yaml
 if [ $? -eq 0 ]; then
   echo "Updated hmctspublic alias in Chart.yaml"
   ALIAS_UPDATED=true

--- a/resources/uk/gov/hmcts/helm/check-helm-version-bumped.sh
+++ b/resources/uk/gov/hmcts/helm/check-helm-version-bumped.sh
@@ -46,7 +46,9 @@ git diff origin/master charts/"${CHART_DIRECTORY}"/Chart.yaml | grep --quiet '+v
 
 if [ $? -eq 0 ]; then
   echo "Chart.yaml version has been bumped :)"
+  CHART_BUMPED=false
 else
+  CHART_BUMPED=true
   echo "==================================================================="
   echo "=====  Version is not bumped in Chart.yaml file    ====="
   echo "=====  This is required as you changed something in           ====="
@@ -60,12 +62,14 @@ else
 
 fi
 
-git fetch origin $BRANCH:$BRANCH
-git remote set-url origin $(git config remote.origin.url | sed "s/github.com/${USER_NAME}:${BEARER_TOKEN}@github.com/g")
-git config --global user.name ${USER_NAME}
-git config --global user.email ${GIT_APP_EMAIL_ID}
+if [[ ${CHART_BUMPED} = 'true' ]]  || [[ ${ALIAS_UPDATED} = 'true' ]] ; then
+  git fetch origin $BRANCH:$BRANCH
+  git remote set-url origin $(git config remote.origin.url | sed "s/github.com/${USER_NAME}:${BEARER_TOKEN}@github.com/g")
+  git config --global user.name ${USER_NAME}
+  git config --global user.email ${GIT_APP_EMAIL_ID}
 
-git add charts/"${CHART_DIRECTORY}"/Chart.yaml
-git commit -m "Bumping chart version/ fixing aliases"
-git push origin HEAD:$BRANCH
-exit 1
+  git add charts/"${CHART_DIRECTORY}"/Chart.yaml
+  git commit -m "Bumping chart version/ fixing aliases"
+  git push origin HEAD:$BRANCH
+  exit 1
+fi

--- a/vars/enforceChartVersionBumped.groovy
+++ b/vars/enforceChartVersionBumped.groovy
@@ -15,7 +15,7 @@ def call(Map<String, String> params) {
       returnStatus: true
     )
     if (CHART_BUMP==1) {
-      error('AUTO_ABORT Automatically bumped chart version due to changes in the chart')
+      error('AUTO_ABORT Automatically bumped chart version or fixing aliases in chart')
     }
   }
 


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
* This will automatically replace hmctspublic alias with corresponding full url and commit to PR branch
* Bumps the chart if needed, like usual
* Removed a check on requirements.yaml change as its no longer supported on api version v2.
