### PR TITLE
Deprecate Java 11, deadline 2023-08-01

### DIFF
--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -247,6 +247,15 @@ EOF
         steps.env.PATH = "${steps.env.JAVA_HOME}/bin:${steps.env.PATH}"
         // Workaround jacocoTestReport issue https://github.com/gradle/gradle/issues/18508#issuecomment-1049998305
         steps.env.GRADLE_OPTS = "--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED"
+      } else {
+        WarningCollector.addPipelineWarning("java_11_deprecated",
+          "Please upgrade to Java 17, upgrade to " +
+            "<https://moj.enterprise.slack.com/files/T02DYEB3A/F02V9BNFXRU?origin_team=T1L0WSW9F|Application Insights v3 first>, " +
+            "then <https://github.com/hmcts/draft-store/pull/989|upgrade to Java 17>. " +
+            "Make sure you use the latest version of the Application insights agent, see the configuration in " +
+            "<https://github.com/hmcts/spring-boot-template/|spring-boot-template>, " +
+            "look at the `.github/renovate.json` and `Dockerfile` files.", LocalDate.of(2023, 8, 1)
+        )
       }
     } catch(err) {
       steps.echo "Failed to detect java version, ensure the root project has the correct Java requirements set"


### PR DESCRIPTION
![Please upgrade to Java 17, upgrade to [Application Insights v3 first](https://moj.enterprise.slack.com/files/T02DYEB3A/F02V9BNFXRU?origin_team=T1L0WSW9F&origin_channel=DQEFLFC67), then [upgrade to Java 17](https://github.com/hmcts/draft-store/pull/989). Make sure you use the latest version of the Application insights agent, see the configuration in [spring-boot-template](https://github.com/hmcts/spring-boot-template/), look at the .github/renovate.json and Dockerfile files. This configuration will stop working by 01/08/2023 ( in 112 days )](https://user-images.githubusercontent.com/21194782/231118068-b1d7bdd5-d63c-49cb-9a0d-f706243660fa.png)

Tested in https://github.com/hmcts/cmc-claim-store/pull/2727