### PR TITLE
Add git commit hash to pipeline metrics

### DIFF
--- a/src/uk/gov/hmcts/contino/MetricsPublisher.groovy
+++ b/src/uk/gov/hmcts/contino/MetricsPublisher.groovy
@@ -38,6 +38,7 @@ class MetricsPublisher implements Serializable {
       build_url                    : env.BUILD_URL,
       job_url                      : env.JOB_URL,
       git_url                      : env.GIT_URL,
+      git_commit                   : env.GIT_COMMIT,
       current_build_number         : currentBuild.number,
       current_step_name            : currentStepName,
       current_build_result         : currentBuild.result,


### PR DESCRIPTION
Add in the git commit hash to the pipeline metrics so we can connect github merged PRs to pipeline runs.