### PR TITLE
wrap tech stack logic in try catch

### DIFF
--- a/src/uk/gov/hmcts/ardoq/ArdoqClient.groovy
+++ b/src/uk/gov/hmcts/ardoq/ArdoqClient.groovy
@@ -33,7 +33,6 @@ class ArdoqClient {
     }
     steps.sh "grep -E '^FROM' Dockerfile | awk '{print \$2}' | awk -F ':' '{printf(\"%s\", \$1)}' | tr '/' '\\n' | tail -1 > languageProc"
     def result = steps.readFile('languageProc')
-    steps.sh "rm -f languageProc"
     return result
   }
 
@@ -44,7 +43,6 @@ class ArdoqClient {
     }
     steps.sh "grep -E '^FROM' Dockerfile | awk '{print \$2}' | awk -F ':' '{printf(\"%s\", \$2)}' > languageVersionProc"
     def result = steps.readFile('languageVersionProc')
-    steps.sh "rm -f languageProc"
     return result
   }
 

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -146,15 +146,19 @@ class GradleBuilder extends AbstractBuilder {
   @Override
   def techStackMaintenance() {
     localSteps.echo "Running Gradle Tech stack maintenance"
-    def secrets = [
-      [ secretType: 'Secret', name: 'ardoq-api-key', version: '', envVariable: 'ARDOQ_API_KEY' ],
-      [ secretType: 'Secret', name: 'ardoq-api-url', version: '', envVariable: 'ARDOQ_API_URL' ]
-    ]
-    localSteps.withAzureKeyvault(secrets) {
-      localSteps.sh "./gradlew -q dependencies > depsProc"
-      def client = new ArdoqClient(localSteps.env.ARDOQ_API_KEY, localSteps.env.ARDOQ_API_URL, steps)
-      client.updateDependencies(localSteps.readFile('depsProc'), 'gradle')
-      localSteps.sh "rm -f depsProc"
+    try {
+      def secrets = [
+        [ secretType: 'Secret', name: 'ardoq-api-key', version: '', envVariable: 'ARDOQ_API_KEY' ],
+        [ secretType: 'Secret', name: 'ardoq-api-url', version: '', envVariable: 'ARDOQ_API_URL' ]
+      ]
+      localSteps.withAzureKeyvault(secrets) {
+        localSteps.sh "./gradlew -q dependencies > depsProc"
+        def client = new ArdoqClient(localSteps.env.ARDOQ_API_KEY, localSteps.env.ARDOQ_API_URL, steps)
+        client.updateDependencies(localSteps.readFile('depsProc'), 'gradle')
+        localSteps.sh "rm -f depsProc"
+      }
+    } catch(Exception e) {
+      localSteps.echo "Error running Gradle tech stack maintenance {e.getMessage()}"
     }
   }
 

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -155,7 +155,6 @@ class GradleBuilder extends AbstractBuilder {
         localSteps.sh "./gradlew -q dependencies > depsProc"
         def client = new ArdoqClient(localSteps.env.ARDOQ_API_KEY, localSteps.env.ARDOQ_API_URL, steps)
         client.updateDependencies(localSteps.readFile('depsProc'), 'gradle')
-        localSteps.sh "rm -f depsProc"
       }
     } catch(Exception e) {
       localSteps.echo "Error running Gradle tech stack maintenance {e.getMessage()}"

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -162,13 +162,17 @@ class YarnBuilder extends AbstractBuilder {
   @Override
   def techStackMaintenance() {
     this.steps.echo "Running Yarn Tech stack maintenance"
-    def secrets = [
-      [ secretType: 'Secret', name: 'ardoq-api-key', version: '', envVariable: 'ARDOQ_API_KEY' ],
-      [ secretType: 'Secret', name: 'ardoq-api-url', version: '', envVariable: 'ARDOQ_API_URL' ]
-    ]
-    localSteps.withAzureKeyvault(secrets) {
-      def client = new ArdoqClient(localSteps.env.ARDOQ_API_KEY, localSteps.env.ARDOQ_API_URL, steps)
-      client.updateDependencies(localSteps.readFile('yarn.lock'), 'yarn')
+    try {
+      def secrets = [
+        [ secretType: 'Secret', name: 'ardoq-api-key', version: '', envVariable: 'ARDOQ_API_KEY' ],
+        [ secretType: 'Secret', name: 'ardoq-api-url', version: '', envVariable: 'ARDOQ_API_URL' ]
+      ]
+      localSteps.withAzureKeyvault(secrets) {
+        def client = new ArdoqClient(localSteps.env.ARDOQ_API_KEY, localSteps.env.ARDOQ_API_URL, steps)
+        client.updateDependencies(localSteps.readFile('yarn.lock'), 'yarn')
+      }
+    } catch(Exception e) {
+      localSteps.echo "Error running tech Yarn stack maintenance {e.getMessage()}"
     }
   }
 

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -164,7 +164,7 @@ def call(params) {
         // they can't be safely deleted in the parallel branches as docker build context will collect files
         // and then upload them, if any are missing it will error:
         // ERROR: [Errno 2] No such file or directory: './sorted-yarn-audit-issues'
-        sh "rm -f new_vulnerabilities unneeded_suppressions sorted-yarn-audit-issues sorted-yarn-audit-known-issues active_suppressions unused_suppressions || true"
+        sh "rm -f new_vulnerabilities unneeded_suppressions sorted-yarn-audit-issues sorted-yarn-audit-known-issues active_suppressions unused_suppressions depsProc languageProc || true"
       }
     }
 


### PR DESCRIPTION
Fixes

> We've had a couple of failures this morning.  The error in the log is:
11:11:45  ERROR: [Errno 2] No such file or directory: './depsProc'
e.g. https://build.platform.hmcts.net/view/Civil-SDT/job/HMCTS_a_to_c/job/civil-sdt/job/master/197/execution/node/99/log/
It failed on one run, worked OK the next, then failed twice in a row.

tested: https://github.com/hmcts/civil-sdt/pull/317