### PR TITLE
PAY-6454: Extension as PayBubble still not migrated due to style issues.

### DIFF
--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -329,7 +329,7 @@ EOF
       case "bar":
       case "fees-register":
       case "ccpay":
-        date = LocalDate.of(2023, 11, 18)
+        date = LocalDate.of(2023, 12, 8)
         break
       default:
         date = NODEJS_EXPIRATION


### PR DESCRIPTION
Resolves # . PAY-6446, PAY-6454

Notes:
* Paybubble applications require a bit more work to fix some cosmetic issues in the web-component.

