### PR TITLE
Revert "Switch to on agent sonar-scanner"

### DIFF
--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -33,7 +33,7 @@ class YarnBuilder extends AbstractBuilder {
   def sonarScan() {
     String properties = SonarProperties.get(steps)
 
-    steps.sh "sonar-scanner ${properties}"
+    yarn("sonar-scan ${properties}")
   }
 
   def highLevelDataSetup(String dataSetupEnvironment) {

--- a/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
@@ -59,6 +59,9 @@ class YarnBuilderTest extends Specification {
     when:
     builder.test()
     then:
+    1 * steps.sh(['script':'yarn check 1> /dev/null 2> /dev/null', 'returnStatus':true])
+    1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains('--mutex network install --frozen-lockfile') })
+    1 * steps.sh({ it.contains('touch .yarn_dependencies_installed') })
     1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains('test') })
     1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains('test:coverage') })
     1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains('test:a11y') })
@@ -68,13 +71,19 @@ class YarnBuilderTest extends Specification {
     when:
       builder.sonarScan()
     then:
-      1 * steps.sh({ it.contains('sonar-scan') })
+      1 * steps.sh(['script':'yarn check 1> /dev/null 2> /dev/null', 'returnStatus':true])
+      1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains('--mutex network install --frozen-lockfile') })
+      1 * steps.sh({ it.contains('touch .yarn_dependencies_installed') })
+      1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains('sonar-scan') })
   }
 
   def "smokeTest calls 'yarn test:smoke'"() {
     when:
       builder.smokeTest()
     then:
+      1 * steps.sh(['script':'yarn check 1> /dev/null 2> /dev/null', 'returnStatus':true])
+      1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains('--mutex network install --frozen-lockfile') })
+      1 * steps.sh({ it.contains('touch .yarn_dependencies_installed') })
       1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains('test:smoke') })
   }
 
@@ -82,6 +91,9 @@ class YarnBuilderTest extends Specification {
     when:
       builder.functionalTest()
     then:
+      1 * steps.sh(['script':'yarn check 1> /dev/null 2> /dev/null', 'returnStatus':true])
+      1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains('--mutex network install --frozen-lockfile') })
+      1 * steps.sh({ it.contains('touch .yarn_dependencies_installed') })
       1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains('test:functional') })
   }
 
@@ -89,6 +101,9 @@ class YarnBuilderTest extends Specification {
     when:
       builder.apiGatewayTest()
     then:
+      1 * steps.sh(['script':'yarn check 1> /dev/null 2> /dev/null', 'returnStatus':true])
+      1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains('--mutex network install --frozen-lockfile') })
+      1 * steps.sh({ it.contains('touch .yarn_dependencies_installed') })
       1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains('test:apiGateway') })
   }
 
@@ -100,6 +115,9 @@ class YarnBuilderTest extends Specification {
     when:
     builder.yarn("test:crossbrowser")
     then:
+    1 * steps.sh(['script':'yarn check 1> /dev/null 2> /dev/null', 'returnStatus':true])
+    1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains('--mutex network install --frozen-lockfile') })
+    1 * steps.sh({ it.contains('touch .yarn_dependencies_installed') })
     1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains('test:crossbrowser') })
   }
 
@@ -116,6 +134,9 @@ class YarnBuilderTest extends Specification {
     when:
         builder.mutationTest()
     then:
+        1 * steps.sh(['script':'yarn check 1> /dev/null 2> /dev/null', 'returnStatus':true])
+        1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains('--mutex network install --frozen-lockfile') })
+        1 * steps.sh({ it.contains('touch .yarn_dependencies_installed') })
         1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains('test:mutation') })
   }
 
@@ -130,6 +151,9 @@ class YarnBuilderTest extends Specification {
     when:
         builder.fullFunctionalTest()
     then:
+        1 * steps.sh(['script':'yarn check 1> /dev/null 2> /dev/null', 'returnStatus':true])
+        1 * steps.sh({ it.startsWith(YARN_CMD) && it.contains('--mutex network install --frozen-lockfile') })
+        1 * steps.sh({ it.contains('touch .yarn_dependencies_installed') })
         1*steps.sh({ it.startsWith(YARN_CMD) && it.contains('test:fullfunctional') })
   }
 


### PR DESCRIPTION
Reverts hmcts/cnp-jenkins-library#888

Temp revert as per discussion with Tim - builds failing on old agents that have been left (can be sorted later)