### PR TITLE
DTSPO-13502 - Enable Override for Security Scan

### DIFF
--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -269,15 +269,15 @@ EOF
 
   @Override
   def securityScan(){
-    if (localSteps.fileExists(".ci/security.sh")) {
-      this.securitytest.execute()
+    if (steps.fileExists(".ci/security.sh")) {
+      steps.writeFile(file: 'security.sh', text: steps.readFile('.ci/security.sh'))
     }
-    // else if (localSteps.fileExists("security.sh")) {
-    //   WarningCollector.addPipelineWarning("security.sh_moved", "Please remove security.sh from root of repository, no longer needed as it has been moved to the Jenkins library", LocalDate.of(2023, 04, 17))
-    // } else {
-    //   localSteps.writeFile(file: 'security.sh', text: localSteps.libraryResource('uk/gov/hmcts/pipeline/security/backend/security.sh'))
-    //   this.securitytest.execute()
-    // }
+    else if (localSteps.fileExists("security.sh")) {
+      WarningCollector.addPipelineWarning("security.sh_moved", "Please remove security.sh from root of repository, no longer needed as it has been moved to the Jenkins library", LocalDate.of(2023, 04, 17))
+    } else {
+      localSteps.writeFile(file: 'security.sh', text: localSteps.libraryResource('uk/gov/hmcts/pipeline/security/backend/security.sh'))
+    }
+    this.securitytest.execute()
   }
 
   @Override

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -270,14 +270,14 @@ EOF
   @Override
   def securityScan(){
     if (localSteps.fileExists(".ci/security.sh")) {
-      echo "Override: use local security.sh script"
+      this.securitytest.execute()
     }
     else if (localSteps.fileExists("security.sh")) {
       WarningCollector.addPipelineWarning("security.sh_moved", "Please remove security.sh from root of repository, no longer needed as it has been moved to the Jenkins library", LocalDate.of(2023, 04, 17))
     } else {
       localSteps.writeFile(file: 'security.sh', text: localSteps.libraryResource('uk/gov/hmcts/pipeline/security/backend/security.sh'))
+      this.securitytest.execute()
     }
-    this.securitytest.execute()
   }
 
   @Override

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -272,12 +272,12 @@ EOF
     if (localSteps.fileExists(".ci/security.sh")) {
       this.securitytest.execute()
     }
-    else if (localSteps.fileExists("security.sh")) {
-      WarningCollector.addPipelineWarning("security.sh_moved", "Please remove security.sh from root of repository, no longer needed as it has been moved to the Jenkins library", LocalDate.of(2023, 04, 17))
-    } else {
-      localSteps.writeFile(file: 'security.sh', text: localSteps.libraryResource('uk/gov/hmcts/pipeline/security/backend/security.sh'))
-      this.securitytest.execute()
-    }
+    // else if (localSteps.fileExists("security.sh")) {
+    //   WarningCollector.addPipelineWarning("security.sh_moved", "Please remove security.sh from root of repository, no longer needed as it has been moved to the Jenkins library", LocalDate.of(2023, 04, 17))
+    // } else {
+    //   localSteps.writeFile(file: 'security.sh', text: localSteps.libraryResource('uk/gov/hmcts/pipeline/security/backend/security.sh'))
+    //   this.securitytest.execute()
+    // }
   }
 
   @Override

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -271,8 +271,7 @@ EOF
   def securityScan(){
     if (steps.fileExists(".ci/security.sh")) {
       steps.writeFile(file: 'security.sh', text: steps.readFile('.ci/security.sh'))
-    }
-    else if (localSteps.fileExists("security.sh")) {
+    } else if (localSteps.fileExists("security.sh")) {
       WarningCollector.addPipelineWarning("security.sh_moved", "Please remove security.sh from root of repository, no longer needed as it has been moved to the Jenkins library", LocalDate.of(2023, 04, 17))
     } else {
       localSteps.writeFile(file: 'security.sh', text: localSteps.libraryResource('uk/gov/hmcts/pipeline/security/backend/security.sh'))

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -269,7 +269,10 @@ EOF
 
   @Override
   def securityScan(){
-    if (localSteps.fileExists("security.sh")) {
+    if (localSteps.fileExists(".ci/security.sh")) {
+      echo "Override: use local security.sh script"
+    }
+    else if (localSteps.fileExists("security.sh")) {
       WarningCollector.addPipelineWarning("security.sh_moved", "Please remove security.sh from root of repository, no longer needed as it has been moved to the Jenkins library", LocalDate.of(2023, 04, 17))
     } else {
       localSteps.writeFile(file: 'security.sh', text: localSteps.libraryResource('uk/gov/hmcts/pipeline/security/backend/security.sh'))

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -270,6 +270,7 @@ EOF
   @Override
   def securityScan(){
     if (steps.fileExists(".ci/security.sh")) {
+      // hook to allow teams to override the default `security.sh` that we provide
       steps.writeFile(file: 'security.sh', text: steps.readFile('.ci/security.sh'))
     } else if (localSteps.fileExists("security.sh")) {
       WarningCollector.addPipelineWarning("security.sh_moved", "Please remove security.sh from root of repository, no longer needed as it has been moved to the Jenkins library", LocalDate.of(2023, 04, 17))

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -348,8 +348,7 @@ EOF
   def securityScan(){
     if (steps.fileExists(".ci/security.sh")) {
       steps.writeFile(file: 'security.sh', text: steps.readFile('.ci/security.sh'))
-    }
-    else if (steps.fileExists("security.sh")) {
+    } else if (steps.fileExists("security.sh")) {
       WarningCollector.addPipelineWarning("security.sh_moved", "Please remove security.sh from root of repository, no longer needed as it has been moved to the Jenkins library", LocalDate.of(2023, 04, 17))
     } else {
       steps.writeFile(file: 'security.sh', text: steps.libraryResource('uk/gov/hmcts/pipeline/security/frontend/security.sh'))

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -347,14 +347,14 @@ EOF
   @Override
   def securityScan(){
     if (steps.fileExists(".ci/security.sh")) {
-      this.securitytest.execute()
+      move(file:".ci/security.sh", tofile:"./security.sh")
     }
     else if (steps.fileExists("security.sh")) {
       WarningCollector.addPipelineWarning("security.sh_moved", "Please remove security.sh from root of repository, no longer needed as it has been moved to the Jenkins library", LocalDate.of(2023, 04, 17))
     } else {
       steps.writeFile(file: 'security.sh', text: steps.libraryResource('uk/gov/hmcts/pipeline/security/frontend/security.sh'))
-      this.securitytest.execute()
     }
+    this.securitytest.execute()
   }
 
   @Override

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -346,12 +346,15 @@ EOF
 
   @Override
   def securityScan(){
-    if (steps.fileExists("security.sh")) {
+    if (steps.fileExists(".ci/security.sh")) {
+      this.securitytest.execute()
+    }
+    else if (steps.fileExists("security.sh")) {
       WarningCollector.addPipelineWarning("security.sh_moved", "Please remove security.sh from root of repository, no longer needed as it has been moved to the Jenkins library", LocalDate.of(2023, 04, 17))
     } else {
       steps.writeFile(file: 'security.sh', text: steps.libraryResource('uk/gov/hmcts/pipeline/security/frontend/security.sh'))
+      this.securitytest.execute()
     }
-    this.securitytest.execute()
   }
 
   @Override

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -347,7 +347,7 @@ EOF
   @Override
   def securityScan(){
     if (steps.fileExists(".ci/security.sh")) {
-      files.move(".ci/security.sh", "./security.sh")
+      steps.writeFile(file: 'security.sh', text: steps.readFile('.ci/security.sh'))
     }
     else if (steps.fileExists("security.sh")) {
       WarningCollector.addPipelineWarning("security.sh_moved", "Please remove security.sh from root of repository, no longer needed as it has been moved to the Jenkins library", LocalDate.of(2023, 04, 17))

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -347,7 +347,7 @@ EOF
   @Override
   def securityScan(){
     if (steps.fileExists(".ci/security.sh")) {
-      move(file:".ci/security.sh", tofile:"./security.sh")
+      files.move(".ci/security.sh", "./security.sh")
     }
     else if (steps.fileExists("security.sh")) {
       WarningCollector.addPipelineWarning("security.sh_moved", "Please remove security.sh from root of repository, no longer needed as it has been moved to the Jenkins library", LocalDate.of(2023, 04, 17))

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -347,6 +347,7 @@ EOF
   @Override
   def securityScan(){
     if (steps.fileExists(".ci/security.sh")) {
+      // hook to allow teams to override the default `security.sh` that we provide
       steps.writeFile(file: 'security.sh', text: steps.readFile('.ci/security.sh'))
     } else if (steps.fileExists("security.sh")) {
       WarningCollector.addPipelineWarning("security.sh_moved", "Please remove security.sh from root of repository, no longer needed as it has been moved to the Jenkins library", LocalDate.of(2023, 04, 17))


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
* Allows for the default security scan to be overridden if the `.ci/security.sh` file exists
* Tested in both [sds-toffee-frontend](https://sds-build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_Nightly%2Fsds-toffee-frontend/detail/nightly-dev/188/pipeline/) and [sds-toffee-recipes-service](https://sds-build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_Nightly%2Fsds-toffee-recipes-service/detail/nightly-dev/79/pipeline)
