### PR TITLE
Move High level data setup in preview to post helm install

### DIFF
--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -80,7 +80,7 @@ def call(params) {
         appPipelineConfig: config,
         pipelineCallbacksRunner: pcr,
         builder: builder,
-        environment: environment.previewName,
+        environment: environment,
         product: product,
       )
     }

--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -75,7 +75,15 @@ def call(params) {
         }
       }
     }
-
+    onPR {
+      highLevelDataSetup(
+        appPipelineConfig: config,
+        pipelineCallbacksRunner: pcr,
+        builder: builder,
+        environment: environment.previewName,
+        product: product,
+      )
+    }
     if (config.serviceApp) {
       withSubscriptionLogin(subscription) {
         withTeamSecrets(config, environment) {

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -121,14 +121,6 @@ def call(type, String product, String component, Closure body) {
             )
           }
 
-          highLevelDataSetup(
-            appPipelineConfig: pipelineConfig,
-            pipelineCallbacksRunner: callbacksRunner,
-            builder: pipelineType.builder,
-            environment: environment.previewName,
-            product: product,
-          )
-
           sectionDeployToAKS(
             appPipelineConfig: pipelineConfig,
             pipelineCallbacksRunner: callbacksRunner,


### PR DESCRIPTION
- Currently it runs before preview deploy, which is of no use for PR pipelines. 
- I have moved this to after AKS deploy for it to be used for deploying preview defintion.
- Tested in https://build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_a_to_c%2Fcivil-ccd-definition/detail/PR-1610/7/pipeline/ 
 
