### PR TITLE
Add Conditions to after for better display and reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,15 @@ Branch | HighDataSetup Stage
 
 It is not possible to remove stages from the pipeline but it is possible to _add_ extra steps to the existing stages.
 
-You can use the `before(stage)` and `after(stage)` within the `withPipeline` block to add extra steps at the beginning or end of a named stage. Valid values for the `stage` variable are as follows where `ENV` must be replaced by the short environment name
+You can use the `before(stage)` and `after<Condition>(stage)` within the `withPipeline` block to add extra steps at the beginning or end of a named stage.
+
+Conditions are:
+
+* Success
+* Failure
+* Always
+
+Valid values for the `stage` variable are as follows where `ENV` must be replaced by the short environment name
 
  * checkout
  * build
@@ -214,11 +222,11 @@ withPipeline(type, product, component) {
 
   ...
 
-  after('checkout') {
+  afterSuccess('checkout') {
     echo 'Checked out'
   }
 
-  after('build') {
+  afterSuccess('build') {
     sh 'yarn setup'
   }
 }
@@ -319,7 +327,15 @@ withInfraPipeline(product, component) {
 
 It is not possible to remove stages from the pipeline but it is possible to _add_ extra steps to the existing stages.
 
-You can use the `before(stage)` and `after(stage)` within the `withInfraPipeline` block to add extra steps at the beginning or end of a named stage. Valid values for the `stage` variable are as follows where `ENV` should be replaced by the short environment name
+You can use the `before(stage)` and `after<Condition>(stage)` within the `withInfraPipeline` block to add extra steps at the beginning or end of a named stage.
+
+Conditions are:
+
+* Success
+* Failure
+* Always
+
+Valid values for the `stage` variable are as follows where `ENV` should be replaced by the short environment name:
 
  * checkout
  * buildinfra:ENV
@@ -331,7 +347,7 @@ withInfraPipeline(product) {
 
   ...
 
-  after('checkout') {
+  afterSuccess('checkout') {
     echo 'Checked out'
   }
 
@@ -385,7 +401,14 @@ When initially setting up the nightly pipeline for use in your repo, you should 
 
 #### Extending the test pipeline
 
-You can use the `before(stage)` and `after(stage)` within the `withNightlyPipeline` block to add extra steps at the beginning or end of a named stage.
+You can use the `before(stage)` and `after<Condition>(stage)` within the `withNightlyPipeline` block to add extra steps at the beginning or end of a named stage.
+
+Conditions are:
+
+* Success
+* Failure
+* Always
+
 ```
 withNightlyPipeline(type, product, component) {
   enableCrossBrowserTest()
@@ -396,11 +419,11 @@ withNightlyPipeline(type, product, component) {
     yarnBuilder.smokeTest()
   }
 
-  after('crossBrowserTest') {
+  afterAlways('crossBrowserTest') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/crossbrowser/reports/**/*'
   }
 
-  after('fullFunctionalTest') {
+  afterAlways('fullFunctionalTest') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/functional/reports/**/*'
   }
 }

--- a/src/uk/gov/hmcts/contino/CommonPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/CommonPipelineDsl.groovy
@@ -23,6 +23,18 @@ abstract class CommonPipelineDsl implements Serializable {
     callbacks.registerAfter(stage, body)
   }
 
+  void afterSuccess(String stage, Closure body) {
+    callbacks.registerAfter(stage, 'success', body)
+  }
+
+  void afterFailure(String stage, Closure body) {
+    callbacks.registerAfter(stage, 'failure', body)
+  }
+
+  void afterAlways(String stage, Closure body) {
+    callbacks.registerAfter(stage, 'always', body)
+  }
+
   void onStageFailure(Closure body) {
     callbacks.registerOnStageFailure(body)
   }

--- a/src/uk/gov/hmcts/contino/PipelineCallbacksConfig.groovy
+++ b/src/uk/gov/hmcts/contino/PipelineCallbacksConfig.groovy
@@ -11,6 +11,10 @@ class PipelineCallbacksConfig {
     bodies.put('after:' + stage, body)
   }
 
+  void registerAfter(String stage, String condition, Closure body) {
+    bodies.put('after:' + stage + ':' + condition, body)
+  }
+
   void registerOnStageFailure(Closure body) {
     bodies.put('onStageFailure', body)
   }

--- a/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
@@ -156,7 +156,7 @@ class GradleBuilderTest extends Specification {
 
     then:
     // Report has 2 dependencies with vulnerabilities and 3 with suppressed vulnerabilities.
-    result.dependencies.size == 5
+    result.dependencies.size() == 5
     // Only dependencies with vulnerabilities or suppressed vulnerabilities should be reported
     result.dependencies.every {
       it.vulnerabilities || it.suppressedVulnerabilities


### PR DESCRIPTION
Fixes a few issues:

1. Errors in after callbacks currently prevent metrics being collected because they are executed in a finally block before the metrics
2. Some builds run their integration tests in an after callback, we've seen cases where compilation has failed or unit tests have failed and then the integration tests run anyway, causing confusion and misreporting in metrics. These should be swapped to `afterSuccess`.
3. (similar to 2) General confusion that after block runs even when build failed, and so you get an error at the bottom of your build log when the actual build cause was further up.

This introduces 3 conditions that you can use to select when you want the callbacks to run:

- failure
- sucess
- always

I've also deprecated the default after so we don't have these reporting issues forever.

Tested in https://github.com/hmcts/draft-store/pull/1150

![image](https://user-images.githubusercontent.com/21194782/203763971-4f4f2674-92f1-413c-941f-d0519662c9c4.png)
