### PR TITLE
DTSPO-17189 - parameterised timeout option

### DIFF
--- a/vars/withNightlyPipeline.groovy
+++ b/vars/withNightlyPipeline.groovy
@@ -11,7 +11,7 @@ import uk.gov.hmcts.contino.PipelineCallbacksConfig
 import uk.gov.hmcts.contino.PipelineCallbacksRunner
 import uk.gov.hmcts.pipeline.TeamConfig
 
-def call(type, product, component, Closure body) {
+def call(type, product, component, timeout = 300, Closure body) {
 
 
   def pipelineTypes = [
@@ -57,7 +57,7 @@ def call(type, product, component, Closure body) {
   }
   
   node(nodeSelector) {
-    timeoutWithMsg(time: 300, unit: 'MINUTES', action: 'pipeline') {
+    timeoutWithMsg(time: timeout, unit: 'MINUTES', action: 'pipeline') {
       def slackChannel = env.BUILD_NOTICES_SLACK_CHANNEL
       try {
         dockerAgentSetup()


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-17189

Allows nightlyPipeline to override the timeout from its being 300 minutes.