### PR TITLE
HMAN-514 Allow optional functional tests for nonServiceApp

### DIFF
--- a/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
@@ -13,6 +13,7 @@ class AppPipelineConfig extends CommonPipelineConfig implements Serializable {
   List<String> parallelCrossBrowsers = []
   boolean mutationTest = false
   boolean fullFunctionalTest = false
+  String fullFunctionalTestNonServiceAppTestUrl
   boolean securityScan = false
   boolean serviceApp = true
   boolean aksStagingDeployment = false

--- a/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
@@ -49,6 +49,12 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
     config.fullFunctionalTest = true
   }
 
+  void enableFullFunctionalTestNonServiceApp(String nonServiceAppTestUrl, int timeout = 30) {
+    config.fullFunctionalTestNonServiceAppTestUrl = nonServiceAppTestUrl
+    config.fullFunctionalTestTimeout = timeout
+    config.fullFunctionalTest = true
+  }
+
   void enableMutationTest(int timeout = 120) {
     config.mutationTestTimeout = timeout
     config.mutationTest = true

--- a/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
+++ b/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
@@ -96,6 +96,32 @@ class AppPipelineConfigTest extends Specification {
       assertThat(pipelineConfig.fullFunctionalTestTimeout).isEqualTo(30)
   }
 
+  def "ensure enable full functional test - with timeout"() {
+    when:
+      dsl.enableFullFunctionalTest(100)
+    then:
+      assertThat(pipelineConfig.fullFunctionalTest).isTrue()
+      assertThat(pipelineConfig.fullFunctionalTestTimeout).isEqualTo(100)
+  }
+
+  def "ensure enable full functional test for non-service app"() {
+    when:
+      dsl.enableFullFunctionalTestNonServiceApp("http://localhost:1234/test")
+    then:
+      assertThat(pipelineConfig.fullFunctionalTest).isTrue()
+      assertThat(pipelineConfig.fullFunctionalTestTimeout).isEqualTo(30)
+      assertThat(pipelineConfig.fullFunctionalTestNonServiceAppTestUrl).isEqualTo("http://localhost:1234/test")
+  }
+
+  def "ensure enable full functional test for non-service app - with timeout"() {
+    when:
+      dsl.enableFullFunctionalTestNonServiceApp("http://localhost:1234/test2", 100)
+    then:
+      assertThat(pipelineConfig.fullFunctionalTest).isTrue()
+      assertThat(pipelineConfig.fullFunctionalTestTimeout).isEqualTo(100)
+      assertThat(pipelineConfig.fullFunctionalTestNonServiceAppTestUrl).isEqualTo("http://localhost:1234/test2")
+  }
+
   def "ensure enable mutation test"() {
     when:
       dsl.enableMutationTest()


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [HMAN-514](https://tools.hmcts.net/jira/browse/HMAN-514) _"Next Hearing Date Updater - use jenkins step for Functional Tests"_

### Change description ###

Allow option of using functional tests for nonServiceApp, e.g. `enableFullFunctionalTest(…)`.

#### Tested in: ####