### PR TITLE
Dtspo 7198 security scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ TestName | How to enable | Example
  CrossBrowser | Add package.json file with "test:crossbrowser" : "Your script to run browser tests" and call enableCrossBrowserTest()| [CrossBrowser example](https://github.com/hmcts/nfdiv-frontend/blob/aea2aa8429d3c7495226ee6b5178bde6f0b639e4/package.json#L31)
  FortifyScan | Call enableFortifyScan() | [Java example](https://github.com/hmcts/ccd-user-profile-api/pull/409/files) <br>[Node example](https://github.com/hmcts/ccd-case-management-web/pull/1102/files)
  Performance* | Add Gatling config and call enablePerformancetest() | [Example Gatling config](https://github.com/hmcts/sscs-performance/tree/64168f527add681d8a2853791a0508b7997fbb1b/src/gatling)
- SecurityScan | Add a file in root of repository called security.sh and call enableSecurityScan() | [Web Application example](https://github.com/hmcts/probate-frontend/blob/a56b63fb306b6b2139148c27b7b1daf001f2743c/security.sh) <br>[API example](https://github.com/hmcts/document-management-store-app/blob/master/security.sh)
+ SecurityScan | Call enableSecurityScan() | [Web Application example](https://github.com/hmcts/sds-toffee-frontend/pull/119) <br>[API example](https://github.com/hmcts/sds-toffee-recipes-service/pull/135)
  Mutation | Add package.json file with "test:mutation": "Your script to run mutation tests" and call enableMutationTest() | [Mutation example](https://github.com/hmcts/pcq-frontend/blob/77d59f2143c91502bec4a1690609b5195cc78908/package.json#L30)
  FullFunctional | Call enableFullFunctionalTest() | [FullFunctional example](https://github.com/hmcts/nfdiv-frontend/blob/aea2aa8429d3c7495226ee6b5178bde6f0b639e4/Jenkinsfile_nightly#L48)
 

--- a/resources/uk/gov/hmcts/pipeline/security/security-backend/security.sh
+++ b/resources/uk/gov/hmcts/pipeline/security/security-backend/security.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+echo ${TEST_URL}
+zap-api-scan.py -t ${TEST_URL}/v2/api-docs -f openapi -S -d -u ${SecurityRules} -P 1001 -l FAIL
+curl --fail http://0.0.0.0:1001/OTHER/core/other/jsonreport/?formMethod=GET --output report.json
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
+zap-cli --zap-url http://0.0.0.0 -p 1001 report -o /zap/api-report.html -f html
+zap-cli --zap-url http://0.0.0.0 -p 1001 alerts -l Medium --exit-code False
+cp /zap/api-report.html functional-output/
+cp *.* functional-output/

--- a/resources/uk/gov/hmcts/pipeline/security/security-frontend/security.sh
+++ b/resources/uk/gov/hmcts/pipeline/security/security-frontend/security.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#echo "${SECURITYCONTEXT}" > /zap/security.context
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
+
+zap-x.sh -daemon -host 0.0.0.0 -port 1001 -config database.newsession=3 -config database.newsessionprompt=false -config api.disablekey=true -config scanner.attackOnStart=true -config view.mode=attack -config connection.dnsTtlSuccessfulQueries=-1 -config api.addrs.addr.name=.* -config api.addrs.addr.regex=true &
+i=0
+while !(curl -s http://0.0.0.0:1001) > /dev/null
+  do
+    i=$(( (i+1) %4 ))
+    sleep .1
+  done
+  echo "ZAP has successfully started"
+  zap-cli --zap-url http://0.0.0.0 -p 1001 status -t 120
+  zap-cli --zap-url http://0.0.0.0 -p 1001 open-url "${TEST_URL}"
+  zap-cli --zap-url http://0.0.0.0 -p 1001 spider ${TEST_URL}
+  zap-cli --zap-url http://0.0.0.0 -p 1001 active-scan --scanners all --recursive "${TEST_URL}"
+  zap-cli --zap-url http://0.0.0.0 -p 1001 report -o activescan.html -f html
+  echo 'Changing owner from $(id -u):$(id -g) to $(id -u):$(id -u)'
+  chown -R $(id -u):$(id -u) activescan.html
+  curl --fail http://0.0.0.0:1001/OTHER/core/other/jsonreport/?formMethod=GET --output report.json
+  cp *.html functional-output/
+  zap-cli --zap-url http://0.0.0.0 -p 1001 alerts -l Medium --exit-code False

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -256,13 +256,10 @@ EOF
     return gradleWithOutput("buildEnvironment").contains(pluginName)
   }
 
-
-  // class SecurityScanBackend extends SecurityScan
-  // {  
-  // }  
-
+  @Override
   def securityScan() {
     localSteps.writeFile(file: 'security.sh', text: localSteps.libraryResource('uk/gov/hmcts/pipeline/security/security-backend/security.sh'))
+    this.securitytest.execute()
   }
 
   @Override

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -256,6 +256,11 @@ EOF
     return gradleWithOutput("buildEnvironment").contains(pluginName)
   }
 
+  class SecurityScanBackend extends SecurityScan
+  {  
+    this.steps.writeFile file: "security.sh", text: this.steps.libraryResource('uk/gov/hmcts/pipeline/security/security-backend/security.sh')
+  }  
+
   @Override
   def performanceTest() {
     //support for the new and old (deprecated) gatling gradle plugins
@@ -268,5 +273,4 @@ EOF
       super.executeGatling()
     }
   }
-
 }

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -258,7 +258,7 @@ EOF
 
   class SecurityScanBackend extends SecurityScan
   {  
-
+    securityScript = "test"
   }  
 
   @Override

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -258,7 +258,7 @@ EOF
 
   class SecurityScanBackend extends SecurityScan
   {  
-    String securityScript = "test"
+    String securityScript = this.steps.writeFile file: "security.sh", text: this.steps.libraryResource('uk/gov/hmcts/pipeline/security/security-backend/security.sh')
   }  
 
   @Override

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -255,12 +255,15 @@ EOF
   def hasPlugin(String pluginName) {
     return gradleWithOutput("buildEnvironment").contains(pluginName)
   }
-  
-  @Override
-  class SecurityScanBackend extends SecurityScan
-  {  
+
+
+  // class SecurityScanBackend extends SecurityScan
+  // {  
+  // }  
+
+  def securityScan() {
     String securityScript = this.steps.writeFile file: "security.sh", text: this.steps.libraryResource('uk/gov/hmcts/pipeline/security/security-backend/security.sh')
-  }  
+  }
 
   @Override
   def performanceTest() {

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -258,7 +258,7 @@ EOF
 
   class SecurityScanBackend extends SecurityScan
   {  
-    securityScript = "test"
+    def securityScript
   }  
 
   @Override

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -263,6 +263,7 @@ EOF
 
   def securityScan() {
     String securityScript = this.steps.writeFile file: "security.sh", text: this.steps.libraryResource('uk/gov/hmcts/pipeline/security/security-backend/security.sh')
+    SecurityScan ()
   }
 
   @Override

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -258,7 +258,7 @@ EOF
 
   class SecurityScanBackend extends SecurityScan
   {  
-    def securityScript
+    String securityScript = "test"
   }  
 
   @Override

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -258,7 +258,7 @@ EOF
 
   class SecurityScanBackend extends SecurityScan
   {  
-    this.steps.writeFile file: "security.sh", text: this.steps.libraryResource('uk/gov/hmcts/pipeline/security/security-backend/security.sh')
+    writeFile file: "security.sh", text: this.steps.libraryResource('uk/gov/hmcts/pipeline/security/security-backend/security.sh')
   }  
 
   @Override

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -258,7 +258,7 @@ EOF
 
   class SecurityScanBackend extends SecurityScan
   {  
-    writeFile file: "security.sh", text: libraryResource('uk/gov/hmcts/pipeline/security/security-backend/security.sh')
+    env.securityScript = libraryResource('uk/gov/hmcts/pipeline/security/security-backend/security.sh')
   }  
 
   @Override

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -260,6 +260,8 @@ EOF
   def securityScan() {
     localSteps.writeFile(file: 'security.sh', text: localSteps.libraryResource('uk/gov/hmcts/pipeline/security/security-backend/security.sh'))
     this.securitytest.execute()
+    WarningCollector.addPipelineWarning("security.sh_moved", "Please remove security.sh from root of repository, no longer needed as it has been moved to the Jenkins library, LocalDate.of(2023, 03, 29))
+
   }
 
   @Override

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -258,7 +258,7 @@ EOF
 
   class SecurityScanBackend extends SecurityScan
   {  
-    env.securityScript = libraryResource('uk/gov/hmcts/pipeline/security/security-backend/security.sh')
+
   }  
 
   @Override

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -258,7 +258,7 @@ EOF
 
   class SecurityScanBackend extends SecurityScan
   {  
-    writeFile file: "security.sh", text: this.steps.libraryResource('uk/gov/hmcts/pipeline/security/security-backend/security.sh')
+    writeFile file: "security.sh", text: libraryResource('uk/gov/hmcts/pipeline/security/security-backend/security.sh')
   }  
 
   @Override

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -260,7 +260,7 @@ EOF
   def securityScan() {
     localSteps.writeFile(file: 'security.sh', text: localSteps.libraryResource('uk/gov/hmcts/pipeline/security/security-backend/security.sh'))
     this.securitytest.execute()
-    WarningCollector.addPipelineWarning("security.sh_moved", "Please remove security.sh from root of repository, no longer needed as it has been moved to the Jenkins library", LocalDate.of(2023, 03, 20))
+    WarningCollector.addPipelineWarning("security.sh_moved", "Please remove security.sh from root of repository, no longer needed as it has been moved to the Jenkins library", LocalDate.of(2023, 03, 29))
   }
 
   @Override

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -255,7 +255,8 @@ EOF
   def hasPlugin(String pluginName) {
     return gradleWithOutput("buildEnvironment").contains(pluginName)
   }
-
+  
+  @Override
   class SecurityScanBackend extends SecurityScan
   {  
     String securityScript = this.steps.writeFile file: "security.sh", text: this.steps.libraryResource('uk/gov/hmcts/pipeline/security/security-backend/security.sh')

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -260,7 +260,7 @@ EOF
   def securityScan() {
     localSteps.writeFile(file: 'security.sh', text: localSteps.libraryResource('uk/gov/hmcts/pipeline/security/security-backend/security.sh'))
     this.securitytest.execute()
-    WarningCollector.addPipelineWarning("security.sh_moved", "Please remove security.sh from root of repository, no longer needed as it has been moved to the Jenkins library", LocalDate.of(2023, 03, 29))
+    WarningCollector.addPipelineWarning("security.sh_moved", "Please remove security.sh from root of repository, no longer needed as it has been moved to the Jenkins library", LocalDate.of(2023, 03, 20))
   }
 
   @Override

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -260,8 +260,7 @@ EOF
   def securityScan() {
     localSteps.writeFile(file: 'security.sh', text: localSteps.libraryResource('uk/gov/hmcts/pipeline/security/security-backend/security.sh'))
     this.securitytest.execute()
-    WarningCollector.addPipelineWarning("security.sh_moved", "Please remove security.sh from root of repository, no longer needed as it has been moved to the Jenkins library, LocalDate.of(2023, 03, 29))
-
+    WarningCollector.addPipelineWarning("security.sh_moved", "Please remove security.sh from root of repository, no longer needed as it has been moved to the Jenkins library", LocalDate.of(2023, 03, 29))
   }
 
   @Override

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -262,8 +262,7 @@ EOF
   // }  
 
   def securityScan() {
-    String securityScript = this.steps.writeFile file: "security.sh", text: this.steps.libraryResource('uk/gov/hmcts/pipeline/security/security-backend/security.sh')
-    SecurityScan ()
+    localSteps.writeFile(file: 'security.sh', text: localSteps.libraryResource('uk/gov/hmcts/pipeline/security/security-backend/security.sh'))
   }
 
   @Override

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -341,8 +341,10 @@ EOF
     runYarn(task, prepend)
   }
 
+  @Override
   def securityScan() {
-    String securityScript = this.steps.writeFile file: "security.sh", text: this.steps.libraryResource('uk/gov/hmcts/pipeline/security/security-frontend/security.sh')
+    localSteps.writeFile(file: 'security.sh', text: localSteps.libraryResource('uk/gov/hmcts/pipeline/security/security-frontend/security.sh'))
+    this.securitytest.execute()
   }
 
   @Override

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -345,6 +345,8 @@ EOF
   def securityScan() {
     steps.writeFile(file: 'security.sh', text: steps.libraryResource('uk/gov/hmcts/pipeline/security/security-frontend/security.sh'))
     this.securitytest.execute()
+    WarningCollector.addPipelineWarning("security.sh_moved", "Please remove security.sh from root of repository, no longer needed as it has been moved to the Jenkins library", LocalDate.of(2023, 03, 29))
+
   }
 
   @Override

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -341,6 +341,10 @@ EOF
     runYarn(task, prepend)
   }
 
+  def securityScan() {
+    String securityScript = this.steps.writeFile file: "security.sh", text: this.steps.libraryResource('uk/gov/hmcts/pipeline/security/security-frontend/security.sh')
+  }
+
   @Override
   def setupToolVersion() {
     super.setupToolVersion()

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -343,7 +343,7 @@ EOF
 
   @Override
   def securityScan() {
-    steps.writeFile(file: 'security.sh', text: localSteps.libraryResource('uk/gov/hmcts/pipeline/security/security-frontend/security.sh'))
+    steps.writeFile(file: 'security.sh', text: steps.libraryResource('uk/gov/hmcts/pipeline/security/security-frontend/security.sh'))
     this.securitytest.execute()
   }
 

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -343,7 +343,7 @@ EOF
 
   @Override
   def securityScan() {
-    localSteps.writeFile(file: 'security.sh', text: localSteps.libraryResource('uk/gov/hmcts/pipeline/security/security-frontend/security.sh'))
+    steps.writeFile(file: 'security.sh', text: localSteps.libraryResource('uk/gov/hmcts/pipeline/security/security-frontend/security.sh'))
     this.securitytest.execute()
   }
 


### PR DESCRIPTION
Notes:
- Move security.sh (for both frontend and backend) to Jenkins library
- Override created for `securityScan()` in `GradleBuilder`
- Override created for `securityScan()` in `YarnBuilder`
- Add pipeline warning for deprecated enableSecurityScan()
- Update README to reflect changes

Changes made on this branch were tested with the following builds:
-  [sds-toffee-frontend](https://sds-build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_Nightly%2Fsds-toffee-frontend/detail/nightly-dev/101/pipeline/74) (pipeline failed at a different stage but passed for Security Scan)
- [sds-toffee-recipes-service](https://sds-build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_Nightly%2Fsds-toffee-recipes-service/detail/nightly-dev/43/pipeline)
- Working in sscs-cor-frontend with an exclusion file. Build examples [before](https://build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_j_to_z_Nightly%2Fsscs-cor-frontend/detail/nightly-dev/10/pipeline/94) and [after](https://build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_j_to_z_Nightly%2Fsscs-cor-frontend/detail/nightly-dev/11/pipeline) exclusion file added. Some exclusions weren't covered by the audit.json exclusion file but warnings in the file were ignored.