### PR TITLE
Update warnAboutDeprecatedPostgres.groovy Adjust PG migration end date for CCD repos

### DIFF
--- a/vars/warnAboutDeprecatedPostgres.groovy
+++ b/vars/warnAboutDeprecatedPostgres.groovy
@@ -42,7 +42,7 @@ switch (gitUrl.toLowerCase()) {
     case "https://github.com/hmcts/hmc-cft-hearing-service.git":
     case "https://github.com/hmcts/cpo-case-payment-orders-api.git":
     case "https://github.com/hmcts/ts-translation-service.git":
-        expiryDate = LocalDate.of(2024, 5, 22);
+        expiryDate = LocalDate.of(2024, 6, 22);
         break;
     default:
         expiryDate = LocalDate.of(2024, 1, 31);


### PR DESCRIPTION
Due to late migrations and retention periods, and op issues extending.