### PR TITLE
DTSAM-240 Adjust jenkins PG migration end date for AM repos

### DIFF
--- a/vars/warnAboutDeprecatedPostgres.groovy
+++ b/vars/warnAboutDeprecatedPostgres.groovy
@@ -10,15 +10,15 @@ switch (gitUrl.toLowerCase()) {
     case "https://github.com/hmcts/am-org-role-mapping-service.git":
     case "https://github.com/hmcts/am-role-assignment-service.git":
     case "https://github.com/hmcts/am-judicial-booking-service.git":
-    case "https://github.com/hmcts/rd-user-profile-api.git":
-    case "https://github.com/hmcts/rd-profile-sync.git":
-        expiryDate = LocalDate.of(2024, 4, 22);
-        break;
     case "https://github.com/hmcts/rd-commondata-api.git":
     case "https://github.com/hmcts/rd-professional-api.git":
     case "https://github.com/hmcts/rd-location-ref-api.git":
     case "https://github.com/hmcts/rd-judicial-api.git":
     case "https://github.com/hmcts/rd-caseworker-ref-api.git":
+    case "https://github.com/hmcts/rd-user-profile-api.git":
+    case "https://github.com/hmcts/rd-profile-sync.git":
+        expiryDate = LocalDate.of(2024, 4, 29);
+        break;
     case "https://github.com/hmcts/bulk-scan-processor.git":
     case "https://github.com/hmcts/bulk-scan-orchestrator.git":
     case "https://github.com/hmcts/bulk-scan-payment-processor.git":

--- a/vars/warnAboutDeprecatedPostgres.groovy
+++ b/vars/warnAboutDeprecatedPostgres.groovy
@@ -7,13 +7,13 @@ String gitUrl = env.GIT_URL;
 LocalDate expiryDate;
 
 switch (gitUrl.toLowerCase()) {
+    case "https://github.com/hmcts/am-org-role-mapping-service.git":
+    case "https://github.com/hmcts/am-role-assignment-service.git":
+    case "https://github.com/hmcts/am-judicial-booking-service.git":
     case "https://github.com/hmcts/rd-user-profile-api.git":
     case "https://github.com/hmcts/rd-profile-sync.git":
         expiryDate = LocalDate.of(2024, 4, 22);
         break;
-    case "https://github.com/hmcts/am-org-role-mapping-service.git":
-    case "https://github.com/hmcts/am-role-assignment-service.git":
-    case "https://github.com/hmcts/am-judicial-booking-service.git":
     case "https://github.com/hmcts/rd-commondata-api.git":
     case "https://github.com/hmcts/rd-professional-api.git":
     case "https://github.com/hmcts/rd-location-ref-api.git":


### PR DESCRIPTION
### Jira link (if applicable)

[DTSAM-240](https://tools.hmcts.net/jira/browse/DTSAM-240) _"Adjust jenkins PG migration end date for AM repos_"

### Change description ###

Adjust expiry date used in `vars/warnAboutDeprecatedPostgres.groovy` for AM repos to reflect new migration date.

