### PR TITLE
Upgrade to 8.x dependency check plugin

### DIFF
--- a/resources/uk/gov/hmcts/gradle/init.gradle
+++ b/resources/uk/gov/hmcts/gradle/init.gradle
@@ -46,6 +46,7 @@ allprojects {
       configure(project) {
         dependencyCheck {
           autoUpdate = false
+          hostedSuppressions.forceupdate = true
           // Any CVE should fail the build.
           failBuildOnCVSS = 0
 


### PR DESCRIPTION
As we disable autoupdate on owasp dependency check plugin, we cannot use global suppressions without using this additional flag.
