### PR TITLE
DTSPO-14996: Add fees-register to Node 18 exclude list

### DIFF
--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -321,6 +321,7 @@ EOF
         date = LocalDate.of(2023, 10, 31)
         break
       case "bar":
+      case "fees-register":
       case "ccpay":
         date = LocalDate.of(2023, 9, 30)
         break


### PR DESCRIPTION
Resolves: DTSPO-14996

Notes:
    Fee and Payment apps the team is working with EXUI on testing and need an extension to the Node 18 work.
    Node 18 extension for ccpay/bar - the update adds the Fees-Register product which was missed in the original PR. 


