### PR TITLE
Remove extra node allocation

### DIFF
--- a/vars/withNightlyPipeline.groovy
+++ b/vars/withNightlyPipeline.groovy
@@ -62,9 +62,7 @@ def call(type,product,component,Closure body) {
         notifyBuildFailure channel: slackChannel
 
         callbacksRunner.call('onFailure')
-        node {
-          metricsPublisher.publish('Pipeline Failed')
-        }
+        metricsPublisher.publish('Pipeline Failed')
         throw err
       } finally {
         notifyPipelineDeprecations(slackChannel, metricsPublisher)


### PR DESCRIPTION
Noticed when seeing the build queue that a bunch of nightly builds weren't stopping as they couldn't get this node that they don't need