### PR TITLE
Revert "DTSPO-14034 - Update owasp2docker image"

### DIFF
--- a/src/uk/gov/hmcts/contino/SecurityScan.groovy
+++ b/src/uk/gov/hmcts/contino/SecurityScan.groovy
@@ -2,7 +2,7 @@ package uk.gov.hmcts.contino
 
 
 class SecurityScan implements Serializable {
-    public static final String OWASP_ZAP_IMAGE = 'owasp/zap2docker-stable:2.12.0'
+    public static final String OWASP_ZAP_IMAGE = 'owasp/zap2docker-stable:2.11.1'
     public static final String OWASP_ZAP_ARGS = '-u 0:0 --name zap -p 1001:1001 -v $WORKSPACE:/zap/wrk/:rw'
     public static final String GLUEIMAGE = 'hmcts/zap-glue:latest'
     public static final String GLUE_ARGS = '-u 0:0 --name=Glue -w $(pwd):/tmp'


### PR DESCRIPTION
Reverts hmcts/cnp-jenkins-library#1134

zap-cli has been removed in newer images. Reverting so scans work whilst I look at adapting the scans