### PR TITLE
Use amd64 zaproxy image from ghcr.io

### DIFF
--- a/src/uk/gov/hmcts/contino/SecurityScan.groovy
+++ b/src/uk/gov/hmcts/contino/SecurityScan.groovy
@@ -2,7 +2,7 @@ package uk.gov.hmcts.contino
 
 
 class SecurityScan implements Serializable {
-    public static final String OWASP_ZAP_IMAGE = 'owasp/zap2docker-stable:2.13.0'
+    public static final String OWASP_ZAP_IMAGE = 'ghcr.io/zaproxy/zaproxy:20240402-stable@sha256:3280adc730131f1f4460ab226b0f85e3e9ab3301ef5a7030f745ac4dd6b6ff87'
     public static final String OWASP_ZAP_ARGS = '-u 0:0 --name zap -p 1001:1001 -v $WORKSPACE:/zap/wrk/:rw'
     public static final String GLUEIMAGE = 'hmctspublic.azurecr.io/zap-glue:c14eff2a-1692784552'
     public static final String GLUE_ARGS = '-u 0:0 --name=Glue -v ${WORKSPACE}:/tmp -w /tmp'


### PR DESCRIPTION
Notes:
* zaproxy also host on gh where they offer amd64 images. This PR updates the image to pull from ghcr.io instead of docker hub
* Fixes https://tools.hmcts.net/jira/browse/DTSPO-17373 

