### PR TITLE
Dtspo 9278 jenkins library update

### DIFF
--- a/vars/helmInstall.groovy
+++ b/vars/helmInstall.groovy
@@ -112,13 +112,6 @@ def call(DockerImage dockerImage, Map params) {
       "--namespace ${namespace}"
     ]
 
-    if (this.env.DISABLE_TRAEFIK_TLS == "true") {
-      //Add global disableTraefikTls flag as true if DISABLE_TRAEFIK_TLS is set to true in jenkins
-        options.add("--set global.disableTraefikTls=true")
-    } else {
-        options.add("--set global.disableTraefikTls=false")
-    }
-
     if (!config.serviceApp) {
       //Forcing Jobs deployed through Jenkins to be Job to avoid cronJobs being run forever.
         options.add("--set global.job.kind=Job")


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-9278
Update jenkins library to set global disableTraefikTls flag options based on what's passed through flux. Eg. for sds - https://github.com/hmcts/sds-flux-config/pull/2042

Tested this library against multiple places, see inside DTSPO ticket for pipelines

Notes:
*
*
*
