### PR TITLE
DTSPO-6455 - Add support for yarn v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ If you use AKS deployments, a docker image is built and pushed remotely to ACR.
 
 You can optionally make this build faster by using explicit ACR tasks, in a `acb.tpl.yaml` file located at the root of your project (watch out, the extension is .yaml, not .yml).
 
-This is particularly effective for nodejs projecs pulling loads of npm packages.
+This is particularly effective for nodejs projects pulling loads of npm packages.
 
 Here is a sample file, assuming you use docker multi stage build:
 

--- a/resources/uk/gov/hmcts/pipeline/yarn/yarnV2OrNewer-audit-with-suppressions.sh
+++ b/resources/uk/gov/hmcts/pipeline/yarn/yarnV2OrNewer-audit-with-suppressions.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# This is a wrapper script for yarn audit that allows suppressing
+# vulnerabilities without a fix
+
+set +e
+yarn npm audit --environment production
+result=$?
+
+yarn npm audit --environment production --json > yarn-audit-result
+
+set -e
+
+if [ "$result" != 0 ]; then
+  if [ -f yarn-audit-known-issues ]; then
+    set +e
+    cat yarn-audit-result | jq -r '.advisories | keys | join("\n")' | sort -nr > yarn-audit-advisories
+    set -e
+
+    if diff -q yarn-audit-known-advisories yarn-audit-advisories > /dev/null 2>&1; then
+      rm -f yarn-audit-advisories
+      echo
+      echo Ignorning known vulnerabilities
+      exit 0
+    fi
+  fi
+  cat <<EOF
+    Security vulnerabilities were found that were not ignored
+
+    Check to see if these vulnerabilities apply to production
+    and/or if they have fixes available. If they do not have
+    fixes and they do not apply to production, you may ignore them
+
+    To ignore these vulnerabilities, run:
+
+    `yarn npm audit --environment production --json | jq -r '.advisories | keys | join("\n")' | sort -nr > yarn-audit-known-advisories`
+
+    and commit the yarn-audit-known-issues file
+EOF
+
+  rm -f yarn-audit-advisories
+
+  exit "$result"
+fi

--- a/resources/uk/gov/hmcts/pipeline/yarn/yarnV2OrNewer-audit-with-suppressions.sh
+++ b/resources/uk/gov/hmcts/pipeline/yarn/yarnV2OrNewer-audit-with-suppressions.sh
@@ -13,7 +13,7 @@ set -e
 if [ "$result" != 0 ]; then
   if [ -f yarn-audit-known-issues ]; then
     set +e
-    cat yarn-audit-result | /tmp/jq -cr '.advisories| to_entries[] | {"type": "auditAdvisory", "data": { "advisory": .value }}' > yarn-audit-issues
+    cat yarn-audit-result | jq -cr '.advisories| to_entries[] | {"type": "auditAdvisory", "data": { "advisory": .value }}' > yarn-audit-issues
     set -e
 
     if diff -q yarn-audit-known-issues yarn-audit-issues > /dev/null 2>&1; then
@@ -32,7 +32,7 @@ if [ "$result" != 0 ]; then
 
     To ignore these vulnerabilities, run:
 
-    `yarn npm audit --environment production --json | jq -r '.advisories | keys | join("\n")' | sort -nr > yarn-audit-known-issues`
+    `yarn npm audit --environment production --json | jq -cr '.advisories| to_entries[] | {"type": "auditAdvisory", "data": { "advisory": .value }}' > yarn-audit-known-issues`
 
     and commit the yarn-audit-known-issues file
 EOF

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -242,7 +242,10 @@ EOF
     yarn("test:can-i-deploy:consumer")
   }
 
-  private runYarn(task){
+  private runYarn(String task, String prepend = ""){
+    if (prepend && !prepend.endsWith(' ')) {
+      prepend += ' '
+    }
     boolean yarnV2OrNewer = isYarnV2OrNewer()
     if (steps.fileExists(NVMRC)) {
       steps.sh """
@@ -255,25 +258,43 @@ EOF
         if ${yarnV2OrNewer}; then
           export PATH=\$HOME/.local/bin:\$PATH
         fi
-        yarn ${task}
+
+        if ${prepend.toBoolean()}; then
+          ${prepend}yarn ${task}
+        else
+          yarn ${task}
+        fi
       """
     } else {
       steps.sh("""
         if ${yarnV2OrNewer}; then
           export PATH=\$HOME/.local/bin:\$PATH
         fi
-        yarn ${task}
+
+        if ${prepend.toBoolean()}; then
+          ${prepend}yarn ${task}
+        else
+          yarn ${task}
+        fi
       """)
     }
   }
 
-  private runYarnQuiet(task) {
+  private runYarnQuiet(String task, String prepend = "") {
+    if (prepend && !prepend.endsWith(' ')) {
+      prepend += ' '
+    }
     boolean yarnV2OrNewer = isYarnV2OrNewer()
     def status = steps.sh(script: """
         if ${yarnV2OrNewer}; then
           export PATH=\$HOME/.local/bin:\$PATH
         fi
-        yarn ${task} 1> /dev/null 2> /dev/null
+
+        if ${prepend.toBoolean()}; then
+          ${prepend}yarn ${task} 1> /dev/null 2> /dev/null
+        else
+          yarn ${task} 1> /dev/null 2> /dev/null
+        fi
     """, returnStatus: true)
     steps.echo("yarnQuiet ${task} -> ${status}")
     return status == 0  // only a 0 return status is success
@@ -294,7 +315,7 @@ EOF
     return status
   }
 
-  def yarn(task) {
+  def yarn(String task, String prepend = "") {
       boolean yarnV2OrNewer = isYarnV2OrNewer()
           if (yarnV2OrNewer && !steps.fileExists(INSTALL_CHECK_FILE)) {
               corepackEnable()
@@ -305,7 +326,7 @@ EOF
               runYarn("--mutex network install --frozen-lockfile")
               steps.sh("touch ${INSTALL_CHECK_FILE}")
           }
-      runYarn(task)
+      runYarn(task, prepend)
   }
 
   @Override

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -119,8 +119,6 @@ class YarnBuilder extends AbstractBuilder {
             . /opt/nvm/nvm.sh || true
             nvm install
             set -ex
-            wget -O /tmp/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
-            chmod +x /tmp/jq
           """
 
           if (yarnV2OrNewer) {
@@ -140,8 +138,8 @@ class YarnBuilder extends AbstractBuilder {
       } finally {
             if (yarnV2OrNewer) {
               steps.sh """
-              cat yarn-audit-result | /tmp/jq -c '. | {type: "auditSummary", data: .metadata}' > yarn-audit-issues-result-summary
-              cat yarn-audit-result | /tmp/jq -cr '.advisories| to_entries[] | {"type": "auditAdvisory", "data": { "advisory": .value }}' >> yarn-audit-issues-advisories
+              cat yarn-audit-result | jq -c '. | {type: "auditSummary", data: .metadata}' > yarn-audit-issues-result-summary
+              cat yarn-audit-result | jq -cr '.advisories| to_entries[] | {"type": "auditAdvisory", "data": { "advisory": .value }}' >> yarn-audit-issues-advisories
               cat  yarn-audit-issues-result-summary  yarn-audit-issues-advisories > yarn-audit-issues-result
               """
             }

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -248,9 +248,20 @@ EOF
     return status == 0  // only a 0 return status is success
   }
 
+  private isYarnV1() {
+    def status = steps.sh label:"Determine if is YarnV1", script: '''
+                ! grep \"packageManager\": package.json
+          ''', returnStatus: true
+    return status
+  }
+
   def yarn(task) {
     if (!steps.fileExists(INSTALL_CHECK_FILE) && !runYarnQuiet("check")) {
-      runYarn("--mutex network install --frozen-lockfile")
+      if (!isYarnV1()) {
+        runYarn("install")
+      } else {
+        runYarn("--mutex network install --frozen-lockfile")
+      }
       steps.sh("touch ${INSTALL_CHECK_FILE}")
     }
     runYarn(task)

--- a/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
@@ -49,19 +49,19 @@ class YarnBuilderTest extends Specification {
     when:
       builder.build()
     then:
-      1 * steps.sh(['script':'yarn check 1> /dev/null 2> /dev/null', 'returnStatus':true])
-      1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains('--mutex network install --frozen-lockfile') })
+      1 * steps.sh({ it.toString().contains('yarn check 1> /dev/null 2> /dev/null') })
+      1 * steps.sh({ it.contains('--mutex network install --frozen-lockfile') })
       1 * steps.sh({ it.contains('touch .yarn_dependencies_installed') })
-      1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains('lint') })
+      1 * steps.sh({ it.contains('lint') })
   }
 
   def "test calls 'yarn test' and 'yarn test:coverage' and 'yarn test:a11y'"() {
     when:
     builder.test()
     then:
-    1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains('test') })
-    1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains('test:coverage') })
-    1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains('test:a11y') })
+    1 * steps.sh({ it.contains('test') })
+    1 * steps.sh({ it.contains('test:coverage') })
+    1 * steps.sh({ it.contains('test:a11y') })
   }
 
   def "sonarScan calls 'yarn sonar-scan'"() {
@@ -75,21 +75,21 @@ class YarnBuilderTest extends Specification {
     when:
       builder.smokeTest()
     then:
-      1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains('test:smoke') })
+      1 * steps.sh({ it.contains('test:smoke') })
   }
 
   def "functionalTest calls 'yarn test:functional'"() {
     when:
       builder.functionalTest()
     then:
-      1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains('test:functional') })
+      1 * steps.sh({ it.contains('test:functional') })
   }
 
   def "apiGatewayTest calls 'yarn test:apiGateway'"() {
     when:
       builder.apiGatewayTest()
     then:
-      1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains('test:apiGateway') })
+      1 * steps.sh({ it.contains('test:apiGateway') })
   }
 
   def "crossBrowserTest calls 'yarn test:crossbrowser'"() {
@@ -100,7 +100,7 @@ class YarnBuilderTest extends Specification {
     when:
     builder.yarn("test:crossbrowser")
     then:
-    1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains('test:crossbrowser') })
+    1 * steps.sh({ it.contains('test:crossbrowser') })
   }
 
   def "crossBrowserTest calls 'BROWSER_GROUP=chrome yarn test:crossbrowser'"() {
@@ -116,7 +116,7 @@ class YarnBuilderTest extends Specification {
     when:
         builder.mutationTest()
     then:
-        1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains('test:mutation') })
+        1 * steps.sh({ it.contains('test:mutation') })
   }
 
   def "securityCheck calls 'yarn audit'"() {
@@ -130,7 +130,7 @@ class YarnBuilderTest extends Specification {
     when:
         builder.fullFunctionalTest()
     then:
-        1*steps.sh({ it.startsWith(YARN_CMD) && it.contains('test:fullfunctional') })
+        1*steps.sh({ it.contains('test:fullfunctional') })
   }
 
   def "runProviderVerification triggers a yarn hook with publish"() {


### PR DESCRIPTION
This adds support for yarn v3 while maintaining compatibility for yarn v1.

[corepack](https://github.com/nodejs/corepack#-corepack ) is used to install yarn v3 on-demand

For example upgrade PR see https://github.com/hmcts/sds-toffee-frontend/pull/52
Make sure you're using the node version >14 which includes corepack.

We recommend to use [zero-installs](https://yarnpkg.com/features/zero-installs) this will mean that you don't need to run `yarn install` when you swap between branches and the network will not need to be contacted as all files are checked into the repo (unless your app on-demand downloads something like puppeteer, this will still work with zero-installs though).

Yarn v1 entered maintenance mode in January 2020 and has received no new features since then.

It is recommended to upgrade so that you stay on a modern tool chain and get the performance benefits that come with it.

The express.js templates will be updated next sprint so that all new apps use yarn v3
