### PR TITLE
DTSPO-15971 run tf plan on prod by default 

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ PR branch| `preview`
 #### Run Terraform plans against Production
 By default terraform plans against production are executed on Pull Requests that have terraform change. Application teams
 can opt out of this by:
-1. Manually adding a `not-plan-on-prod` topic to the repo. This will automatically add a not-plan-on-prod label to every new PR within the repo.
-2. Manually adding a `not-plan-on-prod` to a PR.
+1. Manually adding a topic `not-plan-on-prod` to the repo. This will automatically add a `not-plan-on-prod` label to every new PR within the repo.
+2. Manually adding a label `not-plan-on-prod` to a PR.
 
 If the base branch is named after one of the following environments, it will plan against that environment NOT production:
 - demo

--- a/README.md
+++ b/README.md
@@ -73,10 +73,7 @@ can opt out of this by:
 1. For all PRs. Manually adding a topic `not-plan-on-prod` to the repo.
 2. For a specific PR. Manually adding a label `not-plan-on-prod` to that PR.
 
-If the base branch is named after one of the following environments, it will plan against that environment NOT production:
-- demo
-- perftest
-- ithc
+If the Pull Request is being merged into these branches `demo`, `perftest`, and `ithc`. Terraform Plan will run against the corresponding environment NOT production.
 
 Plans will only run against production on the Production Jenkins. It will NOT work on the Sandbox Jenkins as its “production” environment is sandbox.
 

--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ Branch | Environment
 PR branch| `preview`
 
 #### Run Terraform plans against Production
-By default terraform plans against production are executed on Pull Requests that have terraform change. Application teams
+By default terraform plans against production are executed on Pull Requests that have any terraform changes. Application teams
 can opt out of this by:
-1. Manually adding a topic `not-plan-on-prod` to the repo. This will automatically add a `not-plan-on-prod` label to every new PR within the repo.
-2. Manually adding a label `not-plan-on-prod` to a PR.
+1. For all PRs. Manually adding a topic `not-plan-on-prod` to the repo.
+2. For a specific PR. Manually adding a label `not-plan-on-prod` to that PR.
 
 If the base branch is named after one of the following environments, it will plan against that environment NOT production:
 - demo

--- a/README.md
+++ b/README.md
@@ -68,11 +68,10 @@ Branch | Environment
 PR branch| `preview`
 
 #### Run Terraform plans against Production
-Teams can run terraform plans against production.
-
-This can be enabled by either:
-1. Manually adding a plan-on-prod topic to the repo. This will automatically add a plan-on-prod label to every new PR within the repo and run terraform plans against the production environment.
-2. Manually adding a plan-on-prod label to a PR. This will run a terraform plan against the production environment for that PR only.
+By default terraform plans against production are executed on Pull Requests that have terraform change. Application teams
+can opt out of this by:
+1. Manually adding a `not-plan-on-prod` topic to the repo. This will automatically add a not-plan-on-prod label to every new PR within the repo.
+2. Manually adding a `not-plan-on-prod` to a PR.
 
 If the base branch is named after one of the following environments, it will plan against that environment NOT production:
 - demo

--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,6 @@ repositories {
 test {
   systemProperty 'groovy.grape.enable', 'false'
   useJUnitPlatform()
-  testLogging {
-    events "passed", "skipped", "failed", "standardOut", "standardError"
-  }
 }
 
 compileGroovy {

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ sourceSets {
   }
   test {
     groovy {
-      srcDirs = ['test','test/withPipeline']
+      srcDirs = ['test']
     }
     resources {
       srcDirs = ['testResources']

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,9 @@ repositories {
 test {
   systemProperty 'groovy.grape.enable', 'false'
   useJUnitPlatform()
+  testLogging {
+    events "passed", "skipped", "failed", "standardOut", "standardError"
+  }
 }
 
 compileGroovy {
@@ -61,10 +64,11 @@ sourceSets {
   }
   test {
     groovy {
-      srcDirs = ['test']
+      srcDirs = ['test','test/withPipeline']
     }
     resources {
       srcDirs = ['testResources']
     }
+
   }
 }

--- a/src/uk/gov/hmcts/contino/GithubAPI.groovy
+++ b/src/uk/gov/hmcts/contino/GithubAPI.groovy
@@ -161,7 +161,7 @@ class GithubAPI {
       consoleLogResponseBody: true,
       validResponseCodes: '200')
 
-      if (response.status == 200) {
+    if (response.status == 200) {
       def json_response = new JsonSlurper().parseText(response.content)
       cachedPR.cache = json_response.base.ref
       cachedPR.isValid = true
@@ -315,10 +315,10 @@ class GithubAPI {
   */
   def startAksEnvironmentWorkflow(String workflowName, String businessArea, String cluster, String environment){
     def body = """
-      { 
-        "ref":"master", 
+      {
+        "ref":"master",
         "inputs":{
-           "PROJECT": "${businessArea}", 
+           "PROJECT": "${businessArea}",
            "SELECTED_ENV": "${environment}",
            "AKS-INSTANCES": "${cluster}"
          }

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -36,7 +36,6 @@ def call(params) {
     }
     builder.setupToolVersion()
   }
-  noSkipImgBuild = false
   boolean dockerFileExists = fileExists('Dockerfile')
   onPathToLive {
     stageWithAgent("Build", product) {

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -36,6 +36,7 @@ def call(params) {
     }
     builder.setupToolVersion()
   }
+  noSkipImgBuild = false
   boolean dockerFileExists = fileExists('Dockerfile')
   onPathToLive {
     stageWithAgent("Build", product) {

--- a/vars/withInfraPipeline.groovy
+++ b/vars/withInfraPipeline.groovy
@@ -17,6 +17,7 @@ def call(String product, String component = null, Closure body) {
   def pipelineConfig = new InfraPipelineConfig()
   def callbacks = new PipelineCallbacksConfig()
   def callbacksRunner = new PipelineCallbacksRunner(callbacks)
+  def ProjectBranch branch = new ProjectBranch(env.BRANCH_NAME)
 
   callbacks.registerAfterAll { stage ->
     metricsPublisher.publish(stage)

--- a/vars/withInfraPipeline.groovy
+++ b/vars/withInfraPipeline.groovy
@@ -114,16 +114,14 @@ def call(String product, String component = null, Closure body) {
         // deploy to environment, and run terraform plan against prod if the label/topic LABEL_NO_TF_PLAN_ON_PROD not found
         if (!optOutTfPlanOnProdFound) {
           println "Apply Terraform Plan against ${base_env_name}"
-          sectionDeployToEnvironment(
-            appPipelineConfig: pipelineConfig,
-            pipelineCallbacksRunner: callbacksRunner,
-            pipelineType: pipelineType,
+          sectionInfraBuild(
             subscription: subscription."${base_env_name}Name",
-            aksSubscription: aksSubscriptions."${base_env_name}",
             environment: environment."${base_env_name}Name",
             product: product,
+            planOnly: true,
             component: component,
-            tfPlanOnly: true
+            expires: pipelineConfig.expiryDate,
+            pipelineCallbacksRunner: callbacksRunner,
           )
         } else {
           println "Skipping Terraform Plan against ${base_env_name} ... "

--- a/vars/withInfraPipeline.groovy
+++ b/vars/withInfraPipeline.groovy
@@ -7,6 +7,7 @@ import uk.gov.hmcts.contino.Subscription
 import uk.gov.hmcts.contino.Environment
 import uk.gov.hmcts.pipeline.TeamConfig
 import uk.gov.hmcts.contino.GithubAPI
+import uk.gov.hmcts.contino.ProjectBranch
 
 def call(String product, String component = null, Closure body) {
 

--- a/vars/withInfraPipeline.groovy
+++ b/vars/withInfraPipeline.groovy
@@ -83,50 +83,48 @@ def call(String product, String component = null, Closure body) {
           pipelineCallbacksRunner: callbacksRunner,
         )
 
+        final String LABEL_NO_TF_PLAN_ON_PROD = "not-plan-on-prod"
         def githubApi = new GithubAPI(this)
-
+        def targetBranch = githubApi.refreshPRCache() // e.g. demo, perftest, ithc, master, or non-standards
+        def labelsCache = githubApi.refreshLabelCache()
+        def topicsCache = githubApi.refreshTopicCache()
+        def branchName = branch.branchName // e.g. PR-123
         def base_envs = ["demo", "perftest", "ithc"]
-        def base_env_name
-        if (githubApi.checkForTopic("plan-on-prod")) {
 
-          println githubApi.refreshPRCache()
+        println "labelsCache: ${labelsCache} \ntopicsCache: ${topicsCache}"
+        // check if the PR has the label not-plan-on-prod
+        boolean optOutTfPlanOnProdFound = githubApi.checkForLabel(branchName, LABEL_NO_TF_PLAN_ON_PROD)
+        // check if the PR has the topic 'not-plan-on-prod' if it can not find the label `not-plan-on-prod`
+        if (!optOutTfPlanOnProdFound) {
+          optOutTfPlanOnProdFound = githubApi.checkForTopic(LABEL_NO_TF_PLAN_ON_PROD)
+        }
+        println "optOutTfPlanOnProdFound: " + optOutTfPlanOnProdFound.toString()
 
-          for(item in base_envs) {
-            if (githubApi.refreshPRCache() == item) {
-              base_env_name = item
-              break
-            } else {
-              base_env_name = "prod"
-            }
-          }
-          if (!githubApi.checkForLabel("PR-123", "plan-on-prod")) {
-            githubApi.addLabelsToCurrentPR(["plan-on-prod"])
-          }
-        } else {
-          if (githubApi.checkForLabel("PR-123", "plan-on-prod")) {
-            println githubApi.refreshPRCache()
-
-          for(item in base_envs) {
-            if (githubApi.refreshPRCache() == item) {
-              base_env_name = item
-              break
-            } else {
-              base_env_name = "prod"
-            }
-          }
-          }
+        // set the base environment to prod if the target branch is not in the list of base_envs
+        // todo: need to find out if we need to deal with branches 'preview' and 'aat' for AksSubscriptions
+        def base_env_name = targetBranch
+        if (!base_envs.contains(targetBranch)) {
+          base_env_name = "prod"
         }
 
-        if (githubApi.checkForLabel("PR-123", "plan-on-prod")) {
-        sectionInfraBuild(
-          subscription: subscription."${base_env_name}Name",
-          environment: environment."${base_env_name}Name",
-          product: product,
-          planOnly: true,
-          component: component,
-          expires: pipelineConfig.expiryDate,
-          pipelineCallbacksRunner: callbacksRunner,
-        )
+        println "${branchName} being merged into: ${targetBranch}" + " base_env_name: " + base_env_name
+
+        // deploy to environment, and run terraform plan against prod if the label/topic LABEL_NO_TF_PLAN_ON_PROD not found
+        if (!optOutTfPlanOnProdFound) {
+          println "Apply Terraform Plan against ${base_env_name}"
+          sectionDeployToEnvironment(
+            appPipelineConfig: pipelineConfig,
+            pipelineCallbacksRunner: callbacksRunner,
+            pipelineType: pipelineType,
+            subscription: subscription."${base_env_name}Name",
+            aksSubscription: aksSubscriptions."${base_env_name}",
+            environment: environment."${base_env_name}Name",
+            product: product,
+            component: component,
+            tfPlanOnly: true
+          )
+        } else {
+          println "Skipping Terraform Plan against ${base_env_name} ... "
         }
       }
     } catch (err) {

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -126,7 +126,7 @@ def call(type, String product, String component, Closure body) {
             def targetBranch = githubApi.refreshPRCache() // e.g. demo, perftest, ithc, master, or non-standards
             def labelCache = githubApi.refreshLabelCache()
             def topicCache = githubApi.refreshTopicCache()
-            def branchName = branch.branchName.toLowerCase() // could be PR-123, #58, or feature/branch-name
+            def branchName = branch.branchName // could be PR-123, #58, or feature/branch-name
             def base_envs = ["demo", "perftest", "ithc"]
 
             println "labelCache: ${labelCache} \ntopicCache: ${topicCache}"

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -124,12 +124,12 @@ def call(type, String product, String component, Closure body) {
             final String LABEL_NO_TF_PLAN_ON_PROD = "not-plan-on-prod"
             def githubApi = new GithubAPI(this)
             def targetBranch = githubApi.refreshPRCache() // e.g. demo, perftest, ithc, master, or non-standards
-            def labelCache = githubApi.refreshLabelCache()
-            def topicCache = githubApi.refreshTopicCache()
-            def branchName = branch.branchName // could be PR-123, #58, or feature/branch-name
+            def labelsCache = githubApi.refreshLabelCache()
+            def topicsCache = githubApi.refreshTopicCache()
+            def branchName = branch.branchName // e.g. PR-123
             def base_envs = ["demo", "perftest", "ithc"]
 
-            println "labelCache: ${labelCache} \ntopicCache: ${topicCache}"
+            println "labelsCache: ${labelsCache} \ntopicsCache: ${topicsCache}"
             // check if the PR has the label not-plan-on-prod
             boolean optOutTfPlanOnProdFound = githubApi.checkForLabel(branchName, LABEL_NO_TF_PLAN_ON_PROD)
             // check if the PR has the topic 'not-plan-on-prod' if it can not find the label `not-plan-on-prod`

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -121,13 +121,17 @@ def call(type, String product, String component, Closure body) {
               tfPlanOnly: true
             )
 
+            final String LABEL_NO_TF_PLAN_ON_PROD = "not-plan-on-prod"
             def githubApi = new GithubAPI(this)
             def targetBranch = githubApi.refreshPRCache() // e.g. demo, perftest, ithc, master, or non-standards
+            def labelCache = githubApi.refreshLabelCache()
+            def topicCache = githubApi.refreshTopicCache()
             def branchName = branch.branchName.toLowerCase() // could be PR-123, #58, or feature/branch-name
-            def LABEL_NO_TF_PLAN_ON_PROD = "not-plan-on-prod"
             def base_envs = ["demo", "perftest", "ithc"]
+
+            println "labelCache: ${labelCache} \ntopicCache: ${topicCache}"
             // check if the PR has the label not-plan-on-prod
-            def optOutTfPlanOnProdFound = githubApi.checkForLabel(branchName, LABEL_NO_TF_PLAN_ON_PROD)
+            boolean optOutTfPlanOnProdFound = githubApi.checkForLabel(branchName, LABEL_NO_TF_PLAN_ON_PROD)
             // check if the PR has the topic 'not-plan-on-prod' if it can not find the label `not-plan-on-prod`
             if (!optOutTfPlanOnProdFound) {
               optOutTfPlanOnProdFound = githubApi.checkForTopic(LABEL_NO_TF_PLAN_ON_PROD)

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -108,26 +108,29 @@ def call(type, String product, String component, Closure body) {
         onPR {
           onTerraformChangeInPR {
             def githubApi = new GithubAPI(this)
-            def prCache = githubApi.refreshPRCache() // e.g. demo, perftest, ithc, etc
-            def branchName = branch.branchName.toLowerCase() // could be PR-123 or #58
+            def targetBranch = githubApi.refreshPRCache() // e.g. demo, perftest, ithc, etc
+            def branchName = branch.branchName.toLowerCase() // could be PR-123, #58, or feature/branch-name
             def LABEL_NO_TF_PLAN_ON_PROD = "not-plan-on-prod"
             def base_envs = ["demo", "perftest", "ithc"]
             // check if the PR has the label not-plan-on-prod
-            def noTFPlanOnProdFound = githubApi.checkForLabel(branchName, LABEL_NO_TF_PLAN_ON_PROD)
-            // check if the PR has the topic 'not-plan-on-prod' if it has no label not-plan-on-prod set
-            if (!noTFPlanOnProdFound) {
-              noTFPlanOnProdFound = githubApi.checkForTopic(LABEL_NO_TF_PLAN_ON_PROD)
+            def optOutTfPlanOnProdFound = githubApi.checkForLabel(branchName, LABEL_NO_TF_PLAN_ON_PROD)
+            // check if the PR has the topic 'not-plan-on-prod' if it can not find label not-plan-on-prod set
+            if (!optOutTfPlanOnProdFound) {
+              optOutTfPlanOnProdFound = githubApi.checkForTopic(LABEL_NO_TF_PLAN_ON_PROD)
             }
-            def base_env_name = prCache
-            if (!base_envs.contains(prCache)) {
+
+            // set the base environment to prod if the target branch is not in the list of base_envs
+            // todo: need to find out if we need to deal with branches 'preview' and 'aat' for AksSubscriptions
+            def base_env_name = targetBranch
+            if (!base_envs.contains(targetBranch)) {
               base_env_name = "prod"
             }
 
-            println "prCache: "+ prCache + "current branch: " + branchName + " base_env_name: " + base_env_name
+            println "being merged to: "+ targetBranch + " current branch: " + branchName + " base_env_name: " + base_env_name
 
 
             // deploy to environment, and run terraform plan against prod if the label/topic LABEL_NO_TF_PLAN_ON_PROD not found
-            if (noTFPlanOnProdFound) {
+            if (!optOutTfPlanOnProdFound) {
               println "Apply Terraform Plan against ${base_env_name}"
               sectionDeployToEnvironment(
                 appPipelineConfig: pipelineConfig,

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -107,6 +107,19 @@ def call(type, String product, String component, Closure body) {
 
         onPR {
           onTerraformChangeInPR {
+            // we always need a tf plan of aat (i.e. staging)
+            sectionDeployToEnvironment(
+              appPipelineConfig: pipelineConfig,
+              pipelineCallbacksRunner: callbacksRunner,
+              pipelineType: pipelineType,
+              subscription: subscription.nonProdName,
+              aksSubscription: aksSubscriptions.aat,
+              environment: environment.nonProdName,
+              product: product,
+              component: component,
+              tfPlanOnly: true
+            )
+
             def githubApi = new GithubAPI(this)
             def targetBranch = githubApi.refreshPRCache() // e.g. demo, perftest, ithc, etc
             def branchName = branch.branchName.toLowerCase() // could be PR-123, #58, or feature/branch-name
@@ -126,7 +139,7 @@ def call(type, String product, String component, Closure body) {
               base_env_name = "prod"
             }
 
-            println "being merged to: "+ targetBranch + " current branch: " + branchName + " base_env_name: " + base_env_name
+            println "being merged into: "+ targetBranch + " current branch: " + branchName + " base_env_name: " + base_env_name
 
 
             // deploy to environment, and run terraform plan against prod if the label/topic LABEL_NO_TF_PLAN_ON_PROD not found

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -14,7 +14,6 @@ import uk.gov.hmcts.contino.PipelineCallbacksConfig
 import uk.gov.hmcts.contino.PipelineCallbacksRunner
 import uk.gov.hmcts.pipeline.AKSSubscriptions
 import uk.gov.hmcts.pipeline.TeamConfig
-import uk.gov.hmcts.pipeline.DeprecationConfig
 import uk.gov.hmcts.contino.GithubAPI
 
 def call(type, String product, String component, Closure body) {


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

DTSPO-15971
- run TF plan against prod by default on PRs
- users can opt out to specify 'not-plan-on-prod' as topic or label 

Notes:
*  could not write unit tests for 'withPipeline` as `gradlew test` is broken at moment
*
*
