### PR TITLE
Move migrateDB call outside folderExists check

### DIFF
--- a/vars/sectionDeployToEnvironment.groovy
+++ b/vars/sectionDeployToEnvironment.groovy
@@ -46,24 +46,23 @@ def call(params) {
                   expires: config.expiryDate
                 )
             }
-
-            if(!tfPlanOnly){
-
-              if (config.migrateDb) {
-                stageWithAgent("DB Migration - ${environment}", product) {
-                  pcr.callAround("dbmigrate:${environment}") {
-                    builder.dbMigrate(
-                      tfOutput?.vaultName ? tfOutput.vaultName.value : "${config.dbMigrationVaultName}-${environment}",
-                      component
-                    )
-                  }
-                }
-              }
-
-            }
-
           }
         }
+      }
+      
+      if(!tfPlanOnly){
+
+        if (config.migrateDb) {
+          stageWithAgent("DB Migration - ${environment}", product) {
+            pcr.callAround("dbmigrate:${environment}") {
+              builder.dbMigrate(
+                tfOutput?.vaultName ? tfOutput.vaultName.value : "${config.dbMigrationVaultName}-${environment}",
+                component
+              )
+            }
+          }
+        }
+
       }
     }
   }


### PR DESCRIPTION
Notes:
* Moving migrateDB call outside of folderExists check so it can be used by teams without an infrastructure folder in their repo

