### PR TITLE
Fix IdAM preview builds

### DIFF
--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -160,6 +160,10 @@ def call(params) {
     stageWithAgent("Promote Docker Image", product) {
       if (dockerFileExists) {
         def deploymentStage = DockerImage.DeploymentStage.STAGING
+        def isOnPreview = new ProjectBranch(env.BRANCH_NAME).isPreview()
+        if (isOnPreview) {
+          deploymentStage = DockerImage.DeploymentStage.PREVIEW
+        }
         onPR {
           deploymentStage = DockerImage.DeploymentStage.PR
         }


### PR DESCRIPTION
we need retagForStage to know when the branch is preview so it uses the simple tag instead of the full one

example failure build :

https://build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_d_to_i%2Fidam-api/detail/preview/170/pipeline/153
