### PR TITLE
DTSAM-305 Adjust jenkins PG migration end date for AM + RD repos

### DIFF
--- a/vars/warnAboutDeprecatedPostgres.groovy
+++ b/vars/warnAboutDeprecatedPostgres.groovy
@@ -17,7 +17,7 @@ switch (gitUrl.toLowerCase()) {
     case "https://github.com/hmcts/rd-caseworker-ref-api.git":
     case "https://github.com/hmcts/rd-user-profile-api.git":
     case "https://github.com/hmcts/rd-profile-sync.git":
-        expiryDate = LocalDate.of(2024, 5, 14);
+        expiryDate = LocalDate.of(2024, 5, 22);
         break;
     case "https://github.com/hmcts/bulk-scan-processor.git":
     case "https://github.com/hmcts/bulk-scan-orchestrator.git":

--- a/vars/warnAboutDeprecatedPostgres.groovy
+++ b/vars/warnAboutDeprecatedPostgres.groovy
@@ -17,7 +17,7 @@ switch (gitUrl.toLowerCase()) {
     case "https://github.com/hmcts/rd-caseworker-ref-api.git":
     case "https://github.com/hmcts/rd-user-profile-api.git":
     case "https://github.com/hmcts/rd-profile-sync.git":
-        expiryDate = LocalDate.of(2024, 5, 22);
+        expiryDate = LocalDate.of(2024, 5, 29);
         break;
     case "https://github.com/hmcts/bulk-scan-processor.git":
     case "https://github.com/hmcts/bulk-scan-orchestrator.git":


### PR DESCRIPTION
### Jira link (if applicable)

[DTSAM-305](https://tools.hmcts.net/jira/browse/DTSAM-305) _"Adjust jenkins PG migration end date for AM and RD repos"_

### Change description ###

Adjust expiry date used in `vars/warnAboutDeprecatedPostgres.groovy` for AM + RD repos by *1 week*.  As team need PG11 to remain available for comparison whilst addressing DTSAM-303.
