### PR TITLE
Improvements for logging on AKS failure

### DIFF
--- a/resources/uk/gov/hmcts/helm/aks-debug-info.sh
+++ b/resources/uk/gov/hmcts/helm/aks-debug-info.sh
@@ -41,7 +41,7 @@ Logs for crashing pod $podName:
 kubectl logs  -n "${NAMESPACE}" ${podName} -p
 "
 
-  kubectl logs -n "${NAMESPACE}" ${podName} -p
+  kubectl logs -n "${NAMESPACE}" ${podName} -p | colour_print
 
 done
 

--- a/resources/uk/gov/hmcts/helm/aks-debug-info.sh
+++ b/resources/uk/gov/hmcts/helm/aks-debug-info.sh
@@ -5,17 +5,17 @@ export TERM=xterm-256color
 
 echo "
 $(tput setaf 3)See below debug information to help troubleshooting the issue.
-================================================================================
-kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
+$(tput setaf 3)================================================================================
+$(tput setaf 3)kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
 "
 
-tput setaf 3; kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
+kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
 
 echo "$(tput setaf 3)================================================================================
-kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
+$(tput setaf 3)kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
 "
 
-tput setaf 3; kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
+kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
 
 # Commenting describe output as that is already covered by events on the namespace
 # echo "
@@ -28,8 +28,8 @@ tput setaf 3; kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance=
 for podName in $(kubectl get pods -n "${NAMESPACE}" -l app.kubernetes.io/instance="${RELEASE_NAME}" -o json | jq  -r '.items[] | select(.status.containerStatuses[] | ((.ready|not) and .state.waiting.reason=="CrashLoopBackOff")) |  .metadata.name'); do
 echo "
 $(tput setaf 3)================================================================================
-Logs for crashing pod $podName:
-kubectl logs  -n "${NAMESPACE}" ${podName} -p
+$(tput setaf 3)Logs for crashing pod $podName:
+$(tput setaf 3)kubectl logs  -n "${NAMESPACE}" ${podName} -p
 "
 tput setaf 3; kubectl logs  -n "${NAMESPACE}" ${podName} -p
 

--- a/resources/uk/gov/hmcts/helm/aks-debug-info.sh
+++ b/resources/uk/gov/hmcts/helm/aks-debug-info.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
+
 RELEASE_NAME=${1}
 NAMESPACE=${2}
-export TERM=xterm-256color
 
-tput setaf 3; echo -e "See below debug information to help troubleshooting the issue.\n ====================================================\n kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n ${NAMESPACE} | grep  ${RELEASE_NAME}"
+function execute_command () {
+tput setaf 3;
+"$@"
+tput sgr0
+}
 
+echo "
+
+See below debug information to help troubleshooting the issue.
+================================================================================
 kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
-
-tput setaf 3; echo -e "====================================================\n kubectl get pods -n ${NAMESPACE}  -l app.kubernetes.io/instance=${RELEASE_NAME}"
-
+"
+kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" |execute_command grep  "${RELEASE_NAME}"
+echo "
+================================================================================
 kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
 
+"
+execute_command kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
 # Commenting describe output as that is already covered by events on the namespace
 # echo "
 #================================================================================
@@ -20,9 +31,14 @@ kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAM
 #kubectl get pods -n "${NAMESPACE}" -l app.kubernetes.io/instance="${RELEASE_NAME}" --field-selector status.phase=Pending -o json | jq '.items[] |  .metadata.name' | xargs kubectl describe pods -n "${NAMESPACE}"
 
 for podName in $(kubectl get pods -n "${NAMESPACE}" -l app.kubernetes.io/instance="${RELEASE_NAME}" -o json | jq  -r '.items[] | select(.status.containerStatuses[] | ((.ready|not) and .state.waiting.reason=="CrashLoopBackOff")) |  .metadata.name'); do
-tput setaf 3; echo -e "====================================================\n Logs for crashing pod $podName: \n kubectl logs  -n ${NAMESPACE} ${podName} -p"
 
+echo "
+================================================================================
+Logs for crashing pod $podName:
 kubectl logs  -n "${NAMESPACE}" ${podName} -p
+"
+
+execute_command kubectl logs  -n "${NAMESPACE}" ${podName} -p
 
 done
 

--- a/resources/uk/gov/hmcts/helm/aks-debug-info.sh
+++ b/resources/uk/gov/hmcts/helm/aks-debug-info.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 RELEASE_NAME=${1}
 NAMESPACE=${2}
+export TERM=xterm-256color
 
 echo "
 

--- a/resources/uk/gov/hmcts/helm/aks-debug-info.sh
+++ b/resources/uk/gov/hmcts/helm/aks-debug-info.sh
@@ -3,19 +3,22 @@
 RELEASE_NAME=${1}
 NAMESPACE=${2}
 echo "
+
 See below debug information to help troubleshooting the issue.
 ================================================================================
 kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
 "
+tput setaf 4;
 kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
-
+tput sgr0
 echo "
 ================================================================================
 kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
 
 "
+tput setaf 4;
 kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
-
+tput sgr0
 # Commenting describe output as that is already covered by events on the namespace
 # echo "
 #================================================================================
@@ -31,8 +34,9 @@ echo "
 Logs for crashing pod $podName:
 kubectl logs  -n "${NAMESPACE}" ${podName} -p
 "
-
+tput setaf 4;
 kubectl logs  -n "${NAMESPACE}" ${podName} -p
+tput sgr0
 done
 
 exit 1

--- a/resources/uk/gov/hmcts/helm/aks-debug-info.sh
+++ b/resources/uk/gov/hmcts/helm/aks-debug-info.sh
@@ -2,7 +2,7 @@
 
 RELEASE_NAME=${1}
 NAMESPACE=${2}
-
+export TERM=xterm-256color
 function execute_command () {
 tput setaf 3;
 "$@"

--- a/resources/uk/gov/hmcts/helm/aks-debug-info.sh
+++ b/resources/uk/gov/hmcts/helm/aks-debug-info.sh
@@ -2,24 +2,26 @@
 RELEASE_NAME=${1}
 NAMESPACE=${2}
 export TERM=xterm-256color
-
+tput setaf 3
 echo "
 
 See below debug information to help troubleshooting the issue.
 ================================================================================
 kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
 "
-tput setaf 3
-kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
 tput sgr0
+kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
+
+tput setaf 3
 echo "
 ================================================================================
 kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
 
 "
-tput setaf 3
-kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
 tput sgr0
+
+kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
+
 # Commenting describe output as that is already covered by events on the namespace
 # echo "
 #================================================================================
@@ -29,16 +31,14 @@ tput sgr0
 #kubectl get pods -n "${NAMESPACE}" -l app.kubernetes.io/instance="${RELEASE_NAME}" --field-selector status.phase=Pending -o json | jq '.items[] |  .metadata.name' | xargs kubectl describe pods -n "${NAMESPACE}"
 
 for podName in $(kubectl get pods -n "${NAMESPACE}" -l app.kubernetes.io/instance="${RELEASE_NAME}" -o json | jq  -r '.items[] | select(.status.containerStatuses[] | ((.ready|not) and .state.waiting.reason=="CrashLoopBackOff")) |  .metadata.name'); do
-
+tput setaf 3
 echo "
 ================================================================================
 Logs for crashing pod $podName:
 kubectl logs  -n "${NAMESPACE}" ${podName} -p
 "
-
-tput setaf 3
-kubectl logs  -n "${NAMESPACE}" ${podName} -p
 tput sgr0
+kubectl logs  -n "${NAMESPACE}" ${podName} -p
 
 done
 

--- a/resources/uk/gov/hmcts/helm/aks-debug-info.sh
+++ b/resources/uk/gov/hmcts/helm/aks-debug-info.sh
@@ -2,11 +2,12 @@
 
 RELEASE_NAME=${1}
 NAMESPACE=${2}
-
-function execute_command () {
-tput setaf 3;
-"$@"
-tput sgr0
+export TERM=xterm-256color
+function colour_print () {
+while read -r line
+do
+    tput setaf 3; echo "$line"
+done
 }
 
 echo "
@@ -15,13 +16,13 @@ See below debug information to help troubleshooting the issue.
 ================================================================================
 kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
 "
-kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" |execute_command grep  "${RELEASE_NAME}"
+kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}" | colour_print
 echo "
 ================================================================================
 kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
 
 "
-execute_command kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
+kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}" | colour_print
 # Commenting describe output as that is already covered by events on the namespace
 # echo "
 #================================================================================
@@ -38,7 +39,7 @@ Logs for crashing pod $podName:
 kubectl logs  -n "${NAMESPACE}" ${podName} -p
 "
 
-execute_command kubectl logs  -n "${NAMESPACE}" ${podName} -p
+kubectl logs  -n "${NAMESPACE}" ${podName} -p | colour_print
 
 done
 

--- a/resources/uk/gov/hmcts/helm/aks-debug-info.sh
+++ b/resources/uk/gov/hmcts/helm/aks-debug-info.sh
@@ -8,7 +8,7 @@ See below debug information to help troubleshooting the issue.
 ================================================================================
 kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
 "
-tput setaf 4;
+tput setaf 3;
 kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
 tput sgr0
 echo "
@@ -16,7 +16,7 @@ echo "
 kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
 
 "
-tput setaf 4;
+tput setaf 3;
 kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
 tput sgr0
 # Commenting describe output as that is already covered by events on the namespace
@@ -34,7 +34,7 @@ echo "
 Logs for crashing pod $podName:
 kubectl logs  -n "${NAMESPACE}" ${podName} -p
 "
-tput setaf 4;
+tput setaf 3;
 kubectl logs  -n "${NAMESPACE}" ${podName} -p
 tput sgr0
 done

--- a/resources/uk/gov/hmcts/helm/aks-debug-info.sh
+++ b/resources/uk/gov/hmcts/helm/aks-debug-info.sh
@@ -1,13 +1,6 @@
 #!/bin/bash
-
 RELEASE_NAME=${1}
 NAMESPACE=${2}
-export TERM=xterm-256color
-function execute_command () {
-tput setaf 3;
-"$@"
-tput sgr0
-}
 
 echo "
 
@@ -15,13 +8,17 @@ See below debug information to help troubleshooting the issue.
 ================================================================================
 kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
 "
-execute_command kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
+tput setaf 3
+kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
+tput sgr0
 echo "
 ================================================================================
 kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
 
 "
-execute_command kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
+tput setaf 3
+kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
+tput sgr0
 # Commenting describe output as that is already covered by events on the namespace
 # echo "
 #================================================================================
@@ -38,7 +35,9 @@ Logs for crashing pod $podName:
 kubectl logs  -n "${NAMESPACE}" ${podName} -p
 "
 
-execute_command kubectl logs  -n "${NAMESPACE}" ${podName} -p
+tput setaf 3
+kubectl logs  -n "${NAMESPACE}" ${podName} -p
+tput sgr0
 
 done
 

--- a/resources/uk/gov/hmcts/helm/aks-debug-info.sh
+++ b/resources/uk/gov/hmcts/helm/aks-debug-info.sh
@@ -2,23 +2,18 @@
 RELEASE_NAME=${1}
 NAMESPACE=${2}
 export TERM=xterm-256color
-tput setaf 3
-echo "
 
-See below debug information to help troubleshooting the issue.
+echo "
+$(tput setaf 3)See below debug information to help troubleshooting the issue.
 ================================================================================
 kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
-"
-tput sgr0
+$(tput sgr0)"
+
 kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
 
-tput setaf 3
-echo "
-================================================================================
+echo "$(tput setaf 3)================================================================================
 kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
-
-"
-tput sgr0
+$(tput sgr0)"
 
 kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
 
@@ -31,13 +26,11 @@ kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAM
 #kubectl get pods -n "${NAMESPACE}" -l app.kubernetes.io/instance="${RELEASE_NAME}" --field-selector status.phase=Pending -o json | jq '.items[] |  .metadata.name' | xargs kubectl describe pods -n "${NAMESPACE}"
 
 for podName in $(kubectl get pods -n "${NAMESPACE}" -l app.kubernetes.io/instance="${RELEASE_NAME}" -o json | jq  -r '.items[] | select(.status.containerStatuses[] | ((.ready|not) and .state.waiting.reason=="CrashLoopBackOff")) |  .metadata.name'); do
-tput setaf 3
 echo "
-================================================================================
+$(tput setaf 3)================================================================================
 Logs for crashing pod $podName:
 kubectl logs  -n "${NAMESPACE}" ${podName} -p
-"
-tput sgr0
+$(tput sgr0)"
 kubectl logs  -n "${NAMESPACE}" ${podName} -p
 
 done

--- a/resources/uk/gov/hmcts/helm/aks-debug-info.sh
+++ b/resources/uk/gov/hmcts/helm/aks-debug-info.sh
@@ -3,11 +3,10 @@
 RELEASE_NAME=${1}
 NAMESPACE=${2}
 export TERM=xterm-256color
-function colour_print () {
-while read -r line
-do
+function colour_print() {
+  while read -r line; do
     tput setaf 3; echo "$line"
-done
+  done
 }
 
 echo "
@@ -16,13 +15,13 @@ See below debug information to help troubleshooting the issue.
 ================================================================================
 kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
 "
-kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}" | colour_print
+kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep "${RELEASE_NAME}" | colour_print
 echo "
 ================================================================================
 kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
 
 "
-kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}" | colour_print
+kubectl get pods -n "${NAMESPACE}" -l app.kubernetes.io/instance="${RELEASE_NAME}" | colour_print
 # Commenting describe output as that is already covered by events on the namespace
 # echo "
 #================================================================================
@@ -31,15 +30,15 @@ kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAM
 
 #kubectl get pods -n "${NAMESPACE}" -l app.kubernetes.io/instance="${RELEASE_NAME}" --field-selector status.phase=Pending -o json | jq '.items[] |  .metadata.name' | xargs kubectl describe pods -n "${NAMESPACE}"
 
-for podName in $(kubectl get pods -n "${NAMESPACE}" -l app.kubernetes.io/instance="${RELEASE_NAME}" -o json | jq  -r '.items[] | select(.status.containerStatuses[] | ((.ready|not) and .state.waiting.reason=="CrashLoopBackOff")) |  .metadata.name'); do
+for podName in $(kubectl get pods -n "${NAMESPACE}" -l app.kubernetes.io/instance="${RELEASE_NAME}" -o json | jq -r '.items[] | select(.status.containerStatuses[] | ((.ready|not) and .state.waiting.reason=="CrashLoopBackOff")) |  .metadata.name'); do
 
-echo "
+  echo "
 ================================================================================
 Logs for crashing pod $podName:
 kubectl logs  -n "${NAMESPACE}" ${podName} -p
 "
 
-kubectl logs  -n "${NAMESPACE}" ${podName} -p | colour_print
+  kubectl logs -n "${NAMESPACE}" ${podName} -p | colour_print
 
 done
 

--- a/resources/uk/gov/hmcts/helm/aks-debug-info.sh
+++ b/resources/uk/gov/hmcts/helm/aks-debug-info.sh
@@ -31,7 +31,7 @@ $(tput setaf 3)=================================================================
 $(tput setaf 3)Logs for crashing pod $podName:
 $(tput setaf 3)kubectl logs  -n "${NAMESPACE}" ${podName} -p
 "
-tput setaf 3; kubectl logs  -n "${NAMESPACE}" ${podName} -p
+kubectl logs  -n "${NAMESPACE}" ${podName} -p
 
 done
 

--- a/resources/uk/gov/hmcts/helm/aks-debug-info.sh
+++ b/resources/uk/gov/hmcts/helm/aks-debug-info.sh
@@ -3,11 +3,11 @@ RELEASE_NAME=${1}
 NAMESPACE=${2}
 export TERM=xterm-256color
 
-$(tput setaf 3); echo -e "See below debug information to help troubleshooting the issue.\n ====================================================\n kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n ${NAMESPACE} | grep  ${RELEASE_NAME}"
+tput setaf 3; echo -e "See below debug information to help troubleshooting the issue.\n ====================================================\n kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n ${NAMESPACE} | grep  ${RELEASE_NAME}"
 
 kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
 
-$(tput setaf 3); echo -e "====================================================\n kubectl get pods -n ${NAMESPACE}  -l app.kubernetes.io/instance=${RELEASE_NAME}"
+tput setaf 3; echo -e "====================================================\n kubectl get pods -n ${NAMESPACE}  -l app.kubernetes.io/instance=${RELEASE_NAME}"
 
 kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
 
@@ -20,7 +20,7 @@ kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAM
 #kubectl get pods -n "${NAMESPACE}" -l app.kubernetes.io/instance="${RELEASE_NAME}" --field-selector status.phase=Pending -o json | jq '.items[] |  .metadata.name' | xargs kubectl describe pods -n "${NAMESPACE}"
 
 for podName in $(kubectl get pods -n "${NAMESPACE}" -l app.kubernetes.io/instance="${RELEASE_NAME}" -o json | jq  -r '.items[] | select(.status.containerStatuses[] | ((.ready|not) and .state.waiting.reason=="CrashLoopBackOff")) |  .metadata.name'); do
-$(tput setaf 3); echo -e "====================================================\n Logs for crashing pod $podName: \n kubectl logs  -n ${NAMESPACE} ${podName} -p"
+tput setaf 3; echo -e "====================================================\n Logs for crashing pod $podName: \n kubectl logs  -n ${NAMESPACE} ${podName} -p"
 
 kubectl logs  -n "${NAMESPACE}" ${podName} -p
 

--- a/resources/uk/gov/hmcts/helm/aks-debug-info.sh
+++ b/resources/uk/gov/hmcts/helm/aks-debug-info.sh
@@ -2,23 +2,26 @@
 
 RELEASE_NAME=${1}
 NAMESPACE=${2}
+
+function execute_command () {
+tput setaf 3;
+"$@"
+tput sgr0
+}
+
 echo "
 
 See below debug information to help troubleshooting the issue.
 ================================================================================
 kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
 "
-tput setaf 3;
-kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
-tput sgr0
+execute_command kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
 echo "
 ================================================================================
 kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
 
 "
-tput setaf 3;
-kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
-tput sgr0
+execute_command kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
 # Commenting describe output as that is already covered by events on the namespace
 # echo "
 #================================================================================
@@ -34,9 +37,9 @@ echo "
 Logs for crashing pod $podName:
 kubectl logs  -n "${NAMESPACE}" ${podName} -p
 "
-tput setaf 3;
-kubectl logs  -n "${NAMESPACE}" ${podName} -p
-tput sgr0
+
+execute_command kubectl logs  -n "${NAMESPACE}" ${podName} -p
+
 done
 
 exit 1

--- a/resources/uk/gov/hmcts/helm/aks-debug-info.sh
+++ b/resources/uk/gov/hmcts/helm/aks-debug-info.sh
@@ -7,15 +7,15 @@ echo "
 $(tput setaf 3)See below debug information to help troubleshooting the issue.
 ================================================================================
 kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
-$(tput sgr0)"
+"
 
-kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
+tput setaf 3; kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
 
 echo "$(tput setaf 3)================================================================================
 kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
-$(tput sgr0)"
+"
 
-kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
+tput setaf 3; kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
 
 # Commenting describe output as that is already covered by events on the namespace
 # echo "
@@ -30,8 +30,8 @@ echo "
 $(tput setaf 3)================================================================================
 Logs for crashing pod $podName:
 kubectl logs  -n "${NAMESPACE}" ${podName} -p
-$(tput sgr0)"
-kubectl logs  -n "${NAMESPACE}" ${podName} -p
+"
+tput setaf 3; kubectl logs  -n "${NAMESPACE}" ${podName} -p
 
 done
 

--- a/resources/uk/gov/hmcts/helm/aks-debug-info.sh
+++ b/resources/uk/gov/hmcts/helm/aks-debug-info.sh
@@ -5,13 +5,13 @@ NAMESPACE=${2}
 echo "
 See below debug information to help troubleshooting the issue.
 ================================================================================
-Events on namespace:
+kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
 "
 kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
 
 echo "
 ================================================================================
-Status of pods:
+kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
 
 "
 kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
@@ -29,9 +29,10 @@ for podName in $(kubectl get pods -n "${NAMESPACE}" -l app.kubernetes.io/instanc
 echo "
 ================================================================================
 Logs for crashing pod $podName:
+kubectl logs  -n "${NAMESPACE}" ${podName} -p
 "
 
-  kubectl logs  -n "${NAMESPACE}" ${podName} -p
+kubectl logs  -n "${NAMESPACE}" ${podName} -p
 done
 
 exit 1

--- a/resources/uk/gov/hmcts/helm/aks-debug-info.sh
+++ b/resources/uk/gov/hmcts/helm/aks-debug-info.sh
@@ -4,9 +4,12 @@ RELEASE_NAME=${1}
 NAMESPACE=${2}
 export TERM=xterm-256color
 function colour_print() {
+  DEFAULT_IFS=$IFS
+  IFS=$'\n'
   while read -r line; do
     tput setaf 3; echo "$line"
   done
+  IFS=$DEFAULT_IFS
 }
 
 echo "
@@ -38,7 +41,7 @@ Logs for crashing pod $podName:
 kubectl logs  -n "${NAMESPACE}" ${podName} -p
 "
 
-  kubectl logs -n "${NAMESPACE}" ${podName} -p | colour_print
+  kubectl logs -n "${NAMESPACE}" ${podName} -p
 
 done
 

--- a/resources/uk/gov/hmcts/helm/aks-debug-info.sh
+++ b/resources/uk/gov/hmcts/helm/aks-debug-info.sh
@@ -3,17 +3,11 @@ RELEASE_NAME=${1}
 NAMESPACE=${2}
 export TERM=xterm-256color
 
-echo "
-$(tput setaf 3)See below debug information to help troubleshooting the issue.
-$(tput setaf 3)================================================================================
-$(tput setaf 3)kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
-"
+$(tput setaf 3); echo -e "See below debug information to help troubleshooting the issue.\n ====================================================\n kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n ${NAMESPACE} | grep  ${RELEASE_NAME}"
 
 kubectl get events '--field-selector=type!=Normal' '--sort-by=.metadata.creationTimestamp' -n "${NAMESPACE}" | grep  "${RELEASE_NAME}"
 
-echo "$(tput setaf 3)================================================================================
-$(tput setaf 3)kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
-"
+$(tput setaf 3); echo -e "====================================================\n kubectl get pods -n ${NAMESPACE}  -l app.kubernetes.io/instance=${RELEASE_NAME}"
 
 kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAME}"
 
@@ -26,11 +20,8 @@ kubectl get pods -n "${NAMESPACE}"  -l app.kubernetes.io/instance="${RELEASE_NAM
 #kubectl get pods -n "${NAMESPACE}" -l app.kubernetes.io/instance="${RELEASE_NAME}" --field-selector status.phase=Pending -o json | jq '.items[] |  .metadata.name' | xargs kubectl describe pods -n "${NAMESPACE}"
 
 for podName in $(kubectl get pods -n "${NAMESPACE}" -l app.kubernetes.io/instance="${RELEASE_NAME}" -o json | jq  -r '.items[] | select(.status.containerStatuses[] | ((.ready|not) and .state.waiting.reason=="CrashLoopBackOff")) |  .metadata.name'); do
-echo "
-$(tput setaf 3)================================================================================
-$(tput setaf 3)Logs for crashing pod $podName:
-$(tput setaf 3)kubectl logs  -n "${NAMESPACE}" ${podName} -p
-"
+$(tput setaf 3); echo -e "====================================================\n Logs for crashing pod $podName: \n kubectl logs  -n ${NAMESPACE} ${podName} -p"
+
 kubectl logs  -n "${NAMESPACE}" ${podName} -p
 
 done

--- a/vars/notifyBuildFailure.groovy
+++ b/vars/notifyBuildFailure.groovy
@@ -16,7 +16,7 @@ def call(Map args = [:]) {
   validate(args)
 
   String changeAuthor = env.CHANGE_AUTHOR
-  def message = "${env.JOB_NAME}: <${env.RUN_DISPLAY_URL}|Build ${env.BUILD_DISPLAY_NAME}> has FAILED. Refer <https://hmcts.github.io/ways-of-working/troubleshooting/#jenkins|Troubleshooting Guide> to help debug the failure"
+  def message = "${env.JOB_NAME}: <${env.RUN_DISPLAY_URL}|Build ${env.BUILD_DISPLAY_NAME}> has FAILED. See the <https://hmcts.github.io/ways-of-working/troubleshooting/#jenkins|troubleshooting Guide> to help debug the failure"
   String channel
   if (new ProjectBranch(env.BRANCH_NAME).isMaster()) {
     channel = args.channel

--- a/vars/notifyBuildFailure.groovy
+++ b/vars/notifyBuildFailure.groovy
@@ -16,7 +16,7 @@ def call(Map args = [:]) {
   validate(args)
 
   String changeAuthor = env.CHANGE_AUTHOR
-  def message = "${env.JOB_NAME}: <${env.RUN_DISPLAY_URL}|Build ${env.BUILD_DISPLAY_NAME}> has FAILED"
+  def message = "${env.JOB_NAME}: <${env.RUN_DISPLAY_URL}|Build ${env.BUILD_DISPLAY_NAME}> has FAILED. Refer <https://hmcts.github.io/ways-of-working/troubleshooting/#jenkins|Troubleshooting Guide> to help debug the failure"
   String channel
   if (new ProjectBranch(env.BRANCH_NAME).isMaster()) {
     channel = args.channel

--- a/vars/withAcrClient.groovy
+++ b/vars/withAcrClient.groovy
@@ -3,7 +3,7 @@ def call(String subscription, Closure block) {
   if (env.IS_DOCKER_BUILD_AGENT && env.IS_DOCKER_BUILD_AGENT.toBoolean()) {
     doAcrOrKubectlTask(subscription, false, block)
   } else {
-    withDocker('hmcts/cnp-aks-client:az-2.39.0-kubectl-1.20.5-helm-3.5.3', null) {
+    withDocker('hmcts/cnp-aks-client:az-2.39.0-kubectl-1.20.5-helm-3.5.4', null) {
       doAcrOrKubectlTask(subscription, true, block)
     }
   }


### PR DESCRIPTION
Tested in https://build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_a_to_c%2Fcnp-plum-recipes-service/detail/PR-620/50/pipeline/110/
Notes:
* standout `kubectl `output in different colour
* Add command to the log for teams to play around
* Add troubleshooting guide to docs.

<img width="1404" alt="Screenshot 2022-11-22 at 16 40 28" src="https://user-images.githubusercontent.com/47391951/203372212-b4b43212-88d7-49c4-baa2-04685eaa13a4.png">

<img width="428" alt="Screenshot 2022-11-22 at 16 44 26" src="https://user-images.githubusercontent.com/47391951/203372150-0e478f37-8b8b-4786-8c95-8123640b7377.png">

