### PR TITLE
DTSPO-8276 - Update terraform validate

### DIFF
--- a/vars/infraModuleTesting.groovy
+++ b/vars/infraModuleTesting.groovy
@@ -5,7 +5,7 @@ def call () {
   }
 
   stage('Terraform Linting Checks') {
-    sh 'terraform validate -check-variables=false -no-color'
+    sh 'terraform validate -no-color'
   }
 
   stage('Integration tests') {


### PR DESCRIPTION
### JIRA link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-8276

### Change description

Terraform validate no longer has a -check-variables switch
This is causing pipeline checks to fail

### Does this PR introduce a breaking change? (check one with "x")

```
[ ] Yes
[x] No
```
