### PR TITLE
Move deprecation config to external file

### DIFF
--- a/resources/uk/gov/hmcts/helm/check-deprecated-charts.sh
+++ b/resources/uk/gov/hmcts/helm/check-deprecated-charts.sh
@@ -2,14 +2,14 @@
 set -x
 
 CHART_DIRECTORY=${1}-${2}
-CHART_NAME=${3}
-CHART_VERSION=${4}
+DEPRECATED_CHART_NAME=${3}
+DEPRECATED_CHART_VERSION=${4}
 
 function ver { printf "%03d%03d%03d%03d" $(echo "$1" | tr '.' ' '); }
 
 
-CURRENT_VERSION=$(helm dependency ls charts/${CHART_DIRECTORY}/ | grep "^${CHART_NAME}" |awk '{ print $2}' | sed "s/~//g")
-if [[ -n $CURRENT_VERSION ]] && [ $(ver $CURRENT_VERSION) -lt $(ver ${CHART_VERSION}) ]; then
-    echo "$deprecation chart $CURRENT_VERSION is deprecated, please upgrade to at least ${CHART_VERSION}"
+CURRENT_VERSION=$(helm dependency ls charts/${CHART_DIRECTORY}/ | grep "^${DEPRECATED_CHART_NAME}" |awk '{ print $2}' | sed "s/~//g")
+if [[ -n $CURRENT_VERSION ]] && [ $(ver $CURRENT_VERSION) -lt $(ver ${DEPRECATED_CHART_VERSION}) ]; then
+    echo "$deprecation chart $CURRENT_VERSION is deprecated, please upgrade to at least ${DEPRECATED_CHART_VERSION}"
     exit 1
 fi

--- a/resources/uk/gov/hmcts/helm/check-deprecated-charts.sh
+++ b/resources/uk/gov/hmcts/helm/check-deprecated-charts.sh
@@ -2,22 +2,14 @@
 set -x
 
 CHART_DIRECTORY=${1}-${2}
-declare -A deprecationMap
+CHART_NAME=${3}
+CHART_VERSION=${4}
+
 function ver { printf "%03d%03d%03d%03d" $(echo "$1" | tr '.' ' '); }
 
-deprecationMap["java"]="4.0.13"
-deprecationMap["nodejs"]="2.4.14"
-deprecationMap["job"]="0.7.11"
-deprecationMap["blobstorage"]="0.3.0"
-deprecationMap["servicebus"]="0.4.0"
-deprecationMap["ccd"]="8.0.27"
-deprecationMap["elasticsearch"]="7.17.3"
 
-for deprecation in "${!deprecationMap[@]}"
-do
-  CURRENT_VERSION=$(helm dependency ls charts/${CHART_DIRECTORY}/ | grep "^$deprecation" |awk '{ print $2}' | sed "s/~//g")
-  if [[ -n $CURRENT_VERSION ]] && [ $(ver $CURRENT_VERSION) -lt $(ver ${deprecationMap[$deprecation]}) ]; then
-      echo "$deprecation chart $CURRENT_VERSION is deprecated, please upgrade to at least ${deprecationMap[$deprecation]}"
-      exit 1
-  fi
-done
+CURRENT_VERSION=$(helm dependency ls charts/${CHART_DIRECTORY}/ | grep "^${CHART_NAME}" |awk '{ print $2}' | sed "s/~//g")
+if [[ -n $CURRENT_VERSION ]] && [ $(ver $CURRENT_VERSION) -lt $(ver ${CHART_VERSION}) ]; then
+    echo "$deprecation chart $CURRENT_VERSION is deprecated, please upgrade to at least ${CHART_VERSION}"
+    exit 1
+fi

--- a/src/uk/gov/hmcts/pipeline/DeprecationConfig.groovy
+++ b/src/uk/gov/hmcts/pipeline/DeprecationConfig.groovy
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.pipeline
+
+class DeprecationConfig {
+
+  def steps
+  static def deprecationConfig
+
+  DeprecationConfig(steps){
+    this.steps = steps
+  }
+
+  def loadDeprecationConfig(){
+    if (deprecationConfig ==null ){
+      def response = steps.httpRequest(
+        consoleLogResponseBody: true,
+        timeout: 10,
+        url: "https://raw.githubusercontent.com/hmcts/cnp-jenkins-config/adddeprecatedconfig/deprecation-config.yml",
+        validResponseCodes: '200'
+      )
+      deprecationConfig = steps.readYaml (text: response.content)
+    }
+    return deprecationConfig
+  }
+
+}

--- a/src/uk/gov/hmcts/pipeline/DeprecationConfig.groovy
+++ b/src/uk/gov/hmcts/pipeline/DeprecationConfig.groovy
@@ -17,7 +17,7 @@ class DeprecationConfig {
         url: "https://raw.githubusercontent.com/hmcts/cnp-jenkins-config/master/deprecation-config.yml",
         validResponseCodes: '200'
       )
-      deprecationConfig = steps.readYaml (text: response.content)
+      deprecationConfig = steps.readYaml(text: response.content)
     }
     return deprecationConfig
   }

--- a/src/uk/gov/hmcts/pipeline/DeprecationConfig.groovy
+++ b/src/uk/gov/hmcts/pipeline/DeprecationConfig.groovy
@@ -14,7 +14,7 @@ class DeprecationConfig {
       def response = steps.httpRequest(
         consoleLogResponseBody: true,
         timeout: 10,
-        url: "https://raw.githubusercontent.com/hmcts/cnp-jenkins-config/adddeprecatedconfig/deprecation-config.yml",
+        url: "https://raw.githubusercontent.com/hmcts/cnp-jenkins-config/master/deprecation-config.yml",
         validResponseCodes: '200'
       )
       deprecationConfig = steps.readYaml (text: response.content)

--- a/vars/warnAboutDeprecatedChartConfig.groovy
+++ b/vars/warnAboutDeprecatedChartConfig.groovy
@@ -7,6 +7,16 @@ def call(Map<String, String> params) {
   def product = params.product
   def component = params.component
 
+  def deprecationMap = [
+    'java' : ['version':'4.0.13', deprecationDate: '29/03/2023'],
+    'nodejs' : ['version':'2.4.14', deprecationDate: '29/03/2023'],
+    'job' : ['version':'0.7.11', deprecationDate: '29/03/2023'],
+    'blobstorage' : ['version':'0.3.0', deprecationDate: '29/03/2023'],
+    'servicebus' : ['version':'0.4.0', deprecationDate: '29/03/2023'],
+    'ccd' : ['version':'8.0.27', deprecationDate: '29/03/2023'],
+    'elasticsearch' : ['version':'7.17.3', deprecationDate: '29/03/2023'],
+  ]
+
   writeFile file: 'check-helm-api-version.sh', text: libraryResource('uk/gov/hmcts/helm/check-helm-api-version.sh')
   writeFile file: 'check-deprecated-charts.sh', text: libraryResource('uk/gov/hmcts/helm/check-deprecated-charts.sh')
 
@@ -19,15 +29,15 @@ def call(Map<String, String> params) {
     sh 'rm -f check-helm-api-version.sh'
   }
 
-  try {
-    sh """
-    chmod +x check-deprecated-charts.sh
-    ./check-deprecated-charts.sh $product $component
-    """
-  } catch(ignored) {
-    WarningCollector.addPipelineWarning("deprecated_helmcharts", "Please upgrade base helm charts to latest. See releases on the chart repo for latest updates, example: https://github.com/hmcts/chart-java/releases", LocalDate.of(2023, 03, 29))
-  } finally {
-    sh 'rm -f check-deprecated-charts.sh'
+  sh 'chmod +x check-deprecated-charts.sh'
+
+  deprecationMap.each { chart, deprecatedVersions ->
+    try {
+      sh './check-deprecated-charts.sh $product $component $chart $deprecatedVersions.version'
+    } catch(ignored) {
+      WarningCollector.addPipelineWarning("deprecated_helmcharts", "Please upgrade base helm charts to latest. See releases on the chart repo for latest updates, example: https://github.com/hmcts/chart-$chart/releases", LocalDate.parse(deprecatedVersions.deprecationDate))
+    }
   }
+  sh 'rm -f check-deprecated-charts.sh'
 
 }

--- a/vars/warnAboutDeprecatedChartConfig.groovy
+++ b/vars/warnAboutDeprecatedChartConfig.groovy
@@ -8,13 +8,13 @@ def call(Map<String, String> params) {
   def component = params.component
 
   def deprecationMap = [
-    'java' : ['version':'4.0.13', deprecationDate: '29/03/2023'],
-    'nodejs' : ['version':'2.4.14', deprecationDate: '29/03/2023'],
-    'job' : ['version':'0.7.11', deprecationDate: '29/03/2023'],
-    'blobstorage' : ['version':'0.3.0', deprecationDate: '29/03/2023'],
-    'servicebus' : ['version':'0.4.0', deprecationDate: '29/03/2023'],
-    'ccd' : ['version':'8.0.27', deprecationDate: '29/03/2023'],
-    'elasticsearch' : ['version':'7.17.3', deprecationDate: '29/03/2023'],
+    'java' : ['version':'4.0.13', deprecationDate: '2023-03-29'],
+    'nodejs' : ['version':'2.4.14', deprecationDate: '2023-03-29'],
+    'job' : ['version':'0.7.11', deprecationDate: '2023-03-29'],
+    'blobstorage' : ['version':'0.3.0', deprecationDate: '2023-03-29'],
+    'servicebus' : ['version':'0.4.0', deprecationDate: '2023-03-29'],
+    'ccd' : ['version':'8.0.27', deprecationDate: '2023-03-29'],
+    'elasticsearch' : ['version':'7.17.3', deprecationDate: '2023-03-29'],
   ]
 
   writeFile file: 'check-helm-api-version.sh', text: libraryResource('uk/gov/hmcts/helm/check-helm-api-version.sh')
@@ -35,7 +35,7 @@ def call(Map<String, String> params) {
     try {
       sh """./check-deprecated-charts.sh $product $component $chart $deprecatedVersions.version """
     } catch(ignored) {
-      WarningCollector.addPipelineWarning("deprecated_helmcharts", "Please upgrade base helm charts to latest. See releases on the chart repo for latest updates, example: https://github.com/hmcts/chart-$chart/releases", LocalDate.parse(deprecatedVersions.deprecationDate, "dd/MM/yyyy"))
+      WarningCollector.addPipelineWarning("deprecated_helmcharts", "Please upgrade base helm charts to latest. See releases on the chart repo for latest updates, example: https://github.com/hmcts/chart-$chart/releases", LocalDate.parse(deprecatedVersions.deprecationDate))
     }
   }
   sh 'rm -f check-deprecated-charts.sh'

--- a/vars/warnAboutDeprecatedChartConfig.groovy
+++ b/vars/warnAboutDeprecatedChartConfig.groovy
@@ -24,11 +24,11 @@ def call(Map<String, String> params) {
   sh 'chmod +x check-deprecated-charts.sh'
 
   helmChartDeprecationConfig.each { chart, deprecatedVersions ->
-    deprecatedVersions.each { deprecatedVersion, deprecationDate ->
+    deprecatedVersions.each { deprecation ->
       try {
-        sh """./check-deprecated-charts.sh $product $component $chart $deprecatedVersion """
+        sh """./check-deprecated-charts.sh $product $component $chart $deprecation.version """
       } catch (ignored) {
-        WarningCollector.addPipelineWarning("deprecated_helmcharts", "Version of $chart helm chart you are using is deprecated, please upgrade to latest release https://github.com/hmcts/chart-$chart/releases", LocalDate.parse(deprecationDate))
+        WarningCollector.addPipelineWarning("deprecated_helmcharts", "Version of $chart helm chart you are using is deprecated, please upgrade to latest release https://github.com/hmcts/chart-$chart/releases", LocalDate.parse(deprecation.date))
       }
     }
   }

--- a/vars/warnAboutDeprecatedChartConfig.groovy
+++ b/vars/warnAboutDeprecatedChartConfig.groovy
@@ -28,7 +28,7 @@ def call(Map<String, String> params) {
       try {
         sh """./check-deprecated-charts.sh $product $component $chart $deprecation.version """
       } catch (ignored) {
-        WarningCollector.addPipelineWarning("deprecated_helmcharts", "Version of $chart helm chart below $deprecation.version is deprecated, please upgrade to latest release https://github.com/hmcts/chart-$chart/releases", LocalDate.parse(deprecation.date))
+        WarningCollector.addPipelineWarning("deprecated_helmcharts", "Version of $chart helm chart below $deprecation.version is deprecated, please upgrade to latest release https://github.com/hmcts/chart-$chart/releases", LocalDate.parse(deprecation.date_deadline))
       }
     }
   }

--- a/vars/warnAboutDeprecatedChartConfig.groovy
+++ b/vars/warnAboutDeprecatedChartConfig.groovy
@@ -35,7 +35,7 @@ def call(Map<String, String> params) {
     try {
       sh """./check-deprecated-charts.sh $product $component $chart $deprecatedVersions.version """
     } catch(ignored) {
-      WarningCollector.addPipelineWarning("deprecated_helmcharts", "Please upgrade base helm charts to latest. See releases on the chart repo for latest updates, example: https://github.com/hmcts/chart-$chart/releases", LocalDate.parse(deprecatedVersions.deprecationDate))
+      WarningCollector.addPipelineWarning("deprecated_helmcharts", "Please upgrade base helm charts to latest. See releases on the chart repo for latest updates, example: https://github.com/hmcts/chart-$chart/releases", LocalDate.parse(deprecatedVersions.deprecationDate, "dd/MM/yyyy"))
     }
   }
   sh 'rm -f check-deprecated-charts.sh'

--- a/vars/warnAboutDeprecatedChartConfig.groovy
+++ b/vars/warnAboutDeprecatedChartConfig.groovy
@@ -28,7 +28,7 @@ def call(Map<String, String> params) {
       try {
         sh """./check-deprecated-charts.sh $product $component $chart $deprecatedVersion """
       } catch (ignored) {
-        WarningCollector.addPipelineWarning("deprecated_helmcharts", "Please upgrade base helm charts to latest. See releases on the chart repo for latest updates, example: https://github.com/hmcts/chart-$chart/releases", LocalDate.parse(deprecationDate))
+        WarningCollector.addPipelineWarning("deprecated_helmcharts", "Version of $chart helm chart you are using is deprecated, please upgrade to latest release https://github.com/hmcts/chart-$chart/releases", LocalDate.parse(deprecationDate))
       }
     }
   }

--- a/vars/warnAboutDeprecatedChartConfig.groovy
+++ b/vars/warnAboutDeprecatedChartConfig.groovy
@@ -26,7 +26,7 @@ def call(Map<String, String> params) {
   helmChartDeprecationConfig.each { chart, deprecatedVersions ->
     deprecatedVersions.each { deprecation ->
       try {
-        sh """./check-deprecated-charts.sh $product $component $chart $deprecation.version """
+        sh "./check-deprecated-charts.sh $product $component $chart $deprecation.version "
       } catch (ignored) {
         WarningCollector.addPipelineWarning("deprecated_helmcharts", "Version of $chart helm chart below $deprecation.version is deprecated, please upgrade to latest release https://github.com/hmcts/chart-$chart/releases", LocalDate.parse(deprecation.date_deadline))
       }

--- a/vars/warnAboutDeprecatedChartConfig.groovy
+++ b/vars/warnAboutDeprecatedChartConfig.groovy
@@ -28,7 +28,7 @@ def call(Map<String, String> params) {
       try {
         sh """./check-deprecated-charts.sh $product $component $chart $deprecation.version """
       } catch (ignored) {
-        WarningCollector.addPipelineWarning("deprecated_helmcharts", "Version of $chart helm chart you are using is deprecated, please upgrade to latest release https://github.com/hmcts/chart-$chart/releases", LocalDate.parse(deprecation.date))
+        WarningCollector.addPipelineWarning("deprecated_helmcharts", "Version of $chart helm chart below $deprecation.version is deprecated, please upgrade to latest release https://github.com/hmcts/chart-$chart/releases", LocalDate.parse(deprecation.date))
       }
     }
   }

--- a/vars/warnAboutDeprecatedChartConfig.groovy
+++ b/vars/warnAboutDeprecatedChartConfig.groovy
@@ -33,7 +33,7 @@ def call(Map<String, String> params) {
 
   deprecationMap.each { chart, deprecatedVersions ->
     try {
-      sh './check-deprecated-charts.sh $product $component $chart $deprecatedVersions.version'
+      sh """./check-deprecated-charts.sh $product $component $chart $deprecatedVersions.version """
     } catch(ignored) {
       WarningCollector.addPipelineWarning("deprecated_helmcharts", "Please upgrade base helm charts to latest. See releases on the chart repo for latest updates, example: https://github.com/hmcts/chart-$chart/releases", LocalDate.parse(deprecatedVersions.deprecationDate))
     }

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -14,6 +14,7 @@ import uk.gov.hmcts.contino.PipelineCallbacksConfig
 import uk.gov.hmcts.contino.PipelineCallbacksRunner
 import uk.gov.hmcts.pipeline.AKSSubscriptions
 import uk.gov.hmcts.pipeline.TeamConfig
+import uk.gov.hmcts.pipeline.DeprecationConfig
 
 def call(type, String product, String component, Closure body) {
 
@@ -62,6 +63,7 @@ def call(type, String product, String component, Closure body) {
   Environment environment = new Environment(env)
 
   def teamConfig = new TeamConfig(this).setTeamConfigEnv(product)
+  def deprecationConfig = new DeprecationConfig(this).loadDeprecationConfig()
   String agentType = env.BUILD_AGENT_TYPE
 
   node(agentType) {


### PR DESCRIPTION

Notes:
* Current implementation has only 1 deprecation date for all charts and versions which makes it difficult to enforce changes.
* Making it external will also help using the same config in other places.
* this also supports different  deprecation dates for different versions of same chart.
* config is added in https://raw.githubusercontent.com/hmcts/cnp-jenkins-config/master/deprecation-config.yml
* Tested in https://build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_a_to_c%2Fcnp-plum-recipes-service/detail/PR-718/17/pipeline/243/
* An example alert with multiple versions deprecated for java:

<img width="750" alt="Screenshot 2023-04-13 at 11 42 23" src="https://user-images.githubusercontent.com/47391951/231735207-07e0b7b8-54e0-468a-9324-845a0947766d.png">

* Example with multiple charts, different versions (wording has been changed since this test)
<img width="722" alt="Screenshot 2023-04-13 at 11 44 01" src="https://user-images.githubusercontent.com/47391951/231735434-974b40aa-624c-417d-9d9c-77fa73d2fbee.png">




