### PR TITLE
Docker Test Build made optional feature for Java build pipeline on Master

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,15 @@ called after each deployment to each environment.
 
 The smoke tests are to be non-destructive (i.e. have no data impact, such as not creating accounts) and a subset of component level functional tests.
 
+#### Docker Test Build
+
+A Docker Test Build can be enabled providing static unit tests, security checks & Sonar scanning for builds from Master if needed. This stage is always run on PR so in most cases does not need enabling for Master builds if following common git workflow. 
+
+By adding `enableDockerTestBuild()` to the Jenkinsfile, `Static Checks/Container Build` stages will be executed in the pipeline for Master instead of skipped.
+
+This stage was previously enabled by default however is now optional. 
+
+
 #### High level data setup
 
 This can be used to import data required for the application.
@@ -190,6 +199,7 @@ Branch | HighDataSetup Stage
 `perftest` | `perftest`
 `demo` | `demo`
 `ithc` | `ithc`
+
 
 #### Extending the opinionated pipeline
 

--- a/README.md
+++ b/README.md
@@ -685,5 +685,5 @@ This file will point to the repository which defines, in json syntax, which infr
  1. Use the Github pull requests to make change
  2. Test the change by pointing a repository, to the branch with the change, edit your `Jenkinsfile` like so:
 ```groovy
-@Library('Infrastructure@<your-branch-name') _
+@Library('Infrastructure@<your-branch-name>') _
 ```

--- a/README.md
+++ b/README.md
@@ -158,14 +158,15 @@ called after each deployment to each environment.
 
 The smoke tests are to be non-destructive (i.e. have no data impact, such as not creating accounts) and a subset of component level functional tests.
 
-#### Docker Test Build
+#### Docker test build for continuous functional and smoke tests
 
-A Docker Test Build can be enabled providing static unit tests, security checks & Sonar scanning for builds from Master if needed. This stage is always run on PR so in most cases does not need enabling for Master builds if following common git workflow. 
+An application can configure running continuous smoke/functional tests on java app deployments managed through flux. 
 
-By adding `enableDockerTestBuild()` to the Jenkinsfile, `Static Checks/Container Build` stages will be executed in the pipeline for Master instead of skipped.
+https://github.com/hmcts/chart-java/#smoke-and-functional-tests
 
-This stage was previously enabled by default however is now optional. 
+To build docker images for this, add `enableDockerTestBuild()` in `Jenkinsfile_CNP`. `Static Checks/Container Build` stage in the pipeline will execute, including a test docker image.
 
+A Docker test build was previously built by default however has been made optional for pipeline speed and reliability.
 
 #### High level data setup
 

--- a/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
@@ -28,7 +28,7 @@ class AppPipelineConfig extends CommonPipelineConfig implements Serializable {
   String fortifyVaultName
   String s2sServiceName
   String highLevelDataSetupKeyVaultName
-  boolean masterTestBuild = false
+  boolean testDockerBuild = false
 
   int crossBrowserTestTimeout
   int perfTestTimeout = 15

--- a/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
@@ -28,7 +28,7 @@ class AppPipelineConfig extends CommonPipelineConfig implements Serializable {
   String fortifyVaultName
   String s2sServiceName
   String highLevelDataSetupKeyVaultName
-  boolean testDockerBuild = false
+  boolean dockerTestBuild = false
 
   int crossBrowserTestTimeout
   int perfTestTimeout = 15

--- a/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
@@ -28,6 +28,7 @@ class AppPipelineConfig extends CommonPipelineConfig implements Serializable {
   String fortifyVaultName
   String s2sServiceName
   String highLevelDataSetupKeyVaultName
+  boolean masterTestBuild = false
 
   int crossBrowserTestTimeout
   int perfTestTimeout = 15

--- a/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
@@ -97,8 +97,8 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
     config.fortifyVaultName = fortifyVaultName
   }
 
-  void enableTestDockerBuild() {
-    config.testDockerBuild = true
+  void enableDockerTestBuild() {
+    config.dockerTestBuild = true
   }
 
 }

--- a/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
@@ -97,8 +97,8 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
     config.fortifyVaultName = fortifyVaultName
   }
 
-  void enableMasterTestBuild() {
-    config.masterTestBuild = true
+  void enableTestDockerBuild() {
+    config.testDockerBuild = true
   }
 
 }

--- a/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
@@ -96,4 +96,9 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
     config.fortifyScan = true
     config.fortifyVaultName = fortifyVaultName
   }
+
+  void enableMasterTestBuild() {
+    config.masterTestBuild = true
+  }
+
 }

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -115,7 +115,7 @@ def call(params) {
     }
 
     onMaster {
-      if (config.masterTestBuild && fileExists('build.gradle') && dockerFileExists) {
+      if (config.testDockerBuild && fileExists('build.gradle') && dockerFileExists) {
         branches["Docker Test Build"] = {
           withAcrClient(subscription) {
             def dockerfileTest = 'Dockerfile_test'

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -115,7 +115,7 @@ def call(params) {
     }
 
     onMaster {
-      if (fileExists('build.gradle') && dockerFileExists) {
+      if (config.masterTestBuild && fileExists('build.gradle') && dockerFileExists) {
         branches["Docker Test Build"] = {
           withAcrClient(subscription) {
             def dockerfileTest = 'Dockerfile_test'

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -115,7 +115,7 @@ def call(params) {
     }
 
     onMaster {
-      if (config.testDockerBuild && fileExists('build.gradle') && dockerFileExists) {
+      if (config.dockerTestBuild && fileExists('build.gradle') && dockerFileExists) {
         branches["Docker Test Build"] = {
           withAcrClient(subscription) {
             def dockerfileTest = 'Dockerfile_test'

--- a/vars/sectionPromoteBuildToStage.groovy
+++ b/vars/sectionPromoteBuildToStage.groovy
@@ -50,7 +50,7 @@ def call(params) {
           }
           if (DockerImage.DeploymentStage.PROD == deploymentStage) {
             acr.retagForStage(DockerImage.DeploymentStage.LATEST, dockerImage)
-            if (config.testDockerBuild && projectBranch.isMaster() && fileExists('build.gradle')) {
+            if (config.dockerTestBuild && projectBranch.isMaster() && fileExists('build.gradle')) {
               def dockerImageTest = new DockerImage(product, "${component}-${DockerImage.TEST_REPO}", acr, projectBranch.imageTag(), env.GIT_COMMIT, env.LAST_COMMIT_TIMESTAMP)
               acr.retagForStage(deploymentStage, dockerImageTest)
             }

--- a/vars/sectionPromoteBuildToStage.groovy
+++ b/vars/sectionPromoteBuildToStage.groovy
@@ -50,7 +50,7 @@ def call(params) {
           }
           if (DockerImage.DeploymentStage.PROD == deploymentStage) {
             acr.retagForStage(DockerImage.DeploymentStage.LATEST, dockerImage)
-            if (projectBranch.isMaster() && fileExists('build.gradle')) {
+            if (config.testDockerBuild && projectBranch.isMaster() && fileExists('build.gradle')) {
               def dockerImageTest = new DockerImage(product, "${component}-${DockerImage.TEST_REPO}", acr, projectBranch.imageTag(), env.GIT_COMMIT, env.LAST_COMMIT_TIMESTAMP)
               acr.retagForStage(deploymentStage, dockerImageTest)
             }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-11015


### Change description ###

Default to skip test docker build/static testing for Java build pipeline run on Master. This is not necessary for the majority of component dev teams as this stage functionality is run on PR already. 

Stage can be enabled using call enableTestDockerBuild() within jenkinsfile if needed.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
