### PR TITLE
DTSPO-12454 Use java 17 for running gradle when project requests 17

### DIFF
--- a/resources/uk/gov/hmcts/gradle/init.gradle
+++ b/resources/uk/gov/hmcts/gradle/init.gradle
@@ -24,10 +24,6 @@ allprojects {
   task printVersionInit {
     doLast { println project.version }
   }
-
-  task javaVersion {
-    doLast { println project.sourceCompatibility }
-  }
 }
 
 settingsEvaluated { settings ->

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -242,6 +242,8 @@ EOF
       if (statusCode == 0) {
         steps.env.JAVA_HOME = "/usr/lib/jvm/java-17-openjdk-amd64"
         steps.env.PATH = "${steps.env.JAVA_HOME}/bin:${steps.env.PATH}"
+        // Workaround jacocoTestReport issue https://github.com/gradle/gradle/issues/18508#issuecomment-1049998305
+        steps.env.GRADLE_OPTS = "--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED"
       }
     } catch(err) {
       steps.echo "Failed to detect java version, ensure the root project has the correct Java requirements set"

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -238,9 +238,8 @@ EOF
     gradle("--version") // ensure wrapper has been downloaded
 
     try {
-      def javaVersion = gradleWithOutput("-q :javaVersion")
-      steps.echo "Found java version: ${javaVersion}"
-      if (javaVersion == '17') {
+      def statusCode = steps.sh script: 'grep -F JavaLanguageVersion.of(17) build.gradle', returnStatus: true
+      if (statusCode == 0) {
         steps.env.JAVA_HOME = "/usr/lib/jvm/java-17-openjdk-amd64"
         steps.env.PATH = "${steps.env.JAVA_HOME}/bin:${steps.env.PATH}"
       }

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -238,7 +238,7 @@ EOF
     gradle("--version") // ensure wrapper has been downloaded
 
     try {
-      def statusCode = steps.sh script: 'grep -F JavaLanguageVersion.of(17) build.gradle', returnStatus: true
+      def statusCode = steps.sh script: 'grep -F "JavaLanguageVersion.of(17)" build.gradle', returnStatus: true
       if (statusCode == 0) {
         steps.env.JAVA_HOME = "/usr/lib/jvm/java-17-openjdk-amd64"
         steps.env.PATH = "${steps.env.JAVA_HOME}/bin:${steps.env.PATH}"

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -236,6 +236,18 @@ EOF
   @Override
   def setupToolVersion() {
     gradle("--version") // ensure wrapper has been downloaded
+
+    try {
+      def javaVersion = gradleWithOutput("-q :javaVersion")
+      steps.echo "Found java version: ${javaVersion}"
+      if (javaVersion == '17') {
+        steps.env.JAVA_HOME = "/usr/lib/jvm/java-17-openjdk-amd64"
+        steps.env.PATH = "${steps.env.JAVA_HOME}/bin:${steps.env.PATH}"
+      }
+    } catch(err) {
+      steps.echo "Failed to detect java version, ensure the root project has the correct Java requirements set"
+    }
+
     localSteps.sh "java -version"
   }
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-12454

Spring Boot 3 gradle plugin requires Java 17
Previously we used toolchains for this and ran on Java 11, but now that a Gradle plugin requires 17, the gradle jvm needs to be running 17 as well