### PR TITLE
Save pods logs in artifacts at the end of tests

### DIFF
--- a/resources/uk/gov/hmcts/helm/save-pods-logs.sh
+++ b/resources/uk/gov/hmcts/helm/save-pods-logs.sh
@@ -8,7 +8,7 @@ mkdir ${PODS_LOGS_DIR}
 
 echo "Saving pods logs for release ${RELEASE_NAME} under Jenkins artifacts directory ${PODS_LOGS_DIR}..."
 
-for podName in $(kubectl get pods -n "${NAMESPACE}" -l app.kubernetes.io/instance="${RELEASE_NAME}" -o json | jq -r '.items[] | select(.status.containerStatuses[] | ((.ready|not) and .state.waiting.reason=="CrashLoopBackOff")) |  .metadata.name'); do
+for podName in $(kubectl get pods -n "${NAMESPACE}" -l app.kubernetes.io/instance="${RELEASE_NAME}" -o json | jq -r '.items[] | .metadata.name'); do
 
   kubectl logs -n "${NAMESPACE}" ${podName} > ${PODS_LOGS_DIR}/${podName}.log
 

--- a/resources/uk/gov/hmcts/helm/save-pods-logs.sh
+++ b/resources/uk/gov/hmcts/helm/save-pods-logs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 RELEASE_NAME=${1}
 NAMESPACE=${2}

--- a/resources/uk/gov/hmcts/helm/save-pods-logs.sh
+++ b/resources/uk/gov/hmcts/helm/save-pods-logs.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+RELEASE_NAME=${1}
+NAMESPACE=${2}
+PODS_LOGS_DIR=${3}
+
+mkdir ${PODS_LOGS_DIR}
+
+echo "
+Check Jenkins artifacts for the pods logs.
+================================================================================
+"
+
+kubectl get pods -n "${NAMESPACE}" -l app.kubernetes.io/instance="${RELEASE_NAME}" | awk '{print $1}'
+
+for podName in $(kubectl get pods -n "${NAMESPACE}" -l app.kubernetes.io/instance="${RELEASE_NAME}" | awk '{print $1}'); do
+
+  kubectl logs -n "${NAMESPACE}" ${podName} > ${PODS_LOGS_DIR}/${podName}.log
+
+done
+

--- a/resources/uk/gov/hmcts/helm/save-pods-logs.sh
+++ b/resources/uk/gov/hmcts/helm/save-pods-logs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 RELEASE_NAME=${1}
 NAMESPACE=${2}
@@ -6,16 +6,12 @@ PODS_LOGS_DIR=${3}
 
 mkdir ${PODS_LOGS_DIR}
 
-echo "
-Check Jenkins artifacts for the pods logs.
-================================================================================
-"
+echo "Saving pods logs for release ${RELEASE_NAME} under Jenkins artifacts directory ${PODS_LOGS_DIR}..."
 
-kubectl get pods -n "${NAMESPACE}" -l app.kubernetes.io/instance="${RELEASE_NAME}" | awk '{print $1}'
-
-for podName in $(kubectl get pods -n "${NAMESPACE}" -l app.kubernetes.io/instance="${RELEASE_NAME}" | awk '{print $1}'); do
+for podName in $(kubectl get pods -n "${NAMESPACE}" -l app.kubernetes.io/instance="${RELEASE_NAME}" -o json | jq -r '.items[] | select(.status.containerStatuses[] | ((.ready|not) and .state.waiting.reason=="CrashLoopBackOff")) |  .metadata.name'); do
 
   kubectl logs -n "${NAMESPACE}" ${podName} > ${PODS_LOGS_DIR}/${podName}.log
 
 done
 
+echo "... done."

--- a/src/uk/gov/hmcts/contino/Kubectl.groovy
+++ b/src/uk/gov/hmcts/contino/Kubectl.groovy
@@ -125,5 +125,4 @@ class Kubectl {
   private Object executeAndExtract(String command, String namespace, String jsonPath) {
     kubectl command,"-n ${namespace}", "-o json -o=jsonpath=" + jsonPath
   }
-
 }

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -14,6 +14,15 @@ class YarnBuilder extends AbstractBuilder {
     super(steps)
   }
 
+  def savePodLogs(String scope) {
+    steps.writeFile(file: 'save-pods-logs.sh', text: steps.libraryResource('uk/gov/hmcts/helm/save-pods-logs.sh'))
+    steps.sh """
+        chmod +x save-pods-logs.sh
+        ./save-pods-logs.sh ${releaseName} ${this.namespace} pods-logs-${scope}
+      """
+    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'pods-logs/**'
+  }
+
   def build() {
     yarn("lint")
 
@@ -46,6 +55,7 @@ class YarnBuilder extends AbstractBuilder {
     } finally {
       steps.junit allowEmptyResults: true, testResults: 'smoke-output/**/*result.xml'
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'smoke-output/**'
+      savePodLogs("smoke")
     }
   }
 
@@ -55,6 +65,7 @@ class YarnBuilder extends AbstractBuilder {
     } finally {
       steps.junit allowEmptyResults: true, testResults: 'functional-output/**/*result.xml'
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**'
+      savePodLogs("functional")
     }
   }
 
@@ -64,6 +75,7 @@ class YarnBuilder extends AbstractBuilder {
     } finally {
       steps.junit allowEmptyResults: true, testResults: 'api-output/*result.xml'
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'api-output/*'
+      savePodLogs("apigateway")
     }
   }
 
@@ -76,6 +88,7 @@ class YarnBuilder extends AbstractBuilder {
     finally {
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/crossbrowser/reports/**/*'
       steps.saucePublisher()
+      savePodLogs("crossbrowser")
     }
   }
 
@@ -88,6 +101,7 @@ class YarnBuilder extends AbstractBuilder {
     finally {
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: "functional-output/$browser*/*"
       steps.saucePublisher()
+      savePodLogs("crossbrowser-${browser}")
     }
   }
 
@@ -98,6 +112,7 @@ class YarnBuilder extends AbstractBuilder {
     finally {
       steps.junit allowEmptyResults: true, testResults: 'functional-output/**/*result.xml'
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**'
+      savePodLogs("full-functional")
     }
   }
 
@@ -107,6 +122,7 @@ class YarnBuilder extends AbstractBuilder {
     }
     finally {
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**/*'
+      savePodLogs("mutation")
     }
   }
 

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -14,15 +14,6 @@ class YarnBuilder extends AbstractBuilder {
     super(steps)
   }
 
-  def savePodLogs(String scope) {
-    steps.writeFile(file: 'save-pods-logs.sh', text: steps.libraryResource('uk/gov/hmcts/helm/save-pods-logs.sh'))
-    steps.sh """
-        chmod +x save-pods-logs.sh
-        ./save-pods-logs.sh ${releaseName} ${this.namespace} pods-logs-${scope}
-      """
-    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'pods-logs/**'
-  }
-
   def build() {
     yarn("lint")
 
@@ -55,7 +46,6 @@ class YarnBuilder extends AbstractBuilder {
     } finally {
       steps.junit allowEmptyResults: true, testResults: 'smoke-output/**/*result.xml'
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'smoke-output/**'
-      savePodLogs("smoke")
     }
   }
 
@@ -65,7 +55,6 @@ class YarnBuilder extends AbstractBuilder {
     } finally {
       steps.junit allowEmptyResults: true, testResults: 'functional-output/**/*result.xml'
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**'
-      savePodLogs("functional")
     }
   }
 
@@ -75,7 +64,6 @@ class YarnBuilder extends AbstractBuilder {
     } finally {
       steps.junit allowEmptyResults: true, testResults: 'api-output/*result.xml'
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'api-output/*'
-      savePodLogs("apigateway")
     }
   }
 
@@ -88,7 +76,6 @@ class YarnBuilder extends AbstractBuilder {
     finally {
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/crossbrowser/reports/**/*'
       steps.saucePublisher()
-      savePodLogs("crossbrowser")
     }
   }
 
@@ -101,7 +88,6 @@ class YarnBuilder extends AbstractBuilder {
     finally {
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: "functional-output/$browser*/*"
       steps.saucePublisher()
-      savePodLogs("crossbrowser-${browser}")
     }
   }
 
@@ -112,7 +98,6 @@ class YarnBuilder extends AbstractBuilder {
     finally {
       steps.junit allowEmptyResults: true, testResults: 'functional-output/**/*result.xml'
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**'
-      savePodLogs("full-functional")
     }
   }
 
@@ -122,7 +107,6 @@ class YarnBuilder extends AbstractBuilder {
     }
     finally {
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**/*'
-      savePodLogs("mutation")
     }
   }
 

--- a/vars/savePodsLogs.groovy
+++ b/vars/savePodsLogs.groovy
@@ -1,3 +1,4 @@
+import uk.gov.hmcts.contino.DockerImage
 
 
 def call(DockerImage dockerImage, Map params, String scope) {

--- a/vars/savePodsLogs.groovy
+++ b/vars/savePodsLogs.groovy
@@ -1,20 +1,24 @@
 import uk.gov.hmcts.contino.DockerImage
+import uk.gov.hmcts.contino.Kubectl
 
 
 def call(DockerImage dockerImage, Map params, String scope) {
-  onPR {
-    stageWithAgent("Save pods logs", params.product) {
-      def chartName = "${params.product}-${params.component}"
-      def imageTag = dockerImage.getTag()
-      def releaseName = "${chartName}-${imageTag}"
+  def chartName = "${params.product}-${params.component}"
+  def imageTag = dockerImage.getImageTag()
+  def releaseName = "${chartName}-${imageTag}"
+  def namespace = env.TEAM_NAMESPACE
 
-      steps.writeFile(file: 'save-pods-logs.sh', text: steps.libraryResource('uk/gov/hmcts/helm/save-pods-logs.sh'))
-      steps.sh """
-        chmod +x save-pods-logs.sh
-        ./save-pods-logs.sh ${releaseName} ${env.TEAM_NAMESPACE} pods-logs-${scope}
-        rm -f save-pods-logs.sh
-      """
-      steps.archiveArtifacts allowEmptyArchive: true, artifacts: "pods-logs-${scope}/**"
-    }
+  withAksClient(params.subscription, params.environment, params.product) {
+    def kubectl = new Kubectl(this, params.subscription, namespace, params.aksSubscription.name)
+    kubectl.login()
+
+    steps.writeFile(file: 'save-pods-logs.sh', text: steps.libraryResource('uk/gov/hmcts/helm/save-pods-logs.sh'))
+    steps.sh(label: "Save pods logs in artifacts, under pods-logs-${scope}", script: """
+    chmod +x save-pods-logs.sh
+    ./save-pods-logs.sh ${releaseName} ${namespace} pods-logs-${scope}
+    rm -f save-pods-logs.sh
+    """)
+
+    steps.archiveArtifacts(allowEmptyArchive: true, artifacts: "pods-logs-${scope}/**")
   }
 }

--- a/vars/savePodsLogs.groovy
+++ b/vars/savePodsLogs.groovy
@@ -15,10 +15,10 @@ def call(DockerImage dockerImage, Map params, String scope) {
 
       steps.writeFile(file: 'save-pods-logs.sh', text: steps.libraryResource('uk/gov/hmcts/helm/save-pods-logs.sh'))
       steps.sh(label: "Save pods logs in artifacts, under pods-logs-${scope}", script: """
-    chmod +x save-pods-logs.sh
-    ./save-pods-logs.sh ${releaseName} ${namespace} pods-logs-${scope}
-    rm -f save-pods-logs.sh
-    """)
+        chmod +x save-pods-logs.sh
+        ./save-pods-logs.sh ${releaseName} ${namespace} pods-logs-${scope}
+        rm -f save-pods-logs.sh
+      """)
 
       steps.archiveArtifacts(allowEmptyArchive: true, artifacts: "pods-logs-${scope}/**")
     }

--- a/vars/savePodsLogs.groovy
+++ b/vars/savePodsLogs.groovy
@@ -3,22 +3,26 @@ import uk.gov.hmcts.contino.Kubectl
 
 
 def call(DockerImage dockerImage, Map params, String scope) {
-  def chartName = "${params.product}-${params.component}"
-  def imageTag = dockerImage.getImageTag()
-  def releaseName = "${chartName}-${imageTag}"
-  def namespace = env.TEAM_NAMESPACE
+  try {
+    def chartName = "${params.product}-${params.component}"
+    def imageTag = dockerImage.getImageTag()
+    def releaseName = "${chartName}-${imageTag}"
+    def namespace = env.TEAM_NAMESPACE
 
-  withAksClient(params.subscription, params.environment, params.product) {
-    def kubectl = new Kubectl(this, params.subscription, namespace, params.aksSubscription.name)
-    kubectl.login()
+    withAksClient(params.subscription, params.environment, params.product) {
+      def kubectl = new Kubectl(this, params.subscription, namespace, params.aksSubscription.name)
+      kubectl.login()
 
-    steps.writeFile(file: 'save-pods-logs.sh', text: steps.libraryResource('uk/gov/hmcts/helm/save-pods-logs.sh'))
-    steps.sh(label: "Save pods logs in artifacts, under pods-logs-${scope}", script: """
+      steps.writeFile(file: 'save-pods-logs.sh', text: steps.libraryResource('uk/gov/hmcts/helm/save-pods-logs.sh'))
+      steps.sh(label: "Save pods logs in artifacts, under pods-logs-${scope}", script: """
     chmod +x save-pods-logs.sh
     ./save-pods-logs.sh ${releaseName} ${namespace} pods-logs-${scope}
     rm -f save-pods-logs.sh
     """)
 
-    steps.archiveArtifacts(allowEmptyArchive: true, artifacts: "pods-logs-${scope}/**")
+      steps.archiveArtifacts(allowEmptyArchive: true, artifacts: "pods-logs-${scope}/**")
+    }
+  } catch(err) {
+    steps.echo "Unable to complete saving pods logs in Jenkins artifacts"
   }
 }

--- a/vars/savePodsLogs.groovy
+++ b/vars/savePodsLogs.groovy
@@ -1,0 +1,19 @@
+
+
+def call(DockerImage dockerImage, Map params, String scope) {
+  onPR {
+    stageWithAgent("Save pods logs", params.product) {
+      def chartName = "${params.product}-${params.component}"
+      def imageTag = dockerImage.getTag()
+      def releaseName = "${chartName}-${imageTag}"
+
+      steps.writeFile(file: 'save-pods-logs.sh', text: steps.libraryResource('uk/gov/hmcts/helm/save-pods-logs.sh'))
+      steps.sh """
+        chmod +x save-pods-logs.sh
+        ./save-pods-logs.sh ${releaseName} ${env.TEAM_NAMESPACE} pods-logs-${scope}
+        rm -f save-pods-logs.sh
+      """
+      steps.archiveArtifacts allowEmptyArchive: true, artifacts: "pods-logs-${scope}/**"
+    }
+  }
+}

--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -93,8 +93,11 @@ def call(params) {
             testEnv(aksUrl) {
               pcr.callAround("smoketest:${environment}") {
                 timeoutWithMsg(time: 10, unit: 'MINUTES', action: 'Smoke Test - AKS') {
-                  builder.smokeTest()
-                  savePodsLogs(dockerImage, params, "smoke")
+                  try {
+                    builder.smokeTest()
+                  } finally {
+                    savePodsLogs(dockerImage, params, "smoke")
+                  }
                 }
               }
             }
@@ -107,8 +110,11 @@ def call(params) {
                   warnError('Failure in fullFunctionalTest') {
                     pcr.callAround("fullFunctionalTest:${environment}") {
                       timeoutWithMsg(time: config.fullFunctionalTestTimeout, unit: 'MINUTES', action: 'Functional tests') {
-                        builder.fullFunctionalTest()
-                        savePodsLogs(dockerImage, params, "full-functional")
+                        try {
+                          builder.fullFunctionalTest()
+                        } finally {
+                          savePodsLogs(dockerImage, params, "full-functional")
+                        }
                       }
                     }
                   }
@@ -119,8 +125,11 @@ def call(params) {
                 testEnv(aksUrl) {
                   pcr.callAround("functionalTest:${environment}") {
                     timeoutWithMsg(time: 40, unit: 'MINUTES', action: 'Functional Test - AKS') {
-                      builder.functionalTest()
-                      savePodsLogs(dockerImage, params, "functional")
+                      try {
+                        builder.functionalTest()
+                      } finally {
+                        savePodsLogs(dockerImage, params, "functional")
+                      }
                     }
                   }
                 }
@@ -195,8 +204,11 @@ def call(params) {
                 warnError('Failure in performanceTest') {
                   pcr.callAround('PerformanceTest') {
                     timeoutWithMsg(time: config.perfTestTimeout, unit: 'MINUTES', action: 'Performance test') {
-                      builder.performanceTest()
-                      savePodsLogs(dockerImage, params, "performance")
+                      try {
+                        builder.performanceTest()
+                      } finally {
+                        savePodsLogs(dockerImage, params, "performance")
+                      }
                     }
                   }
                 }

--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -94,6 +94,7 @@ def call(params) {
               pcr.callAround("smoketest:${environment}") {
                 timeoutWithMsg(time: 10, unit: 'MINUTES', action: 'Smoke Test - AKS') {
                   builder.smokeTest()
+                  savePodsLogs(dockerImage, params, "smoke")
                 }
               }
             }
@@ -107,6 +108,7 @@ def call(params) {
                     pcr.callAround("fullFunctionalTest:${environment}") {
                       timeoutWithMsg(time: config.fullFunctionalTestTimeout, unit: 'MINUTES', action: 'Functional tests') {
                         builder.fullFunctionalTest()
+                        savePodsLogs(dockerImage, params, "full-functional")
                       }
                     }
                   }
@@ -118,6 +120,7 @@ def call(params) {
                   pcr.callAround("functionalTest:${environment}") {
                     timeoutWithMsg(time: 40, unit: 'MINUTES', action: 'Functional Test - AKS') {
                       builder.functionalTest()
+                      savePodsLogs(dockerImage, params, "functional")
                     }
                   }
                 }
@@ -193,6 +196,7 @@ def call(params) {
                   pcr.callAround('PerformanceTest') {
                     timeoutWithMsg(time: config.perfTestTimeout, unit: 'MINUTES', action: 'Performance test') {
                       builder.performanceTest()
+                      savePodsLogs(dockerImage, params, "performance")
                     }
                   }
                 }


### PR DESCRIPTION
Notes:
In Civil we often hit the pods limit. This happens because failing builds keep the pods running to give the developer a chance to look into their logs and unfortunately our builds fail very often for various reasons.

This PR is part of a set of changes that aim at removing the pods regardless of success or failure.

This particular PR focuses on saving the pods logs into Jenkins artifacts so that the developer will no longer need the pods running to check their related logs.


For reference to anyone who is going to review, this is what you should see in Jenkins:
![image](https://user-images.githubusercontent.com/109352283/214066984-b2a4934a-4110-4264-9ccf-78987b4ac278.png)

And this is a log example:
![image](https://user-images.githubusercontent.com/109352283/214067336-76c7d5e3-34b7-47da-a9f1-90aacc3cf64b.png)


Based on this PR:
https://build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_a_to_c%2Fcivil-ccd-definition/detail/PR-1990/28/artifacts/

