### PR TITLE
DTSPO-14034 - Use java version on agent

### DIFF
--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -240,7 +240,7 @@ EOF
 
   @Override
   def setupToolVersion() {
-  def statusCode = steps.sh script: 'grep -F "JavaLanguageVersion.of(11)" build.gradle', returnStatus: true
+    def statusCode = steps.sh script: 'grep -F "JavaLanguageVersion.of(11)" build.gradle', returnStatus: true
     if (statusCode == 0) {
       WarningCollector.addPipelineWarning("java_11_deprecated",
         "Please upgrade to Java 17, upgrade to " +

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -240,20 +240,18 @@ EOF
 
   @Override
   def setupToolVersion() {
-    try {
-      def statusCode = steps.sh script: 'grep -F "JavaLanguageVersion.of(11)" build.gradle', returnStatus: true
-      if (statusCode == 0) {
-        WarningCollector.addPipelineWarning("java_11_deprecated",
-          "Please upgrade to Java 17, upgrade to " +
-            "<https://moj.enterprise.slack.com/files/T02DYEB3A/F02V9BNFXRU?origin_team=T1L0WSW9F|Application Insights v3 first>, " +
-            "then <https://github.com/hmcts/draft-store/pull/989|upgrade to Java 17>. " +
-            "Make sure you use the latest version of the Application insights agent, see the configuration in " +
-            "<https://github.com/hmcts/spring-boot-template/|spring-boot-template>, " +
-            "look at the `.github/renovate.json` and `Dockerfile` files.", LocalDate.of(2023, 8, 1)
-        )
-      }
+  def statusCode = steps.sh script: 'grep -F "JavaLanguageVersion.of(11)" build.gradle', returnStatus: true
+    if (statusCode == 0) {
+      WarningCollector.addPipelineWarning("java_11_deprecated",
+        "Please upgrade to Java 17, upgrade to " +
+          "<https://moj.enterprise.slack.com/files/T02DYEB3A/F02V9BNFXRU?origin_team=T1L0WSW9F|Application Insights v3 first>, " +
+          "then <https://github.com/hmcts/draft-store/pull/989|upgrade to Java 17>. " +
+          "Make sure you use the latest version of the Application insights agent, see the configuration in " +
+          "<https://github.com/hmcts/spring-boot-template/|spring-boot-template>, " +
+          "look at the `.github/renovate.json` and `Dockerfile` files.", LocalDate.of(2023, 8, 1)
+      )
     }
-    
+
     steps.env.GRADLE_OPTS = "--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED"
     gradle("--version") // ensure wrapper has been downloaded
     localSteps.sh "java -version"

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -241,13 +241,8 @@ EOF
   @Override
   def setupToolVersion() {
     try {
-      def statusCode = steps.sh script: 'grep -F "JavaLanguageVersion.of(17)" build.gradle', returnStatus: true
+      def statusCode = steps.sh script: 'grep -F "JavaLanguageVersion.of(11)" build.gradle', returnStatus: true
       if (statusCode == 0) {
-        steps.env.JAVA_HOME = "/usr/lib/jvm/java-17-openjdk-amd64"
-        steps.env.PATH = "${steps.env.JAVA_HOME}/bin:${steps.env.PATH}"
-        // Workaround jacocoTestReport issue https://github.com/gradle/gradle/issues/18508#issuecomment-1049998305
-        steps.env.GRADLE_OPTS = "--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED"
-      } else {
         WarningCollector.addPipelineWarning("java_11_deprecated",
           "Please upgrade to Java 17, upgrade to " +
             "<https://moj.enterprise.slack.com/files/T02DYEB3A/F02V9BNFXRU?origin_team=T1L0WSW9F|Application Insights v3 first>, " +
@@ -257,10 +252,9 @@ EOF
             "look at the `.github/renovate.json` and `Dockerfile` files.", LocalDate.of(2023, 8, 1)
         )
       }
-    } catch(err) {
-      steps.echo "Failed to detect java version, ensure the root project has the correct Java requirements set"
     }
-
+    
+    steps.env.GRADLE_OPTS = "--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED"
     gradle("--version") // ensure wrapper has been downloaded
     localSteps.sh "java -version"
   }

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -252,6 +252,7 @@ EOF
       )
     }
 
+    // Workaround jacocoTestReport issue https://github.com/gradle/gradle/issues/18508#issuecomment-1049998305
     steps.env.GRADLE_OPTS = "--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED"
     gradle("--version") // ensure wrapper has been downloaded
     localSteps.sh "java -version"


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-14034

Java 11 has been removed from the agents
Use version of Java installed on the agent by default (17)
Throw error if build.gradle declares version 11
