### PR TITLE
DTSAM-240 Adjust jenkins PG migration end date for AM + RD repos

### DIFF
--- a/vars/warnAboutDeprecatedPostgres.groovy
+++ b/vars/warnAboutDeprecatedPostgres.groovy
@@ -17,7 +17,7 @@ switch (gitUrl.toLowerCase()) {
     case "https://github.com/hmcts/rd-caseworker-ref-api.git":
     case "https://github.com/hmcts/rd-user-profile-api.git":
     case "https://github.com/hmcts/rd-profile-sync.git":
-        expiryDate = LocalDate.of(2024, 4, 29);
+        expiryDate = LocalDate.of(2024, 5, 14);
         break;
     case "https://github.com/hmcts/bulk-scan-processor.git":
     case "https://github.com/hmcts/bulk-scan-orchestrator.git":


### PR DESCRIPTION
### Jira link (if applicable)

[DTSAM-240](https://tools.hmcts.net/jira/browse/DTSAM-240) _"Adjust jenkins PG migration end date for AM and RD repos"_

### Change description ###

Adjust expiry date used in `vars/warnAboutDeprecatedPostgres.groovy` for AM + RD repos to reflect new migration date, see CHG5016067 & CHG5016068.
