### PR TITLE
set +x to prevent command echoing

### DIFF
--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -136,7 +136,9 @@ class GradleBuilder extends AbstractBuilder {
     ]
     localSteps.withAzureKeyvault(secrets) {
       try {
+          gradle("set +x")
           gradle("--stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${localSteps.env.OWASPDB_V6_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V6_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate")
+          gradle("set -x")
       } finally {
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'
         String dependencyReport = localSteps.readFile('build/reports/dependency-check-report.json')

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -135,9 +135,11 @@ class GradleBuilder extends AbstractBuilder {
       [ secretType: 'Secret', name: 'OWASPPostgresDb-v6-Account', version: '', envVariable: 'OWASPDB_V6_ACCOUNT' ],
       [ secretType: 'Secret', name: 'OWASPPostgresDb-v6-Password', version: '', envVariable: 'OWASPDB_V6_PASSWORD' ]
     ]
-    localSteps.azureKeyVault(secrets) {
-        // using sh directly so that secrets don't get interpolated in the gradle function
-        steps.sh('./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name="org.postgresql.Driver" -Ddata.connection_string="jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck" -Ddata.user=$OWASPDB_V6_ACCOUNT -Ddata.password=$OWASPDB_V6_PASSWORD -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate')
+
+    steps.azureKeyVault(secrets) {
+      // using sh directly so that secrets don't get interpolated in the gradle function
+      steps.sh('./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name="org.postgresql.Driver" -Ddata.connection_string="jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck" -Ddata.user=$OWASPDB_V6_ACCOUNT -Ddata.password=$OWASPDB_V6_PASSWORD -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate')
+    }
     localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'
     String dependencyReport = localSteps.readFile('build/reports/dependency-check-report.json')
 
@@ -145,7 +147,6 @@ class GradleBuilder extends AbstractBuilder {
 
     new CVEPublisher(localSteps)
       .publishCVEReport('java', cveReport)
-      }
     }
 
   def prepareCVEReport(String owaspReportJSON) {

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -136,7 +136,7 @@ class GradleBuilder extends AbstractBuilder {
     ]
     localSteps.withAzureKeyvault(secrets) {
       try {
-        localSteps.sh('./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$localSteps.env.OWASPDB_V6_ACCOUNT -Ddata.password=$localSteps.env.OWASPDB_V6_PASSWORD  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate')
+        localSteps.sh('./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$OWASPDB_V6_ACCOUNT -Ddata.password=$OWASPDB_V6_PASSWORD  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate')
 
 
       } finally {

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -136,7 +136,8 @@ class GradleBuilder extends AbstractBuilder {
     ]
     localSteps.withAzureKeyvault(secrets) {
       try {
-        localSteps.sh './gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$localSteps.env.OWASPDB_V6_ACCOUNT -Ddata.password=$localSteps.env.OWASPDB_V6_PASSWORD  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate'
+        localSteps.sh.withEnv('./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$localSteps.env.OWASPDB_V6_ACCOUNT -Ddata.password=$localSteps.env.OWASPDB_V6_PASSWORD  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate')
+
 
       } finally {
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -138,7 +138,7 @@ class GradleBuilder extends AbstractBuilder {
 
     steps.azureKeyVault(secrets) {
       // using sh directly so that secrets don't get interpolated in the gradle function
-      steps.sh('./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name="org.postgresql.Driver" -Ddata.connection_string="jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck" -Ddata.user=$OWASPDB_V6_ACCOUNT -Ddata.password=$OWASPDB_V6_PASSWORD -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate')
+      steps.sh('''./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name="org.postgresql.Driver" -Ddata.connection_string="jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck" -Ddata.user=$OWASPDB_V6_ACCOUNT -Ddata.password=$OWASPDB_V6_PASSWORD -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate''')
     }
     localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'
     String dependencyReport = localSteps.readFile('build/reports/dependency-check-report.json')

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -140,7 +140,7 @@ class GradleBuilder extends AbstractBuilder {
 set +x
 ./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$OWASPDB_V6_ACCOUNT -Ddata.password=$OWASPDB_V6_PASSWORD  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate
 set -x
-""")
+""", returnStdout: true )
       } finally {
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'
         String dependencyReport = localSteps.readFile('build/reports/dependency-check-report.json')

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -140,10 +140,9 @@ class GradleBuilder extends AbstractBuilder {
 set +x
 ./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$OWASPDB_V6_ACCOUNT -Ddata.password=$OWASPDB_V6_PASSWORD  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate
 set -x
-""", returnStdout: true )
-        except Exception e{
+""", returnStdout: true)
+      } catch (Exception e){
           e.printStackTrace()
-        }
       } finally {
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'
         String dependencyReport = localSteps.readFile('build/reports/dependency-check-report.json')

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -137,7 +137,11 @@ class GradleBuilder extends AbstractBuilder {
     ]
     localSteps.withAzureKeyvault(secrets) {
       try {
-        gradle('--stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name="org.postgresql.Driver" -Ddata.connection_string="jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck" -Ddata.user=$OWASPDB_V6_ACCOUNT -Ddata.password=$OWASPDB_V6_PASSWORD -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate')
+        localSteps.sh('''
+set +x
+./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name="org.postgresql.Driver" -Ddata.connection_string="jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck" -Ddata.user=$OWASPDB_V6_ACCOUNT -Ddata.password=$OWASPDB_V6_PASSWORD -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate
+set -x
+''')
       } catch (Exception e){
         Functions.printThrowable(e)
       } finally {

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -137,11 +137,9 @@ class GradleBuilder extends AbstractBuilder {
     ]
     localSteps.withAzureKeyvault(secrets) {
       try {
-        steps.sh('''
-set +x
-./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name="org.postgresql.Driver" -Ddata.connection_string="jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck" -Ddata.user=$OWASPDB_V6_ACCOUNT -Ddata.password=$OWASPDB_V6_PASSWORD -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate
-set -x
-''')
+        steps.sh(
+          './gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name="org.postgresql.Driver" -Ddata.connection_string="jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck" -Ddata.user=$OWASPDB_V6_ACCOUNT -Ddata.password=$OWASPDB_V6_PASSWORD -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate'
+        )
       } catch (Exception e){
         Functions.printThrowable(e)
       } finally {

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -136,11 +136,9 @@ class GradleBuilder extends AbstractBuilder {
     ]
     localSteps.withAzureKeyvault(secrets) {
       try {
-        localSteps.sh '''
-        set +x
-        ./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${localSteps.env.OWASPDB_V6_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V6_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate
-        set -x
-        '''
+        localSteps.sh "set +x \
+        ./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${localSteps.env.OWASPDB_V6_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V6_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate \
+        set -x"
 
       } finally {
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -136,9 +136,11 @@ class GradleBuilder extends AbstractBuilder {
     ]
     localSteps.withAzureKeyvault(secrets) {
       try {
+        localSteps.sh "set +x"
         localSteps.sh "./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${localSteps.env.OWASPDB_V6_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V6_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate"
 
       } finally {
+        localSteps.sh "set -x"
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'
         String dependencyReport = localSteps.readFile('build/reports/dependency-check-report.json')
 

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -136,7 +136,7 @@ class GradleBuilder extends AbstractBuilder {
     ]
     localSteps.withAzureKeyvault(secrets) {
       try {
-        sh('./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$OWASPDB_V6_ACCOUNT -Ddata.password=$OWASPDB_V6_PASSWORD  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate')
+        localSteps.sh('./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$OWASPDB_V6_ACCOUNT -Ddata.password=$OWASPDB_V6_PASSWORD  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate')
       } finally {
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'
         String dependencyReport = localSteps.readFile('build/reports/dependency-check-report.json')

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -137,6 +137,7 @@ class GradleBuilder extends AbstractBuilder {
     ]
     localSteps.withAzureKeyvault(secrets) {
       try {
+        // using sh directly so that secrets don't get interpolated in the gradle function
         steps.sh(
           './gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name="org.postgresql.Driver" -Ddata.connection_string="jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck" -Ddata.user=$OWASPDB_V6_ACCOUNT -Ddata.password=$OWASPDB_V6_PASSWORD -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate'
         )

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.contino
 
 import groovy.json.JsonSlurper
+import hudson.Functions
 import uk.gov.hmcts.pipeline.CVEPublisher
 import uk.gov.hmcts.pipeline.SonarProperties
 import uk.gov.hmcts.pipeline.deprecation.WarningCollector
@@ -142,7 +143,7 @@ set +x
 set -x
 """, returnStdout: true)
       } catch (Exception e){
-          e.printStackTrace()
+        Functions.printThrowable(e)
       } finally {
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'
         String dependencyReport = localSteps.readFile('build/reports/dependency-check-report.json')

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -137,11 +137,7 @@ class GradleBuilder extends AbstractBuilder {
     ]
     localSteps.withAzureKeyvault(secrets) {
       try {
-        localSteps.sh(script: """
-set +x
-./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$OWASPDB_V6_ACCOUNT -Ddata.password=$OWASPDB_V6_PASSWORD  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate
-set -x
-""", returnStdout: true)
+        gradle('--stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='$OWASPDB_V6_ACCOUNT' -Ddata.password='$OWASPDB_V6_PASSWORD' -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate')
       } catch (Exception e){
         Functions.printThrowable(e)
       } finally {

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -137,7 +137,7 @@ class GradleBuilder extends AbstractBuilder {
     ]
     localSteps.withAzureKeyvault(secrets) {
       try {
-        gradle('--stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='$OWASPDB_V6_ACCOUNT' -Ddata.password='$OWASPDB_V6_PASSWORD' -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate')
+        gradle('--stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name="org.postgresql.Driver" -Ddata.connection_string="jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck" -Ddata.user=$OWASPDB_V6_ACCOUNT -Ddata.password=$OWASPDB_V6_PASSWORD -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate')
       } catch (Exception e){
         Functions.printThrowable(e)
       } finally {

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -136,10 +136,9 @@ class GradleBuilder extends AbstractBuilder {
     ]
     localSteps.withAzureKeyvault(secrets) {
       try {
-        localSteps.sh "set +x \
-        ./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${localSteps.env.OWASPDB_V6_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V6_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate \
-        set -x"
-
+        localSteps.sh '''
+        ./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${localSteps.env.OWASPDB_V6_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V6_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate
+        '''
       } finally {
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'
         String dependencyReport = localSteps.readFile('build/reports/dependency-check-report.json')

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -136,10 +136,11 @@ class GradleBuilder extends AbstractBuilder {
     ]
     localSteps.withAzureKeyvault(secrets) {
       try {
-          localSteps.sh
-        '''set +x
+        localSteps.sh '''
+        set +x
         ./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${localSteps.env.OWASPDB_V6_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V6_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate
-        set -x'''
+        set -x
+        '''
 
       } finally {
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -136,7 +136,7 @@ class GradleBuilder extends AbstractBuilder {
     ]
     localSteps.withAzureKeyvault(secrets) {
       try {
-        localSteps.sh.withEnv('./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$localSteps.env.OWASPDB_V6_ACCOUNT -Ddata.password=$localSteps.env.OWASPDB_V6_PASSWORD  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate')
+        localSteps.sh('./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$localSteps.env.OWASPDB_V6_ACCOUNT -Ddata.password=$localSteps.env.OWASPDB_V6_PASSWORD  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate')
 
 
       } finally {

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -136,7 +136,11 @@ class GradleBuilder extends AbstractBuilder {
     ]
     localSteps.withAzureKeyvault(secrets) {
       try {
-        localSteps.sh(script: 'set +x ./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$OWASPDB_V6_ACCOUNT -Ddata.password=$OWASPDB_V6_PASSWORD  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate')
+        localSteps.sh(script: """
+set +x
+./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$OWASPDB_V6_ACCOUNT -Ddata.password=$OWASPDB_V6_PASSWORD  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate
+set -x
+""")
       } finally {
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'
         String dependencyReport = localSteps.readFile('build/reports/dependency-check-report.json')

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -141,6 +141,9 @@ set +x
 ./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$OWASPDB_V6_ACCOUNT -Ddata.password=$OWASPDB_V6_PASSWORD  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate
 set -x
 """, returnStdout: true )
+        except Exception e{
+          e.printStackTrace()
+        }
       } finally {
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'
         String dependencyReport = localSteps.readFile('build/reports/dependency-check-report.json')

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -136,10 +136,9 @@ class GradleBuilder extends AbstractBuilder {
     ]
     localSteps.withAzureKeyvault(secrets) {
       try {
-        localSteps.sh "set +x ./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${localSteps.env.OWASPDB_V6_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V6_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate"
+        localSteps.sh './gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=${localSteps.env.OWASPDB_V6_ACCOUNT} -Ddata.password=${localSteps.env.OWASPDB_V6_PASSWORD}  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate'
 
       } finally {
-        localSteps.sh "set -x"
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'
         String dependencyReport = localSteps.readFile('build/reports/dependency-check-report.json')
 

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -138,8 +138,9 @@ class GradleBuilder extends AbstractBuilder {
       try {
           localSteps.sh '''set +x'''
           gradle("--stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${localSteps.env.OWASPDB_V6_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V6_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate")
-          localSteps.sh '''set -x'''
+
       } finally {
+        localSteps.sh '''set -x'''
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'
         String dependencyReport = localSteps.readFile('build/reports/dependency-check-report.json')
 

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -136,7 +136,7 @@ class GradleBuilder extends AbstractBuilder {
     ]
     localSteps.withAzureKeyvault(secrets) {
       try {
-        localSteps.sh './gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=${localSteps.env.OWASPDB_V6_ACCOUNT} -Ddata.password=${localSteps.env.OWASPDB_V6_PASSWORD}  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate'
+        localSteps.sh './gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$localSteps.env.OWASPDB_V6_ACCOUNT -Ddata.password=$localSteps.env.OWASPDB_V6_PASSWORD  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate'
 
       } finally {
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -136,8 +136,7 @@ class GradleBuilder extends AbstractBuilder {
     ]
     localSteps.withAzureKeyvault(secrets) {
       try {
-        localSteps.sh "set +x"
-        localSteps.sh "./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${localSteps.env.OWASPDB_V6_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V6_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate"
+        localSteps.sh "set +x ./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${localSteps.env.OWASPDB_V6_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V6_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate"
 
       } finally {
         localSteps.sh "set -x"

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -136,11 +136,12 @@ class GradleBuilder extends AbstractBuilder {
     ]
     localSteps.withAzureKeyvault(secrets) {
       try {
-          localSteps.sh '''set +x'''
-          gradle("--stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${localSteps.env.OWASPDB_V6_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V6_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate")
+          localSteps.sh
+        '''set +x
+        ./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${localSteps.env.OWASPDB_V6_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V6_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate
+        set -x'''
 
       } finally {
-        localSteps.sh '''set -x'''
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'
         String dependencyReport = localSteps.readFile('build/reports/dependency-check-report.json')
 

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -136,9 +136,8 @@ class GradleBuilder extends AbstractBuilder {
     ]
     localSteps.withAzureKeyvault(secrets) {
       try {
-        localSteps.sh '''
-        ./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${localSteps.env.OWASPDB_V6_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V6_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate
-        '''
+        localSteps.sh "./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${localSteps.env.OWASPDB_V6_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V6_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate"
+
       } finally {
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'
         String dependencyReport = localSteps.readFile('build/reports/dependency-check-report.json')

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -136,9 +136,7 @@ class GradleBuilder extends AbstractBuilder {
     ]
     localSteps.withAzureKeyvault(secrets) {
       try {
-        localSteps.sh.withEnv('./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$OWASPDB_V6_ACCOUNT -Ddata.password=$OWASPDB_V6_PASSWORD  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate')
-
-
+        sh('./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$OWASPDB_V6_ACCOUNT -Ddata.password=$OWASPDB_V6_PASSWORD  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate')
       } finally {
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'
         String dependencyReport = localSteps.readFile('build/reports/dependency-check-report.json')

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -135,7 +135,7 @@ class GradleBuilder extends AbstractBuilder {
       [ secretType: 'Secret', name: 'OWASPPostgresDb-v6-Account', version: '', envVariable: 'OWASPDB_V6_ACCOUNT' ],
       [ secretType: 'Secret', name: 'OWASPPostgresDb-v6-Password', version: '', envVariable: 'OWASPDB_V6_PASSWORD' ]
     ]
-    localSteps.withAzureKeyvault(secrets) {
+    localSteps.azureKeyVault(secrets) {
       try {
         // using sh directly so that secrets don't get interpolated in the gradle function
         steps.sh(

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -136,9 +136,9 @@ class GradleBuilder extends AbstractBuilder {
     ]
     localSteps.withAzureKeyvault(secrets) {
       try {
-          gradle("set +x")
+          localSteps.sh '''set +x'''
           gradle("--stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${localSteps.env.OWASPDB_V6_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V6_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate")
-          gradle("set -x")
+          localSteps.sh '''set -x'''
       } finally {
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'
         String dependencyReport = localSteps.readFile('build/reports/dependency-check-report.json')

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -136,7 +136,7 @@ class GradleBuilder extends AbstractBuilder {
     ]
     localSteps.withAzureKeyvault(secrets) {
       try {
-        localSteps.sh('./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$OWASPDB_V6_ACCOUNT -Ddata.password=$OWASPDB_V6_PASSWORD  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate')
+        localSteps.sh.withEnv('./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$OWASPDB_V6_ACCOUNT -Ddata.password=$OWASPDB_V6_PASSWORD  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate')
 
 
       } finally {

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -137,7 +137,7 @@ class GradleBuilder extends AbstractBuilder {
     ]
     localSteps.withAzureKeyvault(secrets) {
       try {
-        localSteps.sh('''
+        steps.sh('''
 set +x
 ./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name="org.postgresql.Driver" -Ddata.connection_string="jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck" -Ddata.user=$OWASPDB_V6_ACCOUNT -Ddata.password=$OWASPDB_V6_PASSWORD -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate
 set -x

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -137,13 +137,7 @@ class GradleBuilder extends AbstractBuilder {
     ]
     localSteps.withAzureKeyvault(secrets) {
       try {
-        localSteps.sh('''
-set +x
-./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name="org.postgresql.Driver" -Ddata.connection_string="jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck" -Ddata.user=$OWASPDB_V6_ACCOUNT -Ddata.password=$OWASPDB_V6_PASSWORD -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate
-set -x
-''')
-      } catch (Exception e){
-        Functions.printThrowable(e)
+        gradle("--stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck' -Ddata.user='${localSteps.env.OWASPDB_V6_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V6_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate", "set +x")
       } finally {
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'
         String dependencyReport = localSteps.readFile('build/reports/dependency-check-report.json')

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -136,7 +136,7 @@ class GradleBuilder extends AbstractBuilder {
     ]
     localSteps.withAzureKeyvault(secrets) {
       try {
-        localSteps.sh('./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$OWASPDB_V6_ACCOUNT -Ddata.password=$OWASPDB_V6_PASSWORD  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate')
+        localSteps.sh(script: 'set +x ./gradlew --no-daemon --init-script init.gradle --stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-v6-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$OWASPDB_V6_ACCOUNT -Ddata.password=$OWASPDB_V6_PASSWORD  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate')
       } finally {
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'
         String dependencyReport = localSteps.readFile('build/reports/dependency-check-report.json')

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -312,7 +312,7 @@ EOF
 
   private nagAboutOldYarnVersions() {
      if (!isYarnV2OrNewer()){
-       WarningCollector.addPipelineWarning("old_yarn_version", "Please upgrade to Yarn V3, see https://moj.enterprise.slack.com/files/T1L0WSW9F/F04784SLAJC?origin_team=T1L0WSW9F", LocalDate.of(2023, 02, 9))
+       WarningCollector.addPipelineWarning("old_yarn_version", "Please upgrade to Yarn V3, see https://moj.enterprise.slack.com/files/T1L0WSW9F/F04784SLAJC?origin_team=T1L0WSW9F", LocalDate.of(2023, 04, 26))
     }  
   }
 

--- a/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
@@ -114,7 +114,7 @@ class GradleBuilderTest extends Specification {
     spyGradleBuilder.securityCheck()
     then:
       1 * steps.sh({
-        GString it -> it.startsWith(GRADLE_CMD) && it.contains('dependencyCheckAggregate') &&
+        GString it -> it.contains(GRADLE_CMD) && it.contains('dependencyCheckAggregate') &&
         it.contains('jdbc:postgresql://owaspdependency-v6-prod')
       })
   }

--- a/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
@@ -106,7 +106,7 @@ class GradleBuilderTest extends Specification {
   def "securityCheck calls 'gradle dependencyCheckAggregate'"() {
     setup:
       def closure
-      steps.azureKeyvault(_, { it.call() }) >> { closure = it }
+      steps.azureKeyVault(_, { it.call() }) >> { closure = it }
     when:
     builder.securityCheck()
     then:

--- a/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
@@ -106,7 +106,7 @@ class GradleBuilderTest extends Specification {
   def "securityCheck calls 'gradle dependencyCheckAggregate'"() {
     setup:
       def closure
-      steps.withAzureKeyvault(_, { it.call() }) >> { closure = it }
+      steps.azureKeyvault(_, { it.call() }) >> { closure = it }
     when:
     builder.securityCheck()
     then:

--- a/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
@@ -107,15 +107,12 @@ class GradleBuilderTest extends Specification {
     setup:
       def closure
       steps.withAzureKeyvault(_, { it.call() }) >> { closure = it }
-      def spyGradleBuilder = Spy(GradleBuilder, constructorArgs: [steps, 'test']) {
-        hasPlugin(_) >> true
-      }
     when:
-    spyGradleBuilder.securityCheck()
+    builder.securityCheck()
     then:
       1 * steps.sh({
-        GString it -> it.contains(GRADLE_CMD) && it.contains('dependencyCheckAggregate') &&
-        it.contains('jdbc:postgresql://owaspdependency-v6-prod')
+        it.contains(GRADLE_CMD) && it.contains('dependencyCheckAggregate') &&
+        it.contains('jdbc:postgresql://owaspdependency-v6-prod') && it.contains('$OWASPDB_V6_ACCOUNT')
       })
   }
 

--- a/test/uk/gov/hmcts/contino/JenkinsStepMock.groovy
+++ b/test/uk/gov/hmcts/contino/JenkinsStepMock.groovy
@@ -17,6 +17,7 @@ interface JenkinsStepMock {
   Object writeFile(Map)
   Object withCredentials(ArrayList, Closure)
   Object withAzureKeyvault(ArrayList, Closure)
+  Object azureKeyVault(ArrayList, Closure)
   Object httpRequest(LinkedHashMap)
 
   Object ansiColor(String, Closure)


### PR DESCRIPTION
Resolves #994 . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
* hidden the shell execution of the ./gradlew step
* moved away from the gradle wrapper function for this (to allow the shell to be intercepted by tests and to use +x for an individual command)
* There is a high likelihood the spock test is not great. If a fix is needed let me know.

