### PR TITLE
Adding support for the old and new Gatling Gradle plugins

### DIFF
--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -245,7 +245,8 @@ EOF
 
   @Override
   def performanceTest() {
-    if (hasPlugin("gradle-gatling-plugin")) {
+    //support for the old (deprecated) and new gatling gradle plugins
+    if (hasPlugin("gradle-gatling-plugin") || hasPlugin("gatling-gradle-plugin")) {
       localSteps.env.GATLING_REPORTS_PATH = 'build/reports/gatling'
       localSteps.env.GATLING_REPORTS_DIR =  '$WORKSPACE/' + localSteps.env.GATLING_REPORTS_PATH
       gradle("gatlingRun")

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -245,8 +245,8 @@ EOF
 
   @Override
   def performanceTest() {
-    //support for the old (deprecated) and new gatling gradle plugins
-    if (hasPlugin("gradle-gatling-plugin") || hasPlugin("gatling-gradle-plugin")) {
+    //support for the new and old (deprecated) gatling gradle plugins
+    if (hasPlugin("gatling-gradle-plugin") || hasPlugin("gradle-gatling-plugin")) {
       localSteps.env.GATLING_REPORTS_PATH = 'build/reports/gatling'
       localSteps.env.GATLING_REPORTS_DIR =  '$WORKSPACE/' + localSteps.env.GATLING_REPORTS_PATH
       gradle("gatlingRun")


### PR DESCRIPTION
Notes:
* Adds support for the new Gatling Gradle plugin, while remaining for the old deprecated plugin
* New plugin - io.gatling.gradle
* Old plugin - com.github.lkishalmi.gatling
