### PR TITLE
DTSPO-11969 - Add expires to withParameterizedInfraPipeline

### DIFF
--- a/vars/spinInfra.groovy
+++ b/vars/spinInfra.groovy
@@ -62,7 +62,7 @@ def call(Map<String, ?> params) {
 
         def tags = [environment: Environment.toTagName(config.environment), changeUrl: changeUrl, managedBy: teamName, BuiltFrom: builtFrom, contactSlackChannel: contactSlackChannel, application: env.TEAM_APPLICATION_TAG, businessArea: env.BUSINESS_AREA_TAG]
 
-        if (new Environment(env).sandbox == config.environment || config.environment == "sbox" || config.environment == "sandbox") {
+        if (config.environment == "sbox" || config.environment == "sandbox") {
           tags = tags + [expiresAfter: config.expires]
         }
 

--- a/vars/spinInfra.groovy
+++ b/vars/spinInfra.groovy
@@ -62,7 +62,7 @@ def call(Map<String, ?> params) {
 
         def tags = [environment: Environment.toTagName(config.environment), changeUrl: changeUrl, managedBy: teamName, BuiltFrom: builtFrom, contactSlackChannel: contactSlackChannel, application: env.TEAM_APPLICATION_TAG, businessArea: env.BUSINESS_AREA_TAG]
 
-        if (config.environment == "sbox" || config.environment == "sandbox") {
+        if (new Environment(env).sandbox == config.environment || config.environment == "sbox") {
           tags = tags + [expiresAfter: config.expires]
         }
 

--- a/vars/spinInfra.groovy
+++ b/vars/spinInfra.groovy
@@ -62,7 +62,7 @@ def call(Map<String, ?> params) {
 
         def tags = [environment: Environment.toTagName(config.environment), changeUrl: changeUrl, managedBy: teamName, BuiltFrom: builtFrom, contactSlackChannel: contactSlackChannel, application: env.TEAM_APPLICATION_TAG, businessArea: env.BUSINESS_AREA_TAG]
 
-        if (new Environment(env).sandbox == config.environment || config.environment == "sbox") {
+        if (new Environment(env).sandbox == config.environment || config.environment == "sbox" || config.environment == "sandbox") {
           tags = tags + [expiresAfter: config.expires]
         }
 

--- a/vars/withParameterizedInfraPipeline.groovy
+++ b/vars/withParameterizedInfraPipeline.groovy
@@ -53,6 +53,7 @@ def call(String product, String environment, String subscription, Boolean planOn
         deploymentTargets: null,
         product: product,
         component: component,
+        expires: pipelineConfig.expiryDate,
         pipelineCallbacksRunner: callbacksRunner,
       )
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-11969

`expires` parameter was missing from withParameterizedInfraPipeline which was preventing passing a non-default value through to the toffee sbox pipeline