### PR TITLE
Ignore openjdk updates in the Dockerfile

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,10 @@
     {
       "matchPackageNames": ["org.spockframework:spock-core"],
       "allowedVersions": "/^[0-9]+\\.[0-9]+(\\.[0-9]+)?-groovy-2\\.5$/"
+    },
+    {
+      "matchPackageNames": ["openjdk"],
+      "allowedVersions": "<12"
     }
   ]
 }


### PR DESCRIPTION
This openjdk update is limited to a tests docker file with very limited adoption, the feature doesn't work on Java 17 due to a bug in gradle as far I remember.