### PR TITLE
Do not fail on yarn npm audit if issues are found

### DIFF
--- a/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
+++ b/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
@@ -79,7 +79,7 @@ check_for_unneeded_suppressions() {
 }
 
 # Perform yarn audit and process the results
-yarn npm audit --recursive --environment production --json > yarn-audit-result
+yarn npm audit --recursive --environment production --json > yarn-audit-result || true
 jq -cr '.advisories | to_entries[].value' < yarn-audit-result | sort > sorted-yarn-audit-issues
 
 # Check if there were any vulnerabilities
@@ -147,4 +147,3 @@ else
     exit 0
   fi
 fi
-


### PR DESCRIPTION
Notes:
Upgrade to yarn@3.7.0 fails if there are any available issues. Yarn fixed their code to correctly exit with non-zero if there are issues found on `yarn npm audit` command (https://github.com/yarnpkg/berry/pull/4358) and released with 3.7.0. Jenkins script yarn-audit-with-suppressions.sh has `set -e` flag, which exits the script with error on the first error, and that is why the fix in yarn breaks our upgrade to yarn v3.7.0. This PR makes sure that the command `yarn npm audit` finishes with 0.