### PR TITLE
DTSPO-13465: Adding nagger for nodejs

### DIFF
--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -326,7 +326,9 @@ EOF
 
     if (steps.fileExists(NVMRC)) {
       String nodeVersion = steps.readFile(NVMRC)
-      nodeVersion = nodeVersion.trim().substring(0, nodeVersion.lastIndexOf("."))
+      nodeVersion = nodeVersion
+                    .trim()
+                    .substring(0, nodeVersion.lastIndexOf("."))
       Float current_version = Float.valueOf(nodeVersion)
       steps.echo("Existing NodeJS at v${current_version}.x")
       validVersion = current_version >= DESIRED_MIN_VERSION
@@ -341,7 +343,7 @@ EOF
   private nagAboutOldNodeJSVersions() {
     if (!isNodeJSV18OrNewer()) {
       steps.echo("NodeJS version is less than v18.16.0 and would need to be upgraded")
-      WarningCollector.addPipelineWarning("old_nodejs_version", "Please upgrade to NodeJS v18.16.0 at least, https://nodejs.org/en", NODEJS_EXPIRATION)
+      WarningCollector.addPipelineWarning("old_nodejs_version", "Please upgrade to NodeJS v18.16.0 at latest, https://nodejs.org/en", NODEJS_EXPIRATION)
     }
   }
 

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -334,7 +334,7 @@ EOF
       validVersion = current_version >= DESIRED_MIN_VERSION
     } else {
       steps.echo(".nvrmc file is missing for this project")
-      WarningCollector.addPipelineWarning("missing_nvrmc_file", "An nvrmc file is missing for this project. see https://", NODEJS_EXPIRATION)
+      WarningCollector.addPipelineWarning("missing_nvrmc_file", "An nvrmc file is missing for this project. see https://github.com/hmcts/expressjs-template", NODEJS_EXPIRATION)
     }
 
     return validVersion
@@ -342,7 +342,7 @@ EOF
 
   private nagAboutOldNodeJSVersions() {
     if (!isNodeJSV18OrNewer()) {
-      steps.echo("NodeJS version is less than v18.16.0 and would need to be upgraded")
+      steps.echo("NodeJS version is less than v18.16.0. Please update your projects .nvmrc file with the desired version")
       WarningCollector.addPipelineWarning("old_nodejs_version", "Please upgrade to NodeJS v18.16.0 or greater, https://nodejs.org/en", NODEJS_EXPIRATION)
     }
   }

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -332,7 +332,7 @@ EOF
       validVersion = current_version >= DESIRED_MIN_VERSION
     } else {
       steps.echo(".nvrmc file is missing for this project")
-      WarningCollector.addPipelineWarning("missing_nvrmc_file", "An .nvrmc file is missing for the project. see https://", NODEJS_EXPIRATION)
+      WarningCollector.addPipelineWarning("missing_nvrmc_file", "An nvrmc file is missing for this project. see https://", NODEJS_EXPIRATION)
     }
 
     return validVersion
@@ -341,7 +341,7 @@ EOF
   private nagAboutOldNodeJSVersions() {
     if (!isNodeJSV18OrNewer()) {
       steps.echo("NodeJS version is less than v18.16.0 and would need to be upgraded")
-      WarningCollector.addPipelineWarning("old_nodejs_version", "Please upgrade to NodeJS v18ls, https://nodejs.org/en", NODEJS_EXPIRATION)
+      WarningCollector.addPipelineWarning("old_nodejs_version", "Please upgrade to NodeJS v18.16.0 at least, https://nodejs.org/en", NODEJS_EXPIRATION)
     }
   }
 

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -330,10 +330,8 @@ EOF
       Float current_version = valueOf(nodeVersion
                                           .trim()
                                           .substring(0, nodeVersion.lastIndexOf(".")))
-      steps.echo("Existing NodeJS at v${current_version}.x")
       validVersion = current_version >= DESIRED_MIN_VERSION
     } else {
-      steps.echo(".nvrmc file is missing for this project")
       WarningCollector.addPipelineWarning("missing_nvrmc_file", "An nvrmc file is missing for this project. see https://github.com/hmcts/expressjs-template/blob/HEAD/.nvmrc", NODEJS_EXPIRATION)
     }
 
@@ -342,7 +340,6 @@ EOF
 
   private nagAboutOldNodeJSVersions() {
     if (!isNodeJSV18OrNewer()) {
-      steps.echo("NodeJS version is less than v18.16.0. Please update your projects .nvmrc file with the desired version")
       WarningCollector.addPipelineWarning("old_nodejs_version", "Please upgrade to NodeJS v18.16.0 or greater, https://nodejs.org/en", NODEJS_EXPIRATION)
     }
   }

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -340,7 +340,7 @@ EOF
 
   private nagAboutOldNodeJSVersions() {
     if (!isNodeJSV18OrNewer()) {
-      WarningCollector.addPipelineWarning("old_nodejs_version", "Please upgrade to NodeJS v18.16.0 or greater, https://nodejs.org/en", NODEJS_EXPIRATION)
+      WarningCollector.addPipelineWarning("old_nodejs_version", "Please upgrade to NodeJS v18.16.0 or greater by updating the version in your .nvrmc file, https://nodejs.org/en", NODEJS_EXPIRATION)
     }
   }
 

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -5,6 +5,7 @@ import uk.gov.hmcts.pipeline.CVEPublisher
 import uk.gov.hmcts.pipeline.SonarProperties
 import uk.gov.hmcts.pipeline.deprecation.WarningCollector
 import java.time.LocalDate
+import static java.lang.Float.valueOf
 
 class YarnBuilder extends AbstractBuilder {
 
@@ -326,10 +327,9 @@ EOF
 
     if (steps.fileExists(NVMRC)) {
       String nodeVersion = steps.readFile(NVMRC)
-      nodeVersion = nodeVersion
-                    .trim()
-                    .substring(0, nodeVersion.lastIndexOf("."))
-      Float current_version = Float.valueOf(nodeVersion)
+      Float current_version = valueOf(nodeVersion
+                                          .trim()
+                                          .substring(0, nodeVersion.lastIndexOf(".")))
       steps.echo("Existing NodeJS at v${current_version}.x")
       validVersion = current_version >= DESIRED_MIN_VERSION
     } else {
@@ -343,7 +343,7 @@ EOF
   private nagAboutOldNodeJSVersions() {
     if (!isNodeJSV18OrNewer()) {
       steps.echo("NodeJS version is less than v18.16.0 and would need to be upgraded")
-      WarningCollector.addPipelineWarning("old_nodejs_version", "Please upgrade to NodeJS v18.16.0 at latest, https://nodejs.org/en", NODEJS_EXPIRATION)
+      WarningCollector.addPipelineWarning("old_nodejs_version", "Please upgrade to NodeJS v18.16.0 or greater, https://nodejs.org/en", NODEJS_EXPIRATION)
     }
   }
 

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -334,7 +334,7 @@ EOF
       validVersion = current_version >= DESIRED_MIN_VERSION
     } else {
       steps.echo(".nvrmc file is missing for this project")
-      WarningCollector.addPipelineWarning("missing_nvrmc_file", "An nvrmc file is missing for this project. see https://github.com/hmcts/expressjs-template", NODEJS_EXPIRATION)
+      WarningCollector.addPipelineWarning("missing_nvrmc_file", "An nvrmc file is missing for this project. see https://github.com/hmcts/expressjs-template/blob/HEAD/.nvmrc", NODEJS_EXPIRATION)
     }
 
     return validVersion


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/DTSPO-13465

### Change description ###

Adding a nagger for Nodejs version if less that`v18.16.0`. It also checks the existence on an `.nvrmc` file and nags about that too.  
