### PR TITLE
Remove invalid condition

### DIFF
--- a/vars/helmInstall.groovy
+++ b/vars/helmInstall.groovy
@@ -143,7 +143,7 @@ def call(DockerImage dockerImage, Map params) {
         echo "Install/upgrade completed(${attempts})."
         break
       } catch (upgradeError) {
-        if (!deleted || attempts >= 3) {
+        if (attempts >= 3) {
           throw upgradeError
         }
         // Clean up the latest install/upgrade attempt


### PR DESCRIPTION
Notes:
* It is always set to false https://github.com/hmcts/cnp-jenkins-library/blob/6cad83179875808ca865f4e2d7ff292891b786d0/vars/helmInstall.groovy#L128 and won't be set to true unless first attempt fails.
* Original author may be wanted it to be below so that we don't need to delete the ones already deleted at start. But i don't see a reason with deleting again and retrying. 

```
if (deleted || attempts >= 3) {
          throw upgradeError
}
```
