### PR TITLE
Get gradle to download wrapper after Java 17 set

### DIFF
--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -238,8 +238,6 @@ EOF
 
   @Override
   def setupToolVersion() {
-    gradle("--version") // ensure wrapper has been downloaded
-
     try {
       def statusCode = steps.sh script: 'grep -F "JavaLanguageVersion.of(17)" build.gradle', returnStatus: true
       if (statusCode == 0) {
@@ -261,6 +259,7 @@ EOF
       steps.echo "Failed to detect java version, ensure the root project has the correct Java requirements set"
     }
 
+    gradle("--version") // ensure wrapper has been downloaded
     localSteps.sh "java -version"
   }
 


### PR DESCRIPTION
It was reported to me that Java 11 was still in the logs for a 17 project
It's harmless but confusing so let's get Java 17 to download the wrapper