### PR TITLE
Add support to delete helm releases on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,35 @@ To clear helm release, do the following:
   }
   ```
 
+#### Clear Helm Release on Failed Build
+
+If your team doesn't need to keep the helm releases for their PR even for failing builds, it is possible to clean them to free further resources.
+This may be useful to reduce resource contention in difficult projects with large teams, where pipeline stability is not yet where it should be.
+
+To clear helm releases for failing builds, do the following:
+
+  ```
+  withPipeline(type, product, component) {
+    ...
+    enableCleanupOfHelmReleaseOnFail()
+    ...
+  }
+  ```
+
+If you know you want to keep the helm releases for specific failures, you can do the following:
+
+  ```
+  withPipeline(type, product, component) {
+    ...
+    disableCleanupOfHelmReleaseOnFail()
+    ...
+  }
+  ```
+
+Note that the above works only for PR builds. Master builds are unaffected by this toggle.
+
+
+
 ### Opinionated infrastructure pipeline
 
 For infrastructure-only repositories e.g. "shared infrastructure" the library provides an opinionated infrastructure pipeline which will build Terraform files in the root of the repository.

--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ The API tests run after smoke tests.
 If your server never uses the deployed resources, teams can clear the helm release to free resources on the cluster.
 This can be done always or depending on success.
 
+To note that clearing the helm release won't deny you access to the pods logs, as they are saved before the helm release is cleared.
+
 To clear the helm release regardless of success or failure, do the following:
 
   ```
@@ -295,8 +297,6 @@ To clear the helm release on a failing build, do the following:
     ...
   }
   ```
-
-To note that clearing the helm release won't deny you access to the pods logs, as they are saved before the helm release is cleared.
 
 
 ### Opinionated infrastructure pipeline

--- a/README.md
+++ b/README.md
@@ -261,12 +261,22 @@ tests for that API. For the pipeline to run those tests, do the following:
 
 The API tests run after smoke tests.
 
+#### Clear Helm Release
 
-#### Clear Helm Release on Successful Build
+If your server never uses the deployed resources, teams can clear the helm release to free resources on the cluster.
+This can be done always or depending on success.
 
-If your service never use the deployed resources once the build is green, teams can clear the helm release to free resources on the cluster.
+To clear the helm release regardless of success or failure, do the following:
 
-To clear helm release, do the following:
+  ```
+  withPipeline(type, product, component) {
+    ...
+    enableCleanupOfHelmReleaseAlways()
+    ...
+  }
+  ```
+
+To clear the helm release on a successful build, do the following:
 
   ```
   withPipeline(type, product, component) {
@@ -276,12 +286,7 @@ To clear helm release, do the following:
   }
   ```
 
-#### Clear Helm Release on Failed Build
-
-If your team doesn't need to keep the helm releases for their PR even for failing builds, it is possible to clean them to free further resources.
-This may be useful to reduce resource contention in difficult projects with large teams, where pipeline stability is not yet where it should be.
-
-To clear helm releases for failing builds, do the following:
+To clear the helm release on a failing build, do the following:
 
   ```
   withPipeline(type, product, component) {
@@ -291,21 +296,7 @@ To clear helm releases for failing builds, do the following:
   }
   ```
 
-#### Clear Helm Release always
-
-If your team doesn't need to keep the helm releases for their PR regardless of success or failure, it is possible to clean them.
-
-To clear helm releases regardless of success, do the following:
-
-  ```
-  withPipeline(type, product, component) {
-    ...
-    enableCleanupOfHelmReleaseOnFailure()
-    ...
-  }
-  ```
-
-This essentially combines `enableCleanupOfHelmReleaseOnSuccess` and `enableCleanupOfHelmReleaseOnFailure` in one command.
+To note that clearing the helm release won't deny you access to the pods logs, as they are saved before the helm release is cleared.
 
 
 ### Opinionated infrastructure pipeline

--- a/README.md
+++ b/README.md
@@ -291,6 +291,22 @@ To clear helm releases for failing builds, do the following:
   }
   ```
 
+#### Clear Helm Release always
+
+If your team doesn't need to keep the helm releases for their PR regardless of success or failure, it is possible to clean them.
+
+To clear helm releases regardless of success, do the following:
+
+  ```
+  withPipeline(type, product, component) {
+    ...
+    enableCleanupOfHelmReleaseOnFailure()
+    ...
+  }
+  ```
+
+This essentially combines `enableCleanupOfHelmReleaseOnSuccess` and `enableCleanupOfHelmReleaseOnFailure` in one command.
+
 
 ### Opinionated infrastructure pipeline
 

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ To clear helm releases for failing builds, do the following:
   ```
   withPipeline(type, product, component) {
     ...
-    enableCleanupOfHelmReleaseOnFail()
+    enableCleanupOfHelmReleaseOnFailure()
     ...
   }
   ```

--- a/README.md
+++ b/README.md
@@ -291,17 +291,6 @@ To clear helm releases for failing builds, do the following:
   }
   ```
 
-If you know you want to keep the helm releases for specific failures, you can do the following:
-
-  ```
-  withPipeline(type, product, component) {
-    ...
-    disableCleanupOfHelmReleaseOnFail()
-    ...
-  }
-  ```
-
-
 
 ### Opinionated infrastructure pipeline
 

--- a/README.md
+++ b/README.md
@@ -301,8 +301,6 @@ If you know you want to keep the helm releases for specific failures, you can do
   }
   ```
 
-Note that the above works only for PR builds. Master builds are unaffected by this toggle.
-
 
 
 ### Opinionated infrastructure pipeline

--- a/README.md
+++ b/README.md
@@ -263,10 +263,8 @@ The API tests run after smoke tests.
 
 #### Clear Helm Release
 
-If your server never uses the deployed resources, teams can clear the helm release to free resources on the cluster.
-This can be done always or depending on success.
+If your service never uses the deployed resources after the pipeline is successful or if you refer to them only for logs in case of failure, you can uninstall the helm release to free resources on the cluster. Note that clearing the helm release won't deny you access to the pods logs, as they are saved as artefacts in Jenkins before the helm release is cleared.
 
-To note that clearing the helm release won't deny you access to the pods logs, as they are saved before the helm release is cleared.
 
 To clear the helm release regardless of success or failure, do the following:
 

--- a/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
@@ -24,7 +24,7 @@ class AppPipelineConfig extends CommonPipelineConfig implements Serializable {
   boolean pactConsumerCanIDeployEnabled = false
   boolean highLevelDataSetup = false
   boolean fortifyScan = false
-  boolean clearHelmRelease = false
+  boolean clearHelmReleaseOnSuccess = false
   boolean clearHelmReleaseOnFailure = false
   String fortifyVaultName
   String s2sServiceName

--- a/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
@@ -25,7 +25,7 @@ class AppPipelineConfig extends CommonPipelineConfig implements Serializable {
   boolean highLevelDataSetup = false
   boolean fortifyScan = false
   boolean clearHelmRelease = false
-  boolean clearHelmReleaseOnFail = false
+  boolean clearHelmReleaseOnFailure = false
   String fortifyVaultName
   String s2sServiceName
   String highLevelDataSetupKeyVaultName

--- a/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
@@ -25,6 +25,7 @@ class AppPipelineConfig extends CommonPipelineConfig implements Serializable {
   boolean highLevelDataSetup = false
   boolean fortifyScan = false
   boolean clearHelmRelease = false
+  boolean clearHelmReleaseOnFail = false
   String fortifyVaultName
   String s2sServiceName
   String highLevelDataSetupKeyVaultName

--- a/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
@@ -78,8 +78,13 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
     config.clearHelmRelease = true;
   }
 
-  void enableCleanupOfHelmReleaseOnFail() {
-    config.clearHelmReleaseOnFail = true;
+  void enableCleanupOfHelmReleaseOnFailure() {
+    config.clearHelmReleaseOnFailure = true;
+  }
+
+  void enableCleanupOfHelmReleaseAlways() {
+    config.clearHelmRelease = true;
+    config.clearHelmReleaseOnFailure = true;
   }
 
   enum PactRoles { CONSUMER, PROVIDER, CONSUMER_DEPLOY_CHECK}

--- a/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
@@ -82,10 +82,6 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
     config.clearHelmReleaseOnFail = true;
   }
 
-  void disableCleanupOfHelmReleaseOnFail() {
-    config.clearHelmReleaseOnFail = false;
-  }
-
   enum PactRoles { CONSUMER, PROVIDER, CONSUMER_DEPLOY_CHECK}
 
   void enablePactAs(List<PactRoles> roles) {

--- a/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
@@ -75,7 +75,7 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
   }
 
   void enableCleanupOfHelmReleaseOnSuccess() {
-    config.clearHelmRelease = true;
+    config.clearHelmReleaseOnSuccess = true;
   }
 
   void enableCleanupOfHelmReleaseOnFailure() {
@@ -83,7 +83,7 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
   }
 
   void enableCleanupOfHelmReleaseAlways() {
-    config.clearHelmRelease = true;
+    config.clearHelmReleaseOnSuccess = true;
     config.clearHelmReleaseOnFailure = true;
   }
 

--- a/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
@@ -78,6 +78,14 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
     config.clearHelmRelease = true;
   }
 
+  void enableCleanupOfHelmReleaseOnFail() {
+    config.clearHelmReleaseOnFail = true;
+  }
+
+  void disableCleanupOfHelmReleaseOnFail() {
+    config.clearHelmReleaseOnFail = false;
+  }
+
   enum PactRoles { CONSUMER, PROVIDER, CONSUMER_DEPLOY_CHECK}
 
   void enablePactAs(List<PactRoles> roles) {

--- a/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
+++ b/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
@@ -153,7 +153,7 @@ class AppPipelineConfigTest extends Specification {
     when:
     dsl.enableCleanupOfHelmReleaseOnSuccess()
     then:
-    assertThat(pipelineConfig.clearHelmRelease).isTrue()
+    assertThat(pipelineConfig.clearHelmReleaseOnSuccess).isTrue()
   }
 
     def "ensure enable high level data setup"() {

--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -259,7 +259,7 @@ def call(params) {
           }
 
           def triggerUninstall = environment == nonProdEnv
-          if (triggerUninstall || config.clearHelmRelease || depLabel) {
+          if (triggerUninstall || config.clearHelmReleaseOnSuccess || depLabel) {
             helmUninstall(dockerImage, params, pcr)
           }
         }

--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -105,7 +105,7 @@ def call(params) {
                   } catch(err) {
                     savePodsLogs(dockerImage, params, "smoke")
                     clearHelmReleaseForFailure(config, dockerImage, params, pcr)
-                    throw err
+                    error 'Build failed. Please check the build logs and the pods logs for further information. You will find the pods logs under Artifacts.'
                   }
                 }
               }
@@ -125,7 +125,7 @@ def call(params) {
                         } catch(err) {
                           savePodsLogs(dockerImage, params, "full-functional")
                           clearHelmReleaseForFailure(config, dockerImage, params, pcr)
-                          throw err
+                          error 'Build failed. Please check the build logs and the pods logs for further information. You will find the pods logs under Artifacts.'
                         }
                       }
                     }
@@ -143,7 +143,7 @@ def call(params) {
                       } catch(err) {
                         savePodsLogs(dockerImage, params, "functional")
                         clearHelmReleaseForFailure(config, dockerImage, params, pcr)
-                        throw err
+                        error 'Build failed. Please check the build logs and the pods logs for further information. You will find the pods logs under Artifacts.'
                       }
                     }
                   }

--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -105,7 +105,7 @@ def call(params) {
                   } catch(err) {
                     savePodsLogs(dockerImage, params, "smoke")
                     clearHelmReleaseForFailure(config, dockerImage, params, pcr)
-                    error 'Build failed. Please check the build logs and the pods logs for further information. You will find the pods logs under Artifacts.'
+                    throw err
                   }
                 }
               }
@@ -125,7 +125,7 @@ def call(params) {
                         } catch(err) {
                           savePodsLogs(dockerImage, params, "full-functional")
                           clearHelmReleaseForFailure(config, dockerImage, params, pcr)
-                          error 'Build failed. Please check the build logs and the pods logs for further information. You will find the pods logs under Artifacts.'
+                          throw err
                         }
                       }
                     }
@@ -143,7 +143,7 @@ def call(params) {
                       } catch(err) {
                         savePodsLogs(dockerImage, params, "functional")
                         clearHelmReleaseForFailure(config, dockerImage, params, pcr)
-                        error 'Build failed. Please check the build logs and the pods logs for further information. You will find the pods logs under Artifacts.'
+                        throw err
                       }
                     }
                   }

--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -103,6 +103,7 @@ def call(params) {
                     builder.smokeTest()
                   } catch(err) {
                     clearHelmReleaseForFailure(dockerImage, params, pcr)
+                    error 'Build failed'
                   }
                 }
               }
@@ -120,6 +121,7 @@ def call(params) {
                           builder.fullFunctionalTest()
                         } catch(err) {
                           clearHelmReleaseForFailure(dockerImage, params, pcr)
+                          error 'Build failed'
                         }
 
                       }
@@ -136,6 +138,7 @@ def call(params) {
                         builder.functionalTest()
                       } catch(err) {
                         clearHelmReleaseForFailure(dockerImage, params, pcr)
+                        error 'Build failed'
                       }
 
                     }

--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -19,7 +19,7 @@ def testEnv(String testUrl, block) {
   }
 }
 
-def clearHelmReleaseForFailure(DockerImage dockerImage, Map params, PipelineCallbacksRunner pcr) {
+def clearHelmReleaseForFailure(AppPipelineConfig config, DockerImage dockerImage, Map params, PipelineCallbacksRunner pcr) {
   if (config.clearHelmReleaseOnFail) {
     helmUninstall(dockerImage, params, pcr)
   }
@@ -104,7 +104,7 @@ def call(params) {
                     savePodsLogs(dockerImage, params, "smoke")
                   } catch(err) {
                     savePodsLogs(dockerImage, params, "smoke")
-                    clearHelmReleaseForFailure(dockerImage, params, pcr)
+                    clearHelmReleaseForFailure(config, dockerImage, params, pcr)
                     error 'Build failed'
                   }
                 }
@@ -124,7 +124,7 @@ def call(params) {
                           savePodsLogs(dockerImage, params, "full-functional")
                         } catch(err) {
                           savePodsLogs(dockerImage, params, "full-functional")
-                          clearHelmReleaseForFailure(dockerImage, params, pcr)
+                          clearHelmReleaseForFailure(config, dockerImage, params, pcr)
                           error 'Build failed'
                         }
                       }
@@ -142,7 +142,7 @@ def call(params) {
                         savePodsLogs(dockerImage, params, "functional")
                       } catch(err) {
                         savePodsLogs(dockerImage, params, "functional")
-                        clearHelmReleaseForFailure(dockerImage, params, pcr)
+                        clearHelmReleaseForFailure(config, dockerImage, params, pcr)
                         error 'Build failed'
                       }
                     }

--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -105,7 +105,7 @@ def call(params) {
                   } catch(err) {
                     savePodsLogs(dockerImage, params, "smoke")
                     clearHelmReleaseForFailure(config, dockerImage, params, pcr)
-                    error 'Build failed'
+                    throw err
                   }
                 }
               }
@@ -125,7 +125,7 @@ def call(params) {
                         } catch(err) {
                           savePodsLogs(dockerImage, params, "full-functional")
                           clearHelmReleaseForFailure(config, dockerImage, params, pcr)
-                          error 'Build failed'
+                          throw err
                         }
                       }
                     }
@@ -143,7 +143,7 @@ def call(params) {
                       } catch(err) {
                         savePodsLogs(dockerImage, params, "functional")
                         clearHelmReleaseForFailure(config, dockerImage, params, pcr)
-                        error 'Build failed'
+                        throw err
                       }
                     }
                   }


### PR DESCRIPTION
In Civil we often hit the pods limit. This happens because failing builds keep the pods running to give the developer a chance to look into their logs and unfortunately our builds fail very often for various reasons.

This PR is part of a set of changes that aim at removing the pods regardless of success or failure.

This particular PR focuses on providing functionality that will allow to delete the helm releases also for failing builds and it's meant to be tested and released after #959 (it touches the same areas and the changes are expected to be functionally conflicting). Other PRs in the civil namespace will then use this functionality to clear the pods.

The expectation is that this change will enable the Civil teams to rid themselves of a problem that is all too often stopping development and testing activity and may even result in a significant reduction in the overall amount of used resources, which may allow the Civil teams to start tackling other related issues.

The following is an example of us running out of pods:
![image](https://user-images.githubusercontent.com/109352283/214091973-15e52e3e-ab08-4991-bda1-d1c1b284f37b.png)

After the changes in this PR, adding the line highlighted below will allow to delete the helm releases even after failure:
![image](https://user-images.githubusercontent.com/109352283/214092395-e2b97cdc-f0b2-4d26-8bb3-b85e8878ff20.png)

