### PR TITLE
Disable fail fast

### DIFF
--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -57,7 +57,7 @@ def call(params) {
       }
     }
 
-    LinkedHashMap<String, Object> branches = [failFast: true]
+    LinkedHashMap<String, Object> branches = [failFast: false]
     branches["Unit tests and Sonar scan"] = {
       pcr.callAround('test') {
         timeoutWithMsg(time: 20, unit: 'MINUTES', action: 'test') {


### PR DESCRIPTION
There are a couple of issues caused by using `failFast`

- It's unclear in the build logs / pipeline visualisation which stage failed vs which was aborted by `failFast`, sometimes multiple stages show up as failed
- Failures get reported for each stage in the metrics as aborting them causes a failure to be recorded

Downside:
- We will spend more CI time running things like tests or sonar when security checks fail