### PR TITLE
DTSPO-14996: CCPAY Node 18 Ext 20 Oct

### DIFF
--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -321,6 +321,7 @@ EOF
         date = LocalDate.of(2023, 10, 31)
         break
       case "bar":
+      case "fees-register":
       case "ccpay":
         date = LocalDate.of(2023, 9, 30)
         break

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -324,7 +324,7 @@ EOF
       case "bar":
       case "fees-register":
       case "ccpay":
-        date = LocalDate.of(2023, 9, 30)
+        date = LocalDate.of(2023, 10, 21)
         break
       default:
         date = NODEJS_EXPIRATION


### PR DESCRIPTION
Resolves # DTSPO-14996

DTSPO-14996 is an old ticket, this PR is to extend the deadline for Node 18 for Fee and Payment application by 3 weeks. Fee and Pay are making good progress on Node 18 and only have 2 components to upgrade, plus a web-component which is tied to the EXUI Manage Case release. So we will not finish before our last deadline of the end of September.

