### PR TITLE
commenting sauce publishing to resolve build failures

### DIFF
--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -75,7 +75,7 @@ class YarnBuilder extends AbstractBuilder {
     }
     finally {
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/crossbrowser/reports/**/*'
-      steps.saucePublisher()
+      //steps.saucePublisher()  //commenting out publishing as all the builds are failing on publish
     }
   }
 
@@ -87,7 +87,7 @@ class YarnBuilder extends AbstractBuilder {
     }
     finally {
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: "functional-output/$browser*/*"
-      steps.saucePublisher()
+      //steps.saucePublisher()  //commenting out publishing as all the builds are failing on publish
     }
   }
 

--- a/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
@@ -109,7 +109,7 @@ class YarnBuilderTest extends Specification {
     then:
     1 * steps.sh({ it.contains('BROWSER_GROUP=chrome yarn test:crossbrowser') })
     1 * steps.archiveArtifacts(['allowEmptyArchive':true, artifacts: "functional-output/chrome*/*"])
-    1 * steps.saucePublisher()
+   // 1 * steps.saucePublisher() //commenting out publishing
   }
 
   def "mutationTest calls 'yarn test:mutation'"() {


### PR DESCRIPTION
fixing the cross browser builds by temporarily commenting out sauce publish which causing the issue

Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
* As all teams cross browser tests are failing at saucelabs publishing so commenting out sauce publish for now
*
*
