### PR TITLE
Update to use new owasp dependency database

### DIFF
--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -230,9 +230,9 @@ EOF
 
   private String gradleWithOutput(String task) {
     addInitScript()
-    return localSteps.sh(script: "./gradlew --no-daemon --stacktrace --init-script init.gradle ${task}", returnStdout: true).trim()
+    localSteps.sh(script: "./gradlew --no-daemon --init-script init.gradle ${task}", returnStdout: true).trim()
   }
-  
+
   def fullFunctionalTest() {
       functionalTest()
   }

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -139,7 +139,7 @@ class GradleBuilder extends AbstractBuilder {
           WarningCollector.addPipelineWarning("deprecate_owasp_8", "Older versions of Owasp dependency check  plugin are not supported, please move to latest 9.x.", new Date().parse("dd.MM.yyyy", "15.12.2023"))
           gradle("--stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='${localSteps.env.OWASPDB_V14_CONNECTION_STRING}' -Ddata.user='${localSteps.env.OWASPDB_V14_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V14_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate")
         }
-      } catch( Exception ex) {
+      } catch (Exception ex) {
          println(ex.toString());
          println(ex.getMessage());
          println(ex.getStackTrace());

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -139,9 +139,6 @@ class GradleBuilder extends AbstractBuilder {
           WarningCollector.addPipelineWarning("deprecate_owasp_8", "Older versions of Owasp dependency check  plugin are not supported, please move to latest 9.x.", new Date().parse("dd.MM.yyyy", "15.12.2023"))
           gradle("--stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='${localSteps.env.OWASPDB_V14_CONNECTION_STRING}' -Ddata.user='${localSteps.env.OWASPDB_V14_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V14_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate")
         }
-      } catch (Throwable t) {
-        println("Caught throwable:")
-        t.printStackTrace()
       } finally {
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'
         String dependencyReport = localSteps.readFile('build/reports/dependency-check-report.json')
@@ -233,7 +230,7 @@ EOF
 
   private String gradleWithOutput(String task) {
     addInitScript()
-    localSteps.sh(script: "./gradlew --no-daemon --init-script init.gradle ${task}", returnStdout: true).trim()
+    localSteps.sh(script: "./gradlew --no-daemon --stacktrace --init-script init.gradle ${task}", returnStdout: true).trim()
   }
 
   def fullFunctionalTest() {

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -151,7 +151,7 @@ class GradleBuilder extends AbstractBuilder {
         if (hasPlugin("org.owasp.dependencycheck.gradle.plugin:9")) {
           gradle("--stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='${localSteps.env.OWASPDB_V15_CONNECTION_STRING}' -Ddata.user='${localSteps.env.OWASPDB_V15_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V15_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate")
         } else {
-          WarningCollector.addPipelineWarning("deprecate_owasp_8", "Older versions of Owasp dependency check  plugin are not supported, please move to latest 9.x.", new Date().parse("dd.MM.yyyy", "15.12.2023"))
+          WarningCollector.addPipelineWarning("deprecated_owasp_8", "Versions of owasp dependency check below v9 are deprecated, please upgrade to latest release.", LocalDate.of(2023, 12, 15))
           gradle("--stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='${localSteps.env.OWASPDB_V14_CONNECTION_STRING}' -Ddata.user='${localSteps.env.OWASPDB_V14_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V14_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate")
         }
       } catch(Exception e) {

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -123,9 +123,9 @@ class GradleBuilder extends AbstractBuilder {
 
   def securityCheck() {
     def secrets = [
-      [ secretType: 'Secret', name: 'OWASPPostgresDb-v15-Account', version: '', envVariable: 'OWASPDB_V14_ACCOUNT' ],
-      [ secretType: 'Secret', name: 'OWASPPostgresDb-v15-Password', version: '', envVariable: 'OWASPDB_V14_PASSWORD' ],
-      [ secretType: 'Secret', name: 'OWASPPostgresDb-v15-Connection-String', version: '', envVariable: 'OWASPDB_V14_CONNECTION_STRING' ],
+      [ secretType: 'Secret', name: 'OWASPPostgresDb-v14-Account', version: '', envVariable: 'OWASPDB_V14_ACCOUNT' ],
+      [ secretType: 'Secret', name: 'OWASPPostgresDb-v14-Password', version: '', envVariable: 'OWASPDB_V14_PASSWORD' ],
+      [ secretType: 'Secret', name: 'OWASPPostgresDb-v14-Connection-String', version: '', envVariable: 'OWASPDB_V14_CONNECTION_STRING' ],
       [ secretType: 'Secret', name: 'OWASPPostgresDb-v15-Account', version: '', envVariable: 'OWASPDB_V15_ACCOUNT' ],
       [ secretType: 'Secret', name: 'OWASPPostgresDb-v15-Password', version: '', envVariable: 'OWASPDB_V15_PASSWORD' ],
       [ secretType: 'Secret', name: 'OWASPPostgresDb-v15-Connection-String', version: '', envVariable: 'OWASPDB_V15_CONNECTION_STRING' ]

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -132,6 +132,12 @@ class GradleBuilder extends AbstractBuilder {
     ]
 
     localSteps.withAzureKeyvault(secrets) {
+      try{
+        boolean hasPlugin = hasPlugin("org.owasp.dependencycheck.gradle.plugin:9")
+      } catch (Exception e) {
+        println("Exception: ${e}")
+      }
+
       try {
         if (hasPlugin("org.owasp.dependencycheck.gradle.plugin:9")) {
           gradle("--stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='${localSteps.env.OWASPDB_V15_CONNECTION_STRING}' -Ddata.user='${localSteps.env.OWASPDB_V15_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V15_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate")

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -123,14 +123,14 @@ class GradleBuilder extends AbstractBuilder {
 
   def securityCheck() {
     def secrets = [
-      [ secretType: 'Secret', name: 'OWASPPostgresDb-v14-Account', version: '', envVariable: 'OWASPDB_V14_ACCOUNT' ],
-      [ secretType: 'Secret', name: 'OWASPPostgresDb-v14-Password', version: '', envVariable: 'OWASPDB_V14_PASSWORD' ],
-      [ secretType: 'Secret', name: 'OWASPPostgresDb-v14-Connection-String', version: '', envVariable: 'OWASPDB_V14_CONNECTION_STRING' ]
+      [ secretType: 'Secret', name: 'OWASPPostgresDb-v15-Account', version: '', envVariable: 'OWASPDB_V15_ACCOUNT' ],
+      [ secretType: 'Secret', name: 'OWASPPostgresDb-v15-Password', version: '', envVariable: 'OWASPDB_V15_PASSWORD' ],
+      [ secretType: 'Secret', name: 'OWASPPostgresDb-v15-Connection-String', version: '', envVariable: 'OWASPDB_V15_CONNECTION_STRING' ]
     ]
 
     localSteps.withAzureKeyvault(secrets) {
       try {
-          gradle("--stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='${localSteps.env.OWASPDB_V14_CONNECTION_STRING}' -Ddata.user='${localSteps.env.OWASPDB_V14_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V14_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate")
+          gradle("--stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='${localSteps.env.OWASPDB_V15_CONNECTION_STRING}' -Ddata.user='${localSteps.env.OWASPDB_V15_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V15_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate")
       } finally {
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'
         String dependencyReport = localSteps.readFile('build/reports/dependency-check-report.json')

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -139,6 +139,10 @@ class GradleBuilder extends AbstractBuilder {
           WarningCollector.addPipelineWarning("deprecate_owasp_8", "Older versions of Owasp dependency check  plugin are not supported, please move to latest 9.x.", new Date().parse("dd.MM.yyyy", "15.12.2023"))
           gradle("--stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='${localSteps.env.OWASPDB_V14_CONNECTION_STRING}' -Ddata.user='${localSteps.env.OWASPDB_V14_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V14_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate")
         }
+      } catch( Exception ex) {
+         println(ex.toString());
+         println(ex.getMessage());
+         println(ex.getStackTrace());
       } finally {
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'
         String dependencyReport = localSteps.readFile('build/reports/dependency-check-report.json')

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -140,9 +140,10 @@ class GradleBuilder extends AbstractBuilder {
           gradle("--stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='${localSteps.env.OWASPDB_V14_CONNECTION_STRING}' -Ddata.user='${localSteps.env.OWASPDB_V14_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V14_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate")
         }
       } catch (Exception ex) {
-         println(ex.toString());
-         println(ex.getMessage());
-         println(ex.getStackTrace());
+        println("Caught exception")
+        println(ex.toString());
+        println(ex.getMessage());
+        println(ex.getStackTrace());
       } finally {
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'
         String dependencyReport = localSteps.readFile('build/reports/dependency-check-report.json')

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -154,7 +154,7 @@ class GradleBuilder extends AbstractBuilder {
           WarningCollector.addPipelineWarning("deprecate_owasp_8", "Older versions of Owasp dependency check  plugin are not supported, please move to latest 9.x.", new Date().parse("dd.MM.yyyy", "15.12.2023"))
           gradle("--stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='${localSteps.env.OWASPDB_V14_CONNECTION_STRING}' -Ddata.user='${localSteps.env.OWASPDB_V14_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V14_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate")
         }
-      } catch {
+      } catch(Exception e) {
         localSteps.echo "Exception is: ${e}"
       } finally {
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -139,11 +139,9 @@ class GradleBuilder extends AbstractBuilder {
           WarningCollector.addPipelineWarning("deprecate_owasp_8", "Older versions of Owasp dependency check  plugin are not supported, please move to latest 9.x.", new Date().parse("dd.MM.yyyy", "15.12.2023"))
           gradle("--stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='${localSteps.env.OWASPDB_V14_CONNECTION_STRING}' -Ddata.user='${localSteps.env.OWASPDB_V14_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V14_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate")
         }
-      } catch (Exception ex) {
-        println("Caught exception")
-        println(ex.toString());
-        println(ex.getMessage());
-        println(ex.getStackTrace());
+      } catch (Throwable t) {
+        println("Caught throwable:")
+        t.printStackTrace()
       } finally {
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'
         String dependencyReport = localSteps.readFile('build/reports/dependency-check-report.json')

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -126,13 +126,13 @@ class GradleBuilder extends AbstractBuilder {
       addInitScript()
       return localSteps.sh(script: "./gradlew --no-daemon --stacktrace --init-script init.gradle ${task}", returnStdout: true).trim()
     } catch (Exception e) {
-      println("Exception in gradleWithOutput: ${e}")
+      localSteps.echo "Exception in gradleWithOutput: ${e}"
       throw e
     }
   }
 
   def hasPlugin(String pluginName) {
-    this.steps.echo "try to print buildenv"
+    localSteps.echo "try to print buildenv"
     return gradleWithOutput("buildEnvironment").contains(pluginName)
   }
 
@@ -154,6 +154,8 @@ class GradleBuilder extends AbstractBuilder {
           WarningCollector.addPipelineWarning("deprecate_owasp_8", "Older versions of Owasp dependency check  plugin are not supported, please move to latest 9.x.", new Date().parse("dd.MM.yyyy", "15.12.2023"))
           gradle("--stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='${localSteps.env.OWASPDB_V14_CONNECTION_STRING}' -Ddata.user='${localSteps.env.OWASPDB_V14_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V14_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate")
         }
+      } catch {
+        localSteps.echo "Exception is: ${e}"
       } finally {
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'
         String dependencyReport = localSteps.readFile('build/reports/dependency-check-report.json')

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -134,6 +134,7 @@ class GradleBuilder extends AbstractBuilder {
     localSteps.withAzureKeyvault(secrets) {
       try{
         boolean hasPlugin = hasPlugin("org.owasp.dependencycheck.gradle.plugin:9")
+        println("After hasPlugin")
       } catch (Exception e) {
         println("Exception: ${e}")
       }

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -122,8 +122,13 @@ class GradleBuilder extends AbstractBuilder {
   }
 
   private String gradleWithOutput(String task) {
-    addInitScript()
-    localSteps.sh(script: "./gradlew --no-daemon --stacktrace --init-script init.gradle ${task}", returnStdout: true).trim()
+    try {
+      addInitScript()
+      return localSteps.sh(script: "./gradlew --no-daemon --stacktrace --init-script init.gradle ${task}", returnStdout: true).trim()
+    } catch (Exception e) {
+      println("Exception in gradleWithOutput: ${e}")
+      throw e
+    }
   }
 
   def hasPlugin(String pluginName) {

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -121,6 +121,15 @@ class GradleBuilder extends AbstractBuilder {
     }
   }
 
+  private String gradleWithOutput(String task) {
+    addInitScript()
+    localSteps.sh(script: "./gradlew --no-daemon --stacktrace --init-script init.gradle ${task}", returnStdout: true).trim()
+  }
+
+  def hasPlugin(String pluginName) {
+    return gradleWithOutput("buildEnvironment").contains(pluginName)
+  }
+
   def securityCheck() {
     def secrets = [
       [ secretType: 'Secret', name: 'OWASPPostgresDb-v14-Account', version: '', envVariable: 'OWASPDB_V14_ACCOUNT' ],
@@ -235,11 +244,6 @@ EOF
     localSteps.sh("${prepend}./gradlew --no-daemon --init-script init.gradle ${task}")
   }
 
-  private String gradleWithOutput(String task) {
-    addInitScript()
-    localSteps.sh(script: "./gradlew --no-daemon --stacktrace --init-script init.gradle ${task}", returnStdout: true).trim()
-  }
-
   def fullFunctionalTest() {
       functionalTest()
   }
@@ -287,9 +291,6 @@ EOF
     localSteps.sh "java -version"
   }
 
-  def hasPlugin(String pluginName) {
-    return gradleWithOutput("buildEnvironment").contains(pluginName)
-  }
 
   @Override
   def securityScan(){

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -133,12 +133,12 @@ class GradleBuilder extends AbstractBuilder {
 
     localSteps.withAzureKeyvault(secrets) {
       try {
-        if (hasPlugin("org.owasp.dependencycheck.gradle.plugin:9")) {
-          localSteps.echo "Running against latest OWASP DB"
-          gradle("--stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='${localSteps.env.OWASPDB_V15_CONNECTION_STRING}' -Ddata.user='${localSteps.env.OWASPDB_V15_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V15_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate")
-        } else {
+        if (hasPlugin("org.owasp.dependencycheck.gradle.plugin:8")) {
           WarningCollector.addPipelineWarning("deprecated_owasp_v8", "Versions of owasp dependency check below v9 are deprecated, please upgrade to latest release.", LocalDate.of(2023, 12, 15))
           gradle("--stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='${localSteps.env.OWASPDB_V14_CONNECTION_STRING}' -Ddata.user='${localSteps.env.OWASPDB_V14_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V14_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate")
+        } else {
+          localSteps.echo "Running against latest OWASP DB"
+          gradle("--stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='${localSteps.env.OWASPDB_V15_CONNECTION_STRING}' -Ddata.user='${localSteps.env.OWASPDB_V15_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V15_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate")
         }
       } finally {
         localSteps.archiveArtifacts 'build/reports/dependency-check-report.html'

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -132,8 +132,7 @@ class GradleBuilder extends AbstractBuilder {
   }
 
   def hasPlugin(String pluginName) {
-    println "print buildenv"
-    println gradleWithOutput("buildEnvironment").contains(pluginName)
+    this.steps.echo "try to print buildenv"
     return gradleWithOutput("buildEnvironment").contains(pluginName)
   }
 
@@ -148,13 +147,6 @@ class GradleBuilder extends AbstractBuilder {
     ]
 
     localSteps.withAzureKeyvault(secrets) {
-      try{
-        boolean hasPlugin = hasPlugin("org.owasp.dependencycheck.gradle.plugin:9")
-        println("After hasPlugin")
-      } catch (Exception e) {
-        println("Exception: ${e}")
-      }
-
       try {
         if (hasPlugin("org.owasp.dependencycheck.gradle.plugin:9")) {
           gradle("--stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='${localSteps.env.OWASPDB_V15_CONNECTION_STRING}' -Ddata.user='${localSteps.env.OWASPDB_V15_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V15_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate")

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -132,6 +132,8 @@ class GradleBuilder extends AbstractBuilder {
   }
 
   def hasPlugin(String pluginName) {
+    println("print buildenv")
+    println(gradleWithOutput("buildEnvironment").contains(pluginName))
     return gradleWithOutput("buildEnvironment").contains(pluginName)
   }
 

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -134,6 +134,7 @@ class GradleBuilder extends AbstractBuilder {
     localSteps.withAzureKeyvault(secrets) {
       try {
         if (hasPlugin("org.owasp.dependencycheck.gradle.plugin:9")) {
+          localSteps.echo "Running against latest OWASP DB"
           gradle("--stacktrace -DdependencyCheck.failBuild=true -Dcve.check.validforhours=24 -Danalyzer.central.enabled=false -Ddata.driver_name='org.postgresql.Driver' -Ddata.connection_string='${localSteps.env.OWASPDB_V15_CONNECTION_STRING}' -Ddata.user='${localSteps.env.OWASPDB_V15_ACCOUNT}' -Ddata.password='${localSteps.env.OWASPDB_V15_PASSWORD}'  -Danalyzer.retirejs.enabled=false -Danalyzer.ossindex.enabled=false dependencyCheckAggregate")
         } else {
           WarningCollector.addPipelineWarning("deprecated_owasp_v8", "Versions of owasp dependency check below v9 are deprecated, please upgrade to latest release.", LocalDate.of(2023, 12, 15))

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -132,8 +132,8 @@ class GradleBuilder extends AbstractBuilder {
   }
 
   def hasPlugin(String pluginName) {
-    println("print buildenv")
-    println(gradleWithOutput("buildEnvironment").contains(pluginName))
+    println "print buildenv"
+    println gradleWithOutput("buildEnvironment").contains(pluginName)
     return gradleWithOutput("buildEnvironment").contains(pluginName)
   }
 


### PR DESCRIPTION
Updates to use new DB that was built with latest version of dependencycheck 9.0.2

Provided on opt-in basis where teams will need latest version to use the newest DB

