### PR TITLE
Increase warning date for single servers BSP

### DIFF
--- a/vars/warnAboutDeprecatedPostgres.groovy
+++ b/vars/warnAboutDeprecatedPostgres.groovy
@@ -29,7 +29,7 @@ switch (gitUrl.toLowerCase()) {
     case "https://github.com/hmcts/ecm-shared-infrastructure.git":
     case "https://github.com/hmcts/et-ccd-callbacks.git":
     case "https://github.com/hmcts/et-message-handler.git":
-        expiryDate = LocalDate.of(2024, 3, 31);
+        expiryDate = LocalDate.of(2024, 4, 25);
         break;
     case "https://github.com/hmcts/wa-case-event-handler.git":
         expiryDate = LocalDate.of(2024, 2, 12);

--- a/vars/warnAboutDeprecatedPostgres.groovy
+++ b/vars/warnAboutDeprecatedPostgres.groovy
@@ -25,11 +25,13 @@ switch (gitUrl.toLowerCase()) {
     case "https://github.com/hmcts/blob-router-service.git":
     case "https://github.com/hmcts/reform-scan-notification-service.git":
     case "https://github.com/hmcts/send-letter-service.git":
+        expiryDate = LocalDate.of(2024, 4, 25);
+        break;
     case "https://github.com/hmcts/ethos-repl-docmosis-service.git":
     case "https://github.com/hmcts/ecm-shared-infrastructure.git":
     case "https://github.com/hmcts/et-ccd-callbacks.git":
     case "https://github.com/hmcts/et-message-handler.git":
-        expiryDate = LocalDate.of(2024, 4, 25);
+        expiryDate = LocalDate.of(2024, 3, 31);
         break;
     case "https://github.com/hmcts/wa-case-event-handler.git":
         expiryDate = LocalDate.of(2024, 2, 12);


### PR DESCRIPTION
Notes:
* Increased date for single server warning for BSP so pipeline runs, we are in the process of deleting single servers now as migration is complete in prod.
