### PR TITLE
try argument 'failFast' in parallel stages of test pipeline

### DIFF
--- a/Jenkinsfile_pipeline_test
+++ b/Jenkinsfile_pipeline_test
@@ -46,7 +46,8 @@ try {
         build job: 'Pipeline_Test_Sandbox/cnp-plum-frontend/master',
           parameters: [string(name: 'LIB_VERSION', value: testBranch)]
       }
-    }
+    },
+    failFast: true
   )
 
 } catch (err) {


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

A suggestion for enabling `failFast` raised at the tech improvement.

Notes:
*
*
*
