### PR TITLE
Add component to build lock on AKS deploy

### DIFF
--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -53,7 +53,7 @@ def call(params) {
   def testLabels = gitHubAPI.getLabelsbyPattern(env.BRANCH_NAME, 'enable_')
   def depLabel = gitHubAPI.checkForDependenciesLabel(env.BRANCH_NAME)
 
-  lock("${deploymentProduct}-${environment}-deploy") {
+  lock("${deploymentProduct}-${component}-${environment}-deploy") {
     stageWithAgent("AKS deploy - ${environment}", product) {
       withTeamSecrets(config, environment) {
         pcr.callAround('akschartsinstall') {


### PR DESCRIPTION

* Currently rd-professional-api master is waiting for rd-user-profile-api master helm deployment and tests to finish.
