### PR TITLE
CIV-7142 Ensure deletion on pods on failed deployment

### DIFF
--- a/vars/helmInstall.groovy
+++ b/vars/helmInstall.groovy
@@ -150,6 +150,9 @@ def call(DockerImage dockerImage, Map params) {
         break
       } catch (upgradeError) {
         if (attempts >= 3) {
+          if (config.clearHelmReleaseOnFailure) {
+            helmUninstall(dockerImage, params, params.pipelineCallbacksRunner)
+          }
           throw upgradeError
         }
         // Clean up the latest install/upgrade attempt

--- a/vars/helmInstall.groovy
+++ b/vars/helmInstall.groovy
@@ -151,7 +151,7 @@ def call(DockerImage dockerImage, Map params) {
       } catch (upgradeError) {
         if (attempts >= 3) {
           if (config.clearHelmReleaseOnFailure) {
-            helmUninstall(dockerImage, params, params.pipelineCallbacksRunner)
+            helm.delete(dockerImage.getImageTag(), namespace)
           }
           throw upgradeError
         }


### PR DESCRIPTION
Resolves https://tools.hmcts.net/jira/browse/CIV-7142.

While looking into the PRs created by renovate for civil, it was noticed that some of them were aborted due to deployment failures (the usual quota issue) and despite this, they were in fact deployed.

The result was that for each of these automated PRs experiencing the quota issue we had 10 running pods, thus further compounding to the quota issues for all subsequent builds. 3 PRs were identified with this issue in just one day, leading to believe the issue could be quite common whenever the quota limits are reached, making things worse exactly at the worst possible time.

This change aims at addressing the issue by clearing the helm release when the deployment has failed and the `clearHelmReleaseOnFailure` flag is set.