### PR TITLE
DTSPO-16787 - Update yarn-audit-with-suppressions.sh

### DIFF
--- a/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
+++ b/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
@@ -24,7 +24,7 @@
 
 
 # Exit script on error
-set -e
+set -x
 
 # Check for dependencies
 command -v yarn >/dev/null 2>&1 || { echo >&2 "yarn is required but it's not installed. Aborting."; exit 1; }

--- a/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
+++ b/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
@@ -24,7 +24,7 @@
 
 
 # Exit script on error
-set -x
+set -e
 
 # Check for dependencies
 command -v yarn >/dev/null 2>&1 || { echo >&2 "yarn is required but it's not installed. Aborting."; exit 1; }

--- a/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
+++ b/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
@@ -79,10 +79,10 @@ check_for_unneeded_suppressions() {
 }
 
 # Perform yarn audit and process the results
-today=$(date +"%Y-%m-%d")
-exclude_until=$(date -d 2024-02-21 +"%Y-%m-%d")
+today=$(date +"%s")
+exclude_until="1708502400"
 
-if [ "$today" > "$exclude_until" ]; then
+if [ "$today" -gt "$exclude_until" ]; then
   yarn npm audit --recursive --environment production --json > yarn-audit-result
 else
   yarn npm audit --recursive --environment production --json --ignore 1096460 > yarn-audit-result

--- a/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
+++ b/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
@@ -80,6 +80,11 @@ check_for_unneeded_suppressions() {
 
 # Perform yarn audit and process the results
 yarn npm audit --recursive --environment production --json > yarn-audit-result
+
+mv yarn-audit-result yarn-audit-result-2
+jq -c 'del(.advisories[].references)' yarn-audit-result-2 >  yarn-audit-result
+rm yarn-audit-result-2
+
 jq -cr '.advisories | to_entries[].value' < yarn-audit-result | sort > sorted-yarn-audit-issues
 
 # Check if there were any vulnerabilities
@@ -113,8 +118,8 @@ else
 
   # Handle edge case for when audit returns in different orders for the two files
   # Convert JSON array into sorted list of issues.
-  jq -cr '.advisories | to_entries[].value' yarn-audit-known-issues \
-  | sort > sorted-yarn-audit-known-issues
+  # jq -cr '.advisories | to_entries[].value | del(.advisories[].references)' yarn-audit-known-issues \
+  # | sort > sorted-yarn-audit-known-issues
 
   # Retain old data ingestion style for cosmosDB
   jq -cr '.advisories| to_entries[] | {"type": "auditAdvisory", "data": { "advisory": .value }}' yarn-audit-known-issues > yarn-audit-known-issues-result
@@ -151,4 +156,3 @@ else
     exit 0
   fi
 fi
-

--- a/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
+++ b/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
@@ -80,6 +80,7 @@ check_for_unneeded_suppressions() {
 
 # Perform yarn audit and process the results
 today=$(date +"%s")
+# 2024-02-21
 exclude_until="1708502400"
 
 if [ "$today" -gt "$exclude_until" ]; then

--- a/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
+++ b/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
@@ -79,7 +79,7 @@ check_for_unneeded_suppressions() {
 }
 
 # Perform yarn audit and process the results
-today=$(gdate +"%Y-%m-%d")
+today=$(date +"%Y-%m-%d")
 exclude_until=2024-02-21
 
 if [ "$today" > "$exclude_until" ]; then

--- a/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
+++ b/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
@@ -80,7 +80,7 @@ check_for_unneeded_suppressions() {
 
 # Perform yarn audit and process the results
 today=$(date +"%Y-%m-%d")
-exclude_until=2024-02-21
+exclude_until=$(date -d 2024-02-21 +"%Y-%m-%d")
 
 if [ "$today" > "$exclude_until" ]; then
   yarn npm audit --recursive --environment production --json > yarn-audit-result

--- a/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
+++ b/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
@@ -126,6 +126,10 @@ else
     fi
   done < sorted-yarn-audit-issues
 
+  mv new_vulnerabilities new_vulnerabilities_with_references
+  jq -c 'del(.references)' new_vulnerabilities_with_references > new_vulnerabilities
+  rm new_vulnerabilities_with_references
+
   # Check for unneeded suppressions
   check_for_unneeded_suppressions
 


### PR DESCRIPTION
Add workaround to fix issues with suppression script coping with excluding advisory GHSA-78xj-cgh5-2h22.

Currently set to expire on 21st Feb 2024