### PR TITLE
Delay node.js 18 for XUI

### DIFF
--- a/src/uk/gov/hmcts/contino/AngularPipelineType.groovy
+++ b/src/uk/gov/hmcts/contino/AngularPipelineType.groovy
@@ -12,6 +12,8 @@ public class AngularPipelineType implements PipelineType, Serializable {
     this.product = product
     this.app = app
 
+    this.steps.env.PRODUCT = product
+
     builder = new AngularBuilder(steps)
   }
 }

--- a/src/uk/gov/hmcts/contino/NodePipelineType.groovy
+++ b/src/uk/gov/hmcts/contino/NodePipelineType.groovy
@@ -12,6 +12,8 @@ public class NodePipelineType implements PipelineType, Serializable {
     this.product = product
     this.app = app
 
+    this.steps.env.PRODUCT = product
+
     builder = new YarnBuilder(steps)
   }
 }

--- a/src/uk/gov/hmcts/contino/RubyPipelineType.groovy
+++ b/src/uk/gov/hmcts/contino/RubyPipelineType.groovy
@@ -12,6 +12,8 @@ class RubyPipelineType implements PipelineType, Serializable {
     this.product = product
     this.app = app
 
+    this.steps.env.PRODUCT = product
+
     builder = new RubyBuilder(steps)
   }
 }

--- a/src/uk/gov/hmcts/contino/SpringBootPipelineType.groovy
+++ b/src/uk/gov/hmcts/contino/SpringBootPipelineType.groovy
@@ -12,6 +12,8 @@ class SpringBootPipelineType implements PipelineType, Serializable {
     this.product = product
     this.app = app
 
+    this.steps.env.PRODUCT = product
+
     builder = new GradleBuilder(steps, product)
   }
 }

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -294,6 +294,12 @@ EOF
     return status == 0  // only a 0 return status is success
   }
 
+  private LocalDate node18ExpirationDate() {
+    def date = env.PRODUCT == 'xui' ? LocalDate.of(2023, 10, 31) : NODEJS_EXPIRATION
+    steps.echo "Node.Js upgrade deadline is: ${date}"
+    return date
+  }
+
   private isNodeJSV18OrNewer() {
     boolean validVersion = true;
     if (steps.fileExists(NVMRC)) {
@@ -303,7 +309,7 @@ EOF
                                           .substring(0, nodeVersion.lastIndexOf(".")))
       validVersion = current_version >= DESIRED_MIN_VERSION
     } else {
-      WarningCollector.addPipelineWarning("missing_nvrmc_file", "An nvrmc file is missing for this project. see https://github.com/hmcts/expressjs-template/blob/HEAD/.nvmrc", NODEJS_EXPIRATION)
+      WarningCollector.addPipelineWarning("missing_nvrmc_file", "An nvrmc file is missing for this project. see https://github.com/hmcts/expressjs-template/blob/HEAD/.nvmrc", node18ExpirationDate())
     }
 
     return validVersion
@@ -311,7 +317,7 @@ EOF
 
   private nagAboutOldNodeJSVersions() {
     if (!isNodeJSV18OrNewer()) {
-      WarningCollector.addPipelineWarning("old_nodejs_version", "Please upgrade to NodeJS v18.16.0 or greater by updating the version in your .nvrmc file, https://nodejs.org/en", NODEJS_EXPIRATION)
+      WarningCollector.addPipelineWarning("old_nodejs_version", "Please upgrade to NodeJS v18.16.0 or greater by updating the version in your .nvrmc file, https://nodejs.org/en", node18ExpirationDate())
     }
   }
 

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -296,7 +296,7 @@ EOF
 
   private LocalDate node18ExpirationDate() {
     def date = steps.env.PRODUCT == 'xui' ? LocalDate.of(2023, 10, 31) : NODEJS_EXPIRATION
-    steps.echo "Node.Js upgrade deadline is: ${date}"
+    steps.echo "Node.Js upgrade deadline is: ${date}, product is: ${steps.env.PRODUCT}"
     return date
   }
 

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -295,7 +295,7 @@ EOF
   }
 
   private LocalDate node18ExpirationDate() {
-    def date = env.PRODUCT == 'xui' ? LocalDate.of(2023, 10, 31) : NODEJS_EXPIRATION
+    def date = steps.env.PRODUCT == 'xui' ? LocalDate.of(2023, 10, 31) : NODEJS_EXPIRATION
     steps.echo "Node.Js upgrade deadline is: ${date}"
     return date
   }

--- a/vars/withCamundaOnlyPipeline.groovy
+++ b/vars/withCamundaOnlyPipeline.groovy
@@ -25,10 +25,10 @@ def call(type, String product, String component, String s2sServiceName, String t
   def callbacksRunner = new PipelineCallbacksRunner(callbacks)
 
   def pipelineTypes = [
-    java  : new SpringBootPipelineType(this, deploymentProduct, component),
-    nodejs: new NodePipelineType(this, deploymentProduct, component),
-    angular: new AngularPipelineType(this, deploymentProduct, component),
-    ruby: new RubyPipelineType(this, deploymentProduct, component)
+    java  : new SpringBootPipelineType(this, product, component),
+    nodejs: new NodePipelineType(this, product, component),
+    angular: new AngularPipelineType(this, product, component),
+    ruby: new RubyPipelineType(this, product, component)
   ]
 
   PipelineType pipelineType

--- a/vars/withCamundaOnlyPipeline.groovy
+++ b/vars/withCamundaOnlyPipeline.groovy
@@ -6,7 +6,6 @@ import uk.gov.hmcts.contino.MetricsPublisher
 import uk.gov.hmcts.contino.Environment
 import uk.gov.hmcts.contino.Builder
 import uk.gov.hmcts.pipeline.TeamConfig
-import uk.gov.hmcts.contino.ProjectBranch
 import uk.gov.hmcts.contino.AngularPipelineType
 import uk.gov.hmcts.contino.NodePipelineType
 import uk.gov.hmcts.contino.PipelineType
@@ -15,10 +14,6 @@ import uk.gov.hmcts.contino.SpringBootPipelineType
 
 def call(type, String product, String component, String s2sServiceName, String tenantId, Closure body) {
   MetricsPublisher metricsPublisher = new MetricsPublisher(this, currentBuild, product, component)
-
-  def branch = new ProjectBranch(env.BRANCH_NAME)
-  def deploymentNamespace = branch.deploymentNamespace()
-  def deploymentProduct = deploymentNamespace ? "$deploymentNamespace-$product" : product
 
   def pipelineConfig = new AppPipelineConfig()
   def callbacks = new PipelineCallbacksConfig()

--- a/vars/withPactTestOnlyPipeline.groovy
+++ b/vars/withPactTestOnlyPipeline.groovy
@@ -21,10 +21,10 @@ def call(type, String product, String component, Closure body) {
   def deploymentProduct = deploymentNamespace ? "$deploymentNamespace-$product" : product
 
   def pipelineTypes = [
-    java  : new SpringBootPipelineType(this, deploymentProduct, component),
-    nodejs: new NodePipelineType(this, deploymentProduct, component),
-    angular: new AngularPipelineType(this, deploymentProduct, component),
-    ruby: new RubyPipelineType(this, deploymentProduct, component)
+    java  : new SpringBootPipelineType(this, product, component),
+    nodejs: new NodePipelineType(this, product, component),
+    angular: new AngularPipelineType(this, product, component),
+    ruby: new RubyPipelineType(this, product, component)
   ]
 
   PipelineType pipelineType

--- a/vars/withPactTestOnlyPipeline.groovy
+++ b/vars/withPactTestOnlyPipeline.groovy
@@ -15,11 +15,6 @@ import uk.gov.hmcts.pipeline.TeamConfig
 
 def call(type, String product, String component, Closure body) {
 
-  def branch = new ProjectBranch(env.BRANCH_NAME)
-
-  def deploymentNamespace = branch.deploymentNamespace()
-  def deploymentProduct = deploymentNamespace ? "$deploymentNamespace-$product" : product
-
   def pipelineTypes = [
     java  : new SpringBootPipelineType(this, product, component),
     nodejs: new NodePipelineType(this, product, component),

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -24,10 +24,10 @@ def call(type, String product, String component, Closure body) {
   def deploymentProduct = deploymentNamespace ? "$deploymentNamespace-$product" : product
 
   def pipelineTypes = [
-    java  : new SpringBootPipelineType(this, deploymentProduct, component),
-    nodejs: new NodePipelineType(this, deploymentProduct, component),
-    angular: new AngularPipelineType(this, deploymentProduct, component),
-    ruby: new RubyPipelineType(this, deploymentProduct, component)
+    java  : new SpringBootPipelineType(this, product, component),
+    nodejs: new NodePipelineType(this, product, component),
+    angular: new AngularPipelineType(this, product, component),
+    ruby: new RubyPipelineType(this, product, component)
   ]
 
   Subscription subscription = new Subscription(env)


### PR DESCRIPTION
I didn't want to just add the product into the constructor, because:
a) lots of teams use YarnBuilder already including XUI
b) if it was added to the constructor and used by XUI product would need to be used in 2 places, not the end of the work but not ideal

Tested in:

- https://build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_d_to_i%2Fdiv-respondent-frontend/detail/PR-737/4/pipeline/11?branch=PR-737
- https://build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_j_to_z%2Frpx-xui-webapp/detail/PR-3213/4/pipeline/12?branch=PR-3213

More changes than I would have liked but I couldn't find a nice way to do it otherwise, suggestions welcomed