### PR TITLE
Disable docker steps if docker file not present

### DIFF
--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -86,7 +86,7 @@ def call(params) {
       }
     }
     echo("Docker file exists: ${env.DOCKER_IMAGE_EXISTS}")
-    if (env.DOCKER_IMAGE_EXISTS) {
+    if (${env.DOCKER_IMAGE_EXISTS}) {
       branches["Docker Build"] = {
         withAcrClient(subscription) {
           def acbTemplateFilePath = 'acb.tpl.yaml'

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -37,6 +37,7 @@ def call(params) {
     }
   }
   env.DOCKER_IMAGE_EXISTS= fileExists('Dockerfile')
+  echo("Docker file exists: ${env.DOCKER_IMAGE_EXISTS}")
   onPathToLive {
     stageWithAgent("Build", product) {
       onPR {

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -37,7 +37,6 @@ def call(params) {
     }
   }
   env.DOCKER_IMAGE_EXISTS= fileExists('Dockerfile')
-  echo("Docker file exists: ${env.DOCKER_IMAGE_EXISTS}")
   onPathToLive {
     stageWithAgent("Build", product) {
       onPR {
@@ -86,6 +85,7 @@ def call(params) {
         builder.securityCheck()
       }
     }
+    echo("Docker file exists: ${env.DOCKER_IMAGE_EXISTS}")
     if (env.DOCKER_IMAGE_EXISTS) {
       branches["Docker Build"] = {
         withAcrClient(subscription) {

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -36,7 +36,6 @@ def call(params) {
       echo("Checking if we should skip image build, tag: ${projectBranch.imageTag()}, git commit: ${env.GIT_COMMIT}, timestamp: ${env.LAST_COMMIT_TIMESTAMP}, hasTag: ${hasTag}, hasOverride: ${envOverrideForSkip}, result: ${!noSkipImgBuild}")
     }
   }
-  env.DOCKER_IMAGE_EXISTS= fileExists('Dockerfile')
   onPathToLive {
     stageWithAgent("Build", product) {
       onPR {
@@ -85,8 +84,7 @@ def call(params) {
         builder.securityCheck()
       }
     }
-    echo("Docker file exists: ${env.DOCKER_IMAGE_EXISTS}")
-    if (${env.DOCKER_IMAGE_EXISTS}) {
+    if (fileExists('Dockerfile')) {
       branches["Docker Build"] = {
         withAcrClient(subscription) {
           def acbTemplateFilePath = 'acb.tpl.yaml'
@@ -116,7 +114,7 @@ def call(params) {
     }
 
     onMaster {
-      if (fileExists('build.gradle') && env.DOCKER_IMAGE_EXISTS) {
+      if (fileExists('build.gradle') && fileExists('Dockerfile')) {
         branches["Docker Test Build"] = {
           withAcrClient(subscription) {
             def dockerfileTest = 'Dockerfile_test'

--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -41,8 +41,11 @@ def call(params) {
     imageRegistry = env.TEAM_CONTAINER_REGISTRY ?: env.REGISTRY_NAME
     acr = new Acr(this, subscription, imageRegistry, env.REGISTRY_RESOURCE_GROUP, env.REGISTRY_SUBSCRIPTION)
     dockerImage = new DockerImage(product, component, acr, projectBranch.imageTag(), env.GIT_COMMIT, env.LAST_COMMIT_TIMESTAMP)
-    onPR {
-      acr.retagForStage(DockerImage.DeploymentStage.PR, dockerImage)
+    fileExists('Dockerfile'){
+      onPR {
+        acr.retagForStage(DockerImage.DeploymentStage.PR, dockerImage)
+      }
+    }
     }
   }
 

--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -41,11 +41,10 @@ def call(params) {
     imageRegistry = env.TEAM_CONTAINER_REGISTRY ?: env.REGISTRY_NAME
     acr = new Acr(this, subscription, imageRegistry, env.REGISTRY_RESOURCE_GROUP, env.REGISTRY_SUBSCRIPTION)
     dockerImage = new DockerImage(product, component, acr, projectBranch.imageTag(), env.GIT_COMMIT, env.LAST_COMMIT_TIMESTAMP)
-    fileExists('Dockerfile'){
+    if (fileExists('Dockerfile')) {
       onPR {
         acr.retagForStage(DockerImage.DeploymentStage.PR, dockerImage)
       }
-    }
     }
   }
 

--- a/vars/sectionPromoteBuildToStage.groovy
+++ b/vars/sectionPromoteBuildToStage.groovy
@@ -26,7 +26,7 @@ import uk.gov.hmcts.contino.azure.Acr
 
 def call(params) {
 
-  if(env.DOCKER_IMAGE_EXISTS) {
+  if(fileExists('Dockerfile')) {
     PipelineCallbacksRunner pcr = params.pipelineCallbacksRunner
     AppPipelineConfig config = params.appPipelineConfig
     PipelineType pipelineType = params.pipelineType

--- a/vars/sectionPromoteBuildToStage.groovy
+++ b/vars/sectionPromoteBuildToStage.groovy
@@ -26,17 +26,18 @@ import uk.gov.hmcts.contino.azure.Acr
 
 def call(params) {
 
-  PipelineCallbacksRunner pcr = params.pipelineCallbacksRunner
-  AppPipelineConfig config = params.appPipelineConfig
-  PipelineType pipelineType = params.pipelineType
+  if(env.DOCKER_IMAGE_EXISTS) {
+    PipelineCallbacksRunner pcr = params.pipelineCallbacksRunner
+    AppPipelineConfig config = params.appPipelineConfig
+    PipelineType pipelineType = params.pipelineType
 
-  def subscription = params.subscription
-  def product = params.product
-  def component = params.component
-  DockerImage.DeploymentStage deploymentStage = params.stage
+    def subscription = params.subscription
+    def product = params.product
+    def component = params.component
+    DockerImage.DeploymentStage deploymentStage = params.stage
 
-  stageWithAgent("${deploymentStage.label} build promotion", product) {
-    withAcrClient(subscription) {
+    stageWithAgent("${deploymentStage.label} build promotion", product) {
+      withAcrClient(subscription) {
         def imageRegistry = env.TEAM_CONTAINER_REGISTRY ?: env.REGISTRY_NAME
         def projectBranch = new ProjectBranch(env.BRANCH_NAME)
         def acr = new Acr(this, subscription, imageRegistry, env.REGISTRY_RESOURCE_GROUP, env.REGISTRY_SUBSCRIPTION)
@@ -56,5 +57,6 @@ def call(params) {
           }
         }
       }
+    }
   }
 }


### PR DESCRIPTION
Notes:
* withPipeline is currently used for repos like ccd-definition, camunda-definition and they add a dummy docker file which goes through entire lifecycle in the pipeline for no reason.
