### PR TITLE
DTSPO-14034 - Deprecate gatling docker

### DIFF
--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -286,7 +286,7 @@ EOF
     } else {
       WarningCollector.addPipelineWarning("gatling_docker_deprecated",
         "Please use the gatling plugin instead of the docker image " +
-          "See <https://github.com/hmcts/cnp-plum-recipes-service/pull/817/files|example>", LocalDate.of(2023, 8, 1)
+          "See <https://github.com/hmcts/cnp-plum-recipes-service/pull/817/files|example>", LocalDate.of(2023, 9, 1)
       )
       super.executeGatling()
     }

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -284,6 +284,10 @@ EOF
       gradle("gatlingRun")
       this.localSteps.gatlingArchive()
     } else {
+      WarningCollector.addPipelineWarning("gatling_docker_deprecated",
+        "Please use the gatling plugin instead of the docker image " +
+          "See <https://github.com/hmcts/cnp-plum-recipes-service/pull/817/files|example>", LocalDate.of(2023, 8, 1)
+      )
       super.executeGatling()
     }
   }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-14034

Deprecate gatling docker container in favour of gradle plugin
