### PR TITLE
Deleting Job instead of entire helm release for non service apps

### DIFF
--- a/src/uk/gov/hmcts/contino/Kubectl.groovy
+++ b/src/uk/gov/hmcts/contino/Kubectl.groovy
@@ -49,11 +49,11 @@ class Kubectl {
   }
 
   def getJob(String name) {
-    this.steps.sh(returnStatus: true, script: "kubectl get Job ${name} -n ${this.namespace}")
+    this.steps.sh(returnStatus: true, script: "kubectl get job ${name} -n ${this.namespace}")
   }
 
   def deleteJob(String name) {
-    this.steps.sh(returnStatus: true, script: "kubectl delete Job ${name} -n ${this.namespace}")
+    this.steps.sh(returnStatus: true, script: "kubectl delete job ${name} -n ${this.namespace}")
   }
 
   def getServiceLoadbalancerIP(String name) {

--- a/src/uk/gov/hmcts/contino/Kubectl.groovy
+++ b/src/uk/gov/hmcts/contino/Kubectl.groovy
@@ -48,6 +48,14 @@ class Kubectl {
     this.steps.sh(returnStatus: true, script: "kubectl delete deployment ${deploymentName} -n ${this.namespace}")
   }
 
+  def getJob(String name) {
+    this.steps.sh(returnStatus: true, script: "kubectl get Job ${name} -n ${this.namespace}")
+  }
+
+  def deleteJob(String name) {
+    this.steps.sh(returnStatus: true, script: "kubectl delete Job ${name} -n ${this.namespace}")
+  }
+
   def getServiceLoadbalancerIP(String name) {
     this.getServiceLoadbalancerIP(name, this.namespace)
   }

--- a/test/uk/gov/hmcts/contino/KubectlTest.groovy
+++ b/test/uk/gov/hmcts/contino/KubectlTest.groovy
@@ -8,6 +8,7 @@ class KubectlTest extends Specification {
   static final String NAMESPACE = 'cnp'
   static final String SUBSCRIPTION = 'sandbox'
   static final String DEPLOYMENT = 'my-deployment'
+  static final String PLUM_JOB= 'plum-job'
 
   def steps
   def kubectl
@@ -91,6 +92,28 @@ class KubectlTest extends Specification {
         it.get('script').contains("kubectl delete deployment ${DEPLOYMENT} -n ${NAMESPACE}") &&
         it.containsKey('returnStatus') &&
         it.get('returnStatus').equals(true)})
+  }
+
+  def "getJob() should have Job, namespace and return exit status"() {
+    when:
+    kubectl.getJob(PLUM_JOB)
+
+    then:
+    1 * steps.sh({it.containsKey('script') &&
+      it.get('script').contains("kubectl get job ${PLUM_JOB} -n ${NAMESPACE}") &&
+      it.containsKey('returnStatus') &&
+      it.get('returnStatus').equals(true)})
+  }
+
+  def "deleteJob() should have delete Job, namespace and return exit status"() {
+    when:
+    kubectl.deleteJob(PLUM_JOB)
+
+    then:
+    1 * steps.sh({it.containsKey('script') &&
+      it.get('script').contains("kubectl delete job ${PLUM_JOB} -n ${NAMESPACE}") &&
+      it.containsKey('returnStatus') &&
+      it.get('returnStatus').equals(true)})
   }
 
   def "getService() should have namespace and JSON output"() {

--- a/vars/helmInstall.groovy
+++ b/vars/helmInstall.groovy
@@ -118,9 +118,9 @@ def call(DockerImage dockerImage, Map params) {
         options.add("--set global.jobKind=Job")
         options.add("--set global.smoketestscron.enabled=false")
         options.add("--set global.functionaltestscron.enabled=false")
-      //deleting non service apps before installing as K8s doesn't allow editing image of deployed Jobs
-      if(helm.exists(dockerImage.getImageTag(), namespace)){
-        helm.delete(dockerImage.getImageTag(), namespace)
+      //deleting job for non service apps before installing as K8s doesn't allow editing image/spec of deployed Jobs
+      if(kubectl.getJob(dockerImage.getImageTag()+"-job") == 0){
+        kubectl.deleteJob(dockerImage.getImageTag()+"-job")
       }
     }
 

--- a/vars/helmInstall.groovy
+++ b/vars/helmInstall.groovy
@@ -118,8 +118,8 @@ def call(DockerImage dockerImage, Map params) {
         options.add("--set global.smoketestscron.enabled=false")
         options.add("--set global.functionaltestscron.enabled=false")
       //deleting job for non service apps before installing as K8s doesn't allow editing image/spec of deployed Jobs
-      if(kubectl.getJob(dockerImage.getImageTag()+"-job") == 0){
-        kubectl.deleteJob(dockerImage.getImageTag()+"-job")
+      if(kubectl.getJob(dockerImage.getAksServiceName()+"-job") == 0){
+        kubectl.deleteJob(dockerImage.getAksServiceName()+"-job")
       }
     }
 

--- a/vars/helmInstall.groovy
+++ b/vars/helmInstall.groovy
@@ -19,6 +19,7 @@ def call(DockerImage dockerImage, Map params) {
   AppPipelineConfig config = params.appPipelineConfig
 
   def helmResourcesDir = Helm.HELM_RESOURCES_DIR
+  def namespace = env.TEAM_NAMESPACE
 
   def imageName = dockerImage.getTaggedName()
   def aksServiceName = dockerImage.getAksServiceName()
@@ -27,12 +28,10 @@ def call(DockerImage dockerImage, Map params) {
   AzPrivateDns azPrivateDns = new AzPrivateDns(this, params.environment, dnsConfigEntry)
   String serviceFqdn = azPrivateDns.getHostName(aksServiceName)
 
-  def kubectl = new Kubectl(this, subscription, aksServiceName, params.aksSubscription.name)
+  def kubectl = new Kubectl(this, subscription, namespace, params.aksSubscription.name)
   kubectl.login()
   // Get the IP of the Traefik Ingress Controller
   def ingressIP = kubectl.getServiceLoadbalancerIP("traefik", "admin")
-
-  def namespace = env.TEAM_NAMESPACE
 
   def templateEnvVars = [
     "NAMESPACE=${namespace}",


### PR DESCRIPTION
Notes:
* Currently we delete entire helm release before installing a new one for non-service apps in preview as the job spec cannot be edited.
* But this is causing issues to teams using this with OSBA managed resources. Whenever helm release is deleted, OSBA managed resources also get deleted and immediate install fails with `references a ServiceInstance that is being deleted:` . It takes a couple of runs for it to be succesfull making teams assume its `flaky`. Example https://build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_j_to_z%2Frd-commondata-dataload/detail/PR-127/3/pipeline 
* Tested on couple of apps.

https://build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_j_to_z%2Frd-commondata-dataload/detail/PR-135/2/pipeline
https://build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_j_to_z%2Fsscs-case-loader/detail/PR-1353/3/pipeline/

