### PR TITLE
Remove aat-* tags as they are duplicate of staging-*

### DIFF
--- a/src/uk/gov/hmcts/contino/DockerImage.groovy
+++ b/src/uk/gov/hmcts/contino/DockerImage.groovy
@@ -155,9 +155,8 @@ class DockerImage {
    *   the short name. e.g. hmcts/product-component:branch
    */
   def getBaseShortName() {
-    def baseShortName = this.imageTag == 'staging' ? "${this.imageTag}-${this.commit}-${this.lastCommitTime}" : imageTag
     return repositoryName().concat(':')
-      .concat(baseShortName)
+      .concat(imageTag)
   }
 
   def getRepositoryName() {

--- a/src/uk/gov/hmcts/contino/azure/Acr.groovy
+++ b/src/uk/gov/hmcts/contino/azure/Acr.groovy
@@ -139,12 +139,7 @@ class Acr extends Az {
   }
 
   def hasTag(DockerImage dockerImage) {
-    // on the master branch we search for an AAT tagged image with the same commit hash
-    if (dockerImage.getTag().startsWith("staging")) {
-      return hasTag(DockerImage.DeploymentStage.AAT, dockerImage)
-    } else {
       return hasRepoTag(dockerImage.getTag(), dockerImage.getRepositoryName())
-    }
   }
 
   def hasTag(DockerImage.DeploymentStage stage, DockerImage dockerImage) {

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -157,13 +157,15 @@ def call(params) {
       }
     }
 
-    if (dockerFileExists) {
-      def deploymentStage = DockerImage.DeploymentStage.STAGING
-      onPR{
-        deploymentStage = DockerImage.DeploymentStage.PR
-      }
-      withAcrClient(subscription) {
-          acr.retagForStage(deploymentStage, dockerImage)
+    stageWithAgent("Promote Docker Image", product) {
+      if (dockerFileExists) {
+        def deploymentStage = DockerImage.DeploymentStage.STAGING
+        onPR{
+          deploymentStage = DockerImage.DeploymentStage.PR
+        }
+        withAcrClient(subscription) {
+            acr.retagForStage(deploymentStage, dockerImage)
+        }
       }
     }
 

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -157,6 +157,16 @@ def call(params) {
       }
     }
 
+    if (dockerFileExists) {
+      def deploymentStage = DockerImage.DeploymentStage.STAGING
+      onPR{
+        deploymentStage = DockerImage.DeploymentStage.PR
+      }
+      withAcrClient(subscription) {
+          acr.retagForStage(deploymentStage, dockerImage)
+      }
+    }
+
     if (config.pactBrokerEnabled && config.pactConsumerTestsEnabled && noSkipImgBuild) {
       stageWithAgent("Pact Consumer Verification", product) {
         timeoutWithMsg(time: 20, unit: 'MINUTES', action: 'Pact Consumer Verification') {

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -160,7 +160,7 @@ def call(params) {
     stageWithAgent("Promote Docker Image", product) {
       if (dockerFileExists) {
         def deploymentStage = DockerImage.DeploymentStage.STAGING
-        onPR{
+        onPR {
           deploymentStage = DockerImage.DeploymentStage.PR
         }
         withAcrClient(subscription) {

--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -36,13 +36,19 @@ def call(params) {
   def component = params.component
   def aksUrl
   def environment = params.environment
-  def imageRegistry = env.TEAM_CONTAINER_REGISTRY ?: env.REGISTRY_NAME
+  def acr
+  def dockerImage
+  def imageRegistry
   def projectBranch = new ProjectBranch(env.BRANCH_NAME)
-  def acr = new Acr(this, subscription, imageRegistry, env.REGISTRY_RESOURCE_GROUP, env.REGISTRY_SUBSCRIPTION)
-  def dockerImage = new DockerImage(product, component, acr, projectBranch.imageTag(), env.GIT_COMMIT, env.LAST_COMMIT_TIMESTAMP)
   def nonProdEnv = new Environment(env).nonProdName
 
   Builder builder = pipelineType.builder
+
+  withAcrClient(subscription) {
+    imageRegistry = env.TEAM_CONTAINER_REGISTRY ?: env.REGISTRY_NAME
+    acr = new Acr(this, subscription, imageRegistry, env.REGISTRY_RESOURCE_GROUP, env.REGISTRY_SUBSCRIPTION)
+    dockerImage = new DockerImage(product, component, acr, projectBranch.imageTag(), env.GIT_COMMIT, env.LAST_COMMIT_TIMESTAMP)
+  }
 
   def deploymentNamespace = projectBranch.deploymentNamespace()
   def deploymentProduct = deploymentNamespace ? "$deploymentNamespace-$product" : product

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -134,17 +134,6 @@ def call(type, String product, String component, Closure body) {
 
         onMaster {
 
-          sectionPromoteBuildToStage(
-            appPipelineConfig: pipelineConfig,
-            pipelineCallbacksRunner: callbacksRunner,
-            pipelineType: pipelineType,
-            subscription: subscription.nonProdName,
-            product: product,
-            component: component,
-            stage: DockerImage.DeploymentStage.AAT,
-            environment: environment.nonProdName
-          )
-
           sectionDeployToEnvironment(
             appPipelineConfig: pipelineConfig,
             pipelineCallbacksRunner: callbacksRunner,


### PR DESCRIPTION
Notes:
* Currently, we are tagging images with `aat-*` which are  duplicates of `staging-*` . Removing them to simplify clean up scripts.
* Also, moving the retag with commitid, timestamp to `sectionBuildandDeploy` to make it easy to read.
* Tested in https://github.com/hmcts/cnp-plum-recipes-service/pull/705 
