### PR TITLE
Change pact gradle properties to project properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The smoke tests are to be non-destructive (i.e. have no data impact, such as not
 
 #### Docker test build for continuous functional and smoke tests
 
-An application can configure running continuous smoke/functional tests on java app deployments managed through flux. 
+An application can configure running continuous smoke/functional tests on java app deployments managed through flux.
 
 https://github.com/hmcts/chart-java/#smoke-and-functional-tests
 
@@ -627,9 +627,9 @@ The Pact broker url and other parameters are passed to these hooks as following:
   - `PACT_BROKER_URL`
   - `PACT_CONSUMER_VERSION`/`PACT_PROVIDER_VERSION`
 - `gradlew`:
-  - `-Dpact.broker.url`
-  - `-Dpact.consumer.version`/`-Dpact.provider.version`
-  - `-Dpact.verifier.publishResults=${onMaster}` is passed by default for providers
+  - `-Ppact.broker.url`
+  - `-Ppact.consumer.version`/`-Ppact.provider.version`
+  - `-Ppact.verifier.publishResults=${onMaster}` is passed by default for providers
 
 🛎️  `onMaster` is a boolean that is true if the current branch is `master`
 🛎️  It is expected that the scripts are responsible for figuring out which tag or branch is currently tested.

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -177,7 +177,7 @@ EOF
 
   def runProviderVerification(pactBrokerUrl, version, publish) {
     try {
-      gradle("-Dpact.broker.url=${pactBrokerUrl} -Dpact.provider.version=${version} -Dpact.verifier.publishResults=${publish} runProviderPactVerification")
+      gradle("-Ppact.broker.url=${pactBrokerUrl} -Ppact.provider.version=${version} -Ppact.verifier.publishResults=${publish} runProviderPactVerification")
     } finally {
       localSteps.junit allowEmptyResults: true, testResults: '**/test-results/contract/TEST-*.xml,**/test-results/contractTest/TEST-*.xml'
     }
@@ -185,7 +185,7 @@ EOF
 
   def runConsumerTests(pactBrokerUrl, version) {
    try {
-      gradle("-Dpact.broker.url=${pactBrokerUrl} -Dpact.consumer.version=${version} runAndPublishConsumerPactTests")
+      gradle("-Ppact.broker.url=${pactBrokerUrl} -Ppact.consumer.version=${version} runAndPublishConsumerPactTests")
    } finally {
       localSteps.junit allowEmptyResults: true, testResults: '**/test-results/contract/TEST-*.xml,**/test-results/contractTest/TEST-*.xml'
     }

--- a/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
@@ -127,7 +127,7 @@ class GradleBuilderTest extends Specification {
       builder.runProviderVerification(PACT_BROKER_URL, version, publishResults)
     then:
       1 * steps.sh({it.startsWith(GRADLE_CMD) &&
-                    it.contains("-Dpact.broker.url=${PACT_BROKER_URL} -Dpact.provider.version=${version} -Dpact.verifier.publishResults=${publishResults} runProviderPactVerification")})
+                    it.contains("-Ppact.broker.url=${PACT_BROKER_URL} -Ppact.provider.version=${version} -Ppact.verifier.publishResults=${publishResults} runProviderPactVerification")})
   }
 
   def "runConsumerTests triggers a gradlew hook"() {
@@ -137,7 +137,7 @@ class GradleBuilderTest extends Specification {
       builder.runConsumerTests(PACT_BROKER_URL, version)
     then:
       1 * steps.sh({it.startsWith(GRADLE_CMD) &&
-                    it.contains("-Dpact.broker.url=${PACT_BROKER_URL} -Dpact.consumer.version=${version} runAndPublishConsumerPactTests")})
+                    it.contains("-Ppact.broker.url=${PACT_BROKER_URL} -Ppact.consumer.version=${version} runAndPublishConsumerPactTests")})
   }
 
   def "runConsumerCanIDeploy triggers a gradlew hook"() {


### PR DESCRIPTION
[Pact suggests](https://docs.pact.io/implementation_guides/jvm/provider/gradle#:~:text=Important%20Note%3A%20Any%20properties%20that%20need%20to%20be%20set%20when%20using%20the%20Gradle%20plugin%20need%20to%20be%20provided%20with%20%2DP%20and%20not%20%2DD%20as%20with%20the%20other%20Pact%2DJVM%20modules!) to use -P for -D. we have a couple of users reporting users reporting issues with pact verification.

Branch confirmed working on https://build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_a_to_c%2Fccfr-fees-register-app/detail/master/58/pipeline/486/ 



