### PR TITLE
DTSPO-17348: Use new deprecation map location

### DIFF
--- a/resources/uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh
+++ b/resources/uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh
@@ -26,21 +26,15 @@ compare_versions() {
 DEPENDENCY=${1}
 REQUIRED_VERSION=${2}
 
-version_output=$(terraform --version)
-
-terraform_version="$(echo "$version_output" | grep "Terraform v" | cut -d'v' -f 2)"
-azurerm_version="$(echo "$version_output" | grep "azurerm" | cut -d'v' -f 3)"
-
-terraform_major="$(echo "$terraform_version" | cut -d'.' -f 1)"
-
-echo "terraform major version is: $terraform_major"
+terraform_version=$(terraform --version --json | jq -r '.terraform_version')
 echo "terraform version is: $terraform_version"
+
+
 if [[ "$DEPENDENCY" == "terraform" ]] ; then
-  echo "terraform required version is: $REQUIRED_VERSION"
+  echo "Required terraform version is: $REQUIRED_VERSION"
   compare_versions "$terraform_version" "$REQUIRED_VERSION"
   result=$?
 
-  echo "result of comparison is: $result"
   if [[ $result != 1 ]] ; then
     echo "Terraform is at acceptable version: $terraform_version"
   else
@@ -48,7 +42,7 @@ if [[ "$DEPENDENCY" == "terraform" ]] ; then
     echo "=====  Please update your major terraform version to the latest stable release                 ======"
     echo "=====  The contents of this file will just be a Terraform version number, eg.                  ======"
     echo "=====                                                                                          ======"
-    echo "=====  1.3.7                                                                                   ======"
+    echo "=====  1.8.4                                                                                   ======"
     echo "=====                                                                                          ======"
     echo "=====  Enable terraform in your renovate config, either by extending config:base or enabling   ======"
     echo "=====  the terraform manager.                                                                  ======"

--- a/resources/uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh
+++ b/resources/uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh
@@ -60,7 +60,7 @@ else
 
   echo "Terraform provider name: $DEPENDENCY"
   echo "Required version of provider: $REQUIRED_VERSION ..."
-  provider_version=$(echo $terraform_providers | jq --arg p "${provider_name}" '.[$p]')
+  provider_version=$(echo $terraform_providers | jq --arg p "${DEPENDENCY}" '.[$p]')
 
   # Returns "null" ... if provider not found in nagger map
   if [[ "$provider_version" != "null" ]]; then

--- a/resources/uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh
+++ b/resources/uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh
@@ -67,11 +67,11 @@ else
     compare_versions "$provider_version" "$REQUIRED_VERSION"
     result=$?
 
-    if [[ $result != 1 ]] ; then
+    if [[ $result != 1 || $result == 0 ]] ; then
       echo "Terraform provider $DEPENDENCY is at acceptable version: $provider_version"
     else
       echo "====================================================================================================="
-      echo "=====  Please update your version for provider $DEPENDENCY to latest                           ======"
+      echo "=====  Please update the signalled provider dependency to the desired version                  ======"
       echo "====================================================================================================="
       exit 1
     fi

--- a/resources/uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh
+++ b/resources/uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh
@@ -24,8 +24,7 @@ compare_versions() {
 }
 
 DEPENDENCY=${1}
-REQUIRED_VERSION="1.8.1"
-DEPRECATION_OBJECT=${2}
+REQUIRED_VERSION=${2}
 
 terraform_version=$(terraform --version --json | jq -r '.terraform_version')
 terraform_providers=$(terraform --version --json | jq -r '.provider_selections')
@@ -56,11 +55,9 @@ if [[ "$DEPENDENCY" == "terraform" ]] ; then
     echo "====================================================================================================="
     exit 1
   fi
-elif [[ "$DEPENDENCY" == "providers" ]] ; then
+else
   echo "Terraform provider configuration detected: $terraform_providers"
 
   echo "Terraform provider name: $DEPENDENCY"
-  echo "Testing object: $DEPRECATION_OBJECT ..."
-else
-  echo "Dependency value not recognised, terraform versions not checked"
+  echo "Testing object: $REQUIRED_VERSION ..."
 fi

--- a/resources/uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh
+++ b/resources/uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh
@@ -25,6 +25,7 @@ compare_versions() {
 
 DEPENDENCY=${1}
 REQUIRED_VERSION=${2}
+DEPRECATION_OBJECT=${3}
 
 terraform_version=$(terraform --version --json | jq -r '.terraform_version')
 terraform_providers=$(terraform --version --json | jq -r '.provider_selections')
@@ -60,6 +61,7 @@ elif [[ "$DEPENDENCY" == "providers" ]] ; then
 
   echo "Terraform provider name: $DEPENDENCY"
   echo "Testing output: $REQUIRED_VERSION"
+  echo "Testing object: $DEPRECATION_OBJECT"
 else
   echo "Dependency value not recognised, terraform versions not checked"
 fi

--- a/resources/uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh
+++ b/resources/uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh
@@ -12,10 +12,14 @@ compare_versions() {
   if [[ "$1" == "$2" ]]; then
       return 0
   fi
-
+  echo $1
+  echo $2
   local sorted_version_list=$(printf "%s\n%s" "$1" "$2" | sort -V)
   local first_version=$(echo "$sorted_version_list" | head -n 1)
 
+  echo $sorted_version_list
+  echo $first_version
+  
   if [[ "$first_version" == "$1" ]]; then
       return 1 # below required version
   else
@@ -60,7 +64,7 @@ else
 
   echo "Terraform provider name: $DEPENDENCY"
   echo "Required version of provider: $REQUIRED_VERSION ..."
-  provider_version=$(echo $terraform_providers | jq --arg p "${DEPENDENCY}" '.[$p]')
+  provider_version=$(echo $terraform_providers | jq -r --arg p "${DEPENDENCY}" '.[$p]')
 
   # Returns "null" ... if provider not found in nagger map
   if [[ "$provider_version" != "null" ]]; then

--- a/resources/uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh
+++ b/resources/uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh
@@ -24,8 +24,8 @@ compare_versions() {
 }
 
 DEPENDENCY=${1}
-REQUIRED_VERSION=${2}
-DEPRECATION_OBJECT=${3}
+REQUIRED_VERSION="1.8.1"
+DEPRECATION_OBJECT=${2}
 
 terraform_version=$(terraform --version --json | jq -r '.terraform_version')
 terraform_providers=$(terraform --version --json | jq -r '.provider_selections')
@@ -60,8 +60,7 @@ elif [[ "$DEPENDENCY" == "providers" ]] ; then
   echo "Terraform provider configuration detected: $terraform_providers"
 
   echo "Terraform provider name: $DEPENDENCY"
-  echo "Testing output: $REQUIRED_VERSION"
-  echo "Testing object: $DEPRECATION_OBJECT"
+  echo "Testing object: $DEPRECATION_OBJECT ..."
 else
   echo "Dependency value not recognised, terraform versions not checked"
 fi

--- a/resources/uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh
+++ b/resources/uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh
@@ -1,4 +1,28 @@
 #!/bin/bash
+
+
+# This function takes two version numbers following semantic versioning i.e. 1.4.5 and returns
+# 0 - Versions that are the same
+# 1 - First version argument is less than the second
+# 2 - First version argument is greater than the second
+# You should pass the version you wish to compare against a desired version as the first arg, and the desired
+# version as the second arg
+compare_versions() {
+  # Versions are the same   
+  if [[ "$1" == "$2" ]]; then
+      return 0
+  fi
+
+  local sorted_version_list=$(printf "%s\n%s" "$1" "$2" | sort -V)
+  local first_version=$(echo "$sorted_version_list" | head -n 1)
+
+  if [[ "$first_version" == "$1" ]]; then
+      return 1 # below required version
+  else
+      return 2 # above required version
+  fi
+}
+
 DEPENDENCY=${1}
 REQUIRED_VERSION=${2}
 
@@ -13,28 +37,32 @@ echo "terraform major version is: $terraform_major"
 echo "terraform version is: $terraform_version"
 if [[ "$DEPENDENCY" == "terraform" ]] ; then
   echo "terraform required version is: $REQUIRED_VERSION"
+  compare_versions "$terraform_version" "$REQUIRED_VERSION"
+  result=$?
+
+  echo "result of comparison is: $result"
+  if [[ $result != 1 ]] ; then
+    echo "Terraform is at acceptable version: $terraform_version"
+  else
+    echo "====================================================================================================="
+    echo "=====  Please update your major terraform version to the latest stable release                 ======"
+    echo "=====  The contents of this file will just be a Terraform version number, eg.                  ======"
+    echo "=====                                                                                          ======"
+    echo "=====  1.3.7                                                                                   ======"
+    echo "=====                                                                                          ======"
+    echo "=====  Enable terraform in your renovate config, either by extending config:base or enabling   ======"
+    echo "=====  the terraform manager.                                                                  ======"
+    echo "=====                                                                                          ======"
+    echo "=====  See:                                                                                    ======"
+    echo "=====   - https://github.com/hmcts/spring-boot-template/pull/412                               ======"
+    echo "=====   - https://github.com/hmcts/draft-store/pull/1168                                       ======"
+    echo "=====   - https://github.com/hmcts/spring-boot-template/blob/master/.github/renovate.json      ======"
+    echo "====================================================================================================="
+    exit 1
+  fi
 fi
 
-# if [[ "$DEPENDENCY" == "terraform" ]] ; then
-  # check major version
-#   if [[ "$terraform_major" -ge "$REQUIRED_VERSION" ]] ; then
-#     echo "Terraform is at acceptable version - v${terraform_version}"
-#   else
-#       echo "====================================================================================================="
-#       echo "=====  Please update your major terraform version to the latest stable release                 ======"
-#       echo "=====  The contents of this file will just be a Terraform version number, eg.                  ======"
-#       echo "=====                                                                                          ======"
-#       echo "=====  1.3.7                                                                                   ======"
-#       echo "=====                                                                                          ======"
-#       echo "=====  Enable terraform in your renovate config, either by extending config:base or enabling   ======"
-#       echo "=====  the terraform manager.                                                                  ======"
-#       echo "=====                                                                                          ======"
-#       echo "=====  See:                                                                                    ======"
-#       echo "=====   - https://github.com/hmcts/spring-boot-template/pull/412                               ======"
-#       echo "=====   - https://github.com/hmcts/draft-store/pull/1168                                       ======"
-#       echo "=====   - https://github.com/hmcts/spring-boot-template/blob/master/.github/renovate.json      ======"
-#       echo "====================================================================================================="
-#       exit 1
+
 #     fi
 # elif [[ "$DEPENDENCY" == "providers" ]] ; then
 #   echo

--- a/resources/uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh
+++ b/resources/uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh
@@ -59,5 +59,22 @@ else
   echo "Terraform provider configuration detected: $terraform_providers"
 
   echo "Terraform provider name: $DEPENDENCY"
-  echo "Testing object: $REQUIRED_VERSION ..."
+  echo "Required version of provider: $REQUIRED_VERSION ..."
+  provider_version=$(echo $terraform_providers | jq --arg p "${provider_name}" '.[$p]')
+
+  # Returns "null" ... if provider not found in nagger map
+  if [[ "$provider_version" != "null" ]]; then
+    echo "Found matching provider in map for $DEPENDENCY, checking:"
+    compare_versions "$provider_version" "$REQUIRED_VERSION"
+    result=$?
+
+      if [[ $result != 1 ]] ; then
+        echo "Terraform provider $DEPENDENCY is at acceptable version: $provider_version"
+      else
+        echo "====================================================================================================="
+        echo "=====  Please update your version for provider for $DEPENDENCY to $REQUIRED_VERSION            ======"
+        echo "====================================================================================================="
+        exit 1
+      fi
+  fi  
 fi

--- a/resources/uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh
+++ b/resources/uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh
@@ -27,6 +27,7 @@ DEPENDENCY=${1}
 REQUIRED_VERSION=${2}
 
 terraform_version=$(terraform --version --json | jq -r '.terraform_version')
+terraform_providers=$(terraform --version --json | jq -r '.provider_selections')
 echo "terraform version is: $terraform_version"
 
 
@@ -54,31 +55,11 @@ if [[ "$DEPENDENCY" == "terraform" ]] ; then
     echo "====================================================================================================="
     exit 1
   fi
+elif [[ "$DEPENDENCY" == "providers" ]] ; then
+  echo "Terraform provider configuration detected: $terraform_providers"
+
+  echo "Terraform provider name: $DEPENDENCY"
+  echo "Testing output: $REQUIRED_VERSION"
+else
+  echo "Dependency value not recognised, terraform versions not checked"
 fi
-
-
-#     fi
-# elif [[ "$DEPENDENCY" == "providers" ]] ; then
-#   echo
-  # if [[ "$terraform_major" -ge "$REQUIRED_VERSION" ]] ; then
-  #   echo "Terraform is at acceptable version - v${terraform_version}"
-  # else
-  #     echo "====================================================================================================="
-  #     echo "=====  Please update your major terraform version to the latest stable release                 ======"
-  #     echo "=====  The contents of this file will just be a Terraform version number, eg.                  ======"
-  #     echo "=====                                                                                          ======"
-  #     echo "=====  1.3.7                                                                                   ======"
-  #     echo "=====                                                                                          ======"
-  #     echo "=====  Enable terraform in your renovate config, either by extending config:base or enabling   ======"
-  #     echo "=====  the terraform manager.                                                                  ======"
-  #     echo "=====                                                                                          ======"
-  #     echo "=====  See:                                                                                    ======"
-  #     echo "=====   - https://github.com/hmcts/spring-boot-template/pull/412                               ======"
-  #     echo "=====   - https://github.com/hmcts/draft-store/pull/1168                                       ======"
-  #     echo "=====   - https://github.com/hmcts/spring-boot-template/blob/master/.github/renovate.json      ======"
-  #     echo "====================================================================================================="
-  #     exit 1
-  #   fi
-# else
-#   echo "Dependency value not recognised, terraform versions not checked"
-# fi

--- a/resources/uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh
+++ b/resources/uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+DEPENDENCY=${1}
+REQUIRED_VERSION=${2}
 
 version_output=$(terraform --version)
 
@@ -6,36 +8,55 @@ terraform_version="$(echo "$version_output" | grep "Terraform v" | cut -d'v' -f 
 azurerm_version="$(echo "$version_output" | grep "azurerm" | cut -d'v' -f 3)"
 
 terraform_major="$(echo "$terraform_version" | cut -d'.' -f 1)"
-azurerm_major="$(echo "$azurerm_version" | cut -d'.' -f 1)"
 
-if [[ "$azurerm_major" -eq "3" ]] && [[ "$terraform_major" -eq "1" ]] ; then
-  echo "Terraform is at version - v${terraform_version}"
-  echo "The Azurerm provider is at version v${azurerm_version}"
-else
-  echo "====================================================================================================="
-  echo "=====  Please update your .terraform-version file, to the latest stable 1.x release            ======"
-  echo "=====  The contents of this file will just be a Terraform version number, eg.                  ======"
-  echo "=====                                                                                          ======"
-  echo "=====  1.3.7                                                                                   ======"
-  echo "=====                                                                                          ======"
-  echo "=====  Ensure your required_providers block is on the latest 3.x version of azurerm, i.e       ======"
-  echo "=====                                                                                          ======"
-  echo "=====  terraform {                                                                             ======"
-  echo "=====    required_providers {                                                                  ======"
-  echo "=====      azurerm = {                                                                         ======"
-  echo "=====       source  = \"hashicorp/azurerm\"                                                      ======"
-  echo "=====       version = \"3.40\"                                                                   ======"
-  echo "=====      }                                                                                   ======"
-  echo "=====    }                                                                                     ======"
-  echo "=====  }                                                                                       ======"
-  echo "=====                                                                                          ======"
-  echo "=====  Enable terraform in your renovate config, either by extending config:base or enabling   ======"
-  echo "=====  the terraform manager.                                                                  ======"
-  echo "=====                                                                                          ======"
-  echo "=====  See:                                                                                    ======"
-  echo "=====   - https://github.com/hmcts/spring-boot-template/pull/412                               ======"
-  echo "=====   - https://github.com/hmcts/draft-store/pull/1168                                       ======"
-  echo "=====   - https://github.com/hmcts/spring-boot-template/blob/master/.github/renovate.json      ======"
-  echo "====================================================================================================="
-  exit 1
+echo "terraform major version is: $terraform_major"
+echo "terraform version is: $terraform_version"
+if [[ "$DEPENDENCY" == "terraform" ]] ; then
+  echo "terraform required version is: $REQUIRED_VERSION"
 fi
+
+# if [[ "$DEPENDENCY" == "terraform" ]] ; then
+  # check major version
+#   if [[ "$terraform_major" -ge "$REQUIRED_VERSION" ]] ; then
+#     echo "Terraform is at acceptable version - v${terraform_version}"
+#   else
+#       echo "====================================================================================================="
+#       echo "=====  Please update your major terraform version to the latest stable release                 ======"
+#       echo "=====  The contents of this file will just be a Terraform version number, eg.                  ======"
+#       echo "=====                                                                                          ======"
+#       echo "=====  1.3.7                                                                                   ======"
+#       echo "=====                                                                                          ======"
+#       echo "=====  Enable terraform in your renovate config, either by extending config:base or enabling   ======"
+#       echo "=====  the terraform manager.                                                                  ======"
+#       echo "=====                                                                                          ======"
+#       echo "=====  See:                                                                                    ======"
+#       echo "=====   - https://github.com/hmcts/spring-boot-template/pull/412                               ======"
+#       echo "=====   - https://github.com/hmcts/draft-store/pull/1168                                       ======"
+#       echo "=====   - https://github.com/hmcts/spring-boot-template/blob/master/.github/renovate.json      ======"
+#       echo "====================================================================================================="
+#       exit 1
+#     fi
+# elif [[ "$DEPENDENCY" == "providers" ]] ; then
+#   echo
+  # if [[ "$terraform_major" -ge "$REQUIRED_VERSION" ]] ; then
+  #   echo "Terraform is at acceptable version - v${terraform_version}"
+  # else
+  #     echo "====================================================================================================="
+  #     echo "=====  Please update your major terraform version to the latest stable release                 ======"
+  #     echo "=====  The contents of this file will just be a Terraform version number, eg.                  ======"
+  #     echo "=====                                                                                          ======"
+  #     echo "=====  1.3.7                                                                                   ======"
+  #     echo "=====                                                                                          ======"
+  #     echo "=====  Enable terraform in your renovate config, either by extending config:base or enabling   ======"
+  #     echo "=====  the terraform manager.                                                                  ======"
+  #     echo "=====                                                                                          ======"
+  #     echo "=====  See:                                                                                    ======"
+  #     echo "=====   - https://github.com/hmcts/spring-boot-template/pull/412                               ======"
+  #     echo "=====   - https://github.com/hmcts/draft-store/pull/1168                                       ======"
+  #     echo "=====   - https://github.com/hmcts/spring-boot-template/blob/master/.github/renovate.json      ======"
+  #     echo "====================================================================================================="
+  #     exit 1
+  #   fi
+# else
+#   echo "Dependency value not recognised, terraform versions not checked"
+# fi

--- a/resources/uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh
+++ b/resources/uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh
@@ -68,13 +68,13 @@ else
     compare_versions "$provider_version" "$REQUIRED_VERSION"
     result=$?
 
-      if [[ $result != 1 ]] ; then
-        echo "Terraform provider $DEPENDENCY is at acceptable version: $provider_version"
-      else
-        echo "====================================================================================================="
-        echo "=====  Please update your version for provider for $DEPENDENCY to $REQUIRED_VERSION            ======"
-        echo "====================================================================================================="
-        exit 1
-      fi
+    if [[ $result != 1 ]] ; then
+      echo "Terraform provider $DEPENDENCY is at acceptable version: $provider_version"
+    else
+      echo "====================================================================================================="
+      echo "=====  Please update your version for provider for $DEPENDENCY to $REQUIRED_VERSION            ======"
+      echo "====================================================================================================="
+      exit 1
+    fi
   fi  
 fi

--- a/resources/uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh
+++ b/resources/uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh
@@ -12,14 +12,9 @@ compare_versions() {
   if [[ "$1" == "$2" ]]; then
       return 0
   fi
-  echo $1
-  echo $2
   local sorted_version_list=$(printf "%s\n%s" "$1" "$2" | sort -V)
   local first_version=$(echo "$sorted_version_list" | head -n 1)
 
-  echo $sorted_version_list
-  echo $first_version
-  
   if [[ "$first_version" == "$1" ]]; then
       return 1 # below required version
   else
@@ -76,7 +71,7 @@ else
       echo "Terraform provider $DEPENDENCY is at acceptable version: $provider_version"
     else
       echo "====================================================================================================="
-      echo "=====  Please update your version for provider for $DEPENDENCY to $REQUIRED_VERSION            ======"
+      echo "=====  Please update your version for provider $DEPENDENCY to latest                           ======"
       echo "====================================================================================================="
       exit 1
     fi

--- a/src/uk/gov/hmcts/pipeline/DeprecationConfig.groovy
+++ b/src/uk/gov/hmcts/pipeline/DeprecationConfig.groovy
@@ -14,7 +14,7 @@ class DeprecationConfig {
       def response = steps.httpRequest(
         consoleLogResponseBody: true,
         timeout: 10,
-        url: "https://raw.githubusercontent.com/hmcts/cnp-deprecation-map/new-format/nagger-versions.yaml",
+        url: "https://raw.githubusercontent.com/hmcts/cnp-deprecation-map/master/nagger-versions.yaml",
         validResponseCodes: '200'
       )
       deprecationConfigInternal = steps.readYaml(text: response.content)

--- a/src/uk/gov/hmcts/pipeline/DeprecationConfig.groovy
+++ b/src/uk/gov/hmcts/pipeline/DeprecationConfig.groovy
@@ -14,7 +14,7 @@ class DeprecationConfig {
       def response = steps.httpRequest(
         consoleLogResponseBody: true,
         timeout: 10,
-        url: "https://raw.githubusercontent.com/hmcts/cnp-deprecation-map/master/nagger-versions.yaml",
+        url: "https://raw.githubusercontent.com/hmcts/cnp-deprecation-map/new-format/nagger-versions.yaml",
         validResponseCodes: '200'
       )
       deprecationConfigInternal = steps.readYaml(text: response.content)

--- a/src/uk/gov/hmcts/pipeline/DeprecationConfig.groovy
+++ b/src/uk/gov/hmcts/pipeline/DeprecationConfig.groovy
@@ -14,7 +14,7 @@ class DeprecationConfig {
       def response = steps.httpRequest(
         consoleLogResponseBody: true,
         timeout: 10,
-        url: "https://raw.githubusercontent.com/hmcts/cnp-jenkins-config/master/deprecation-config.yml",
+        url: "https://raw.githubusercontent.com/hmcts/cnp-deprecation-map/master/nagger-versions.yaml",
         validResponseCodes: '200'
       )
       deprecationConfigInternal = steps.readYaml(text: response.content)

--- a/vars/spinInfra.groovy
+++ b/vars/spinInfra.groovy
@@ -108,7 +108,7 @@ def call(Map<String, ?> params) {
             -backend-config "key=${config.productName}/${environmentDeploymentTarget}/terraform.tfstate"
         """
 
-        warnAboutOldTfAzureProvider()
+        warnAboutOldTfAzureProvider(config.environment)
         warnAboutDeprecatedPostgres()
 
         env.TF_VAR_subscription = config.subscription

--- a/vars/spinInfra.groovy
+++ b/vars/spinInfra.groovy
@@ -108,7 +108,7 @@ def call(Map<String, ?> params) {
             -backend-config "key=${config.productName}/${environmentDeploymentTarget}/terraform.tfstate"
         """
 
-        warnAboutOldTfAzureProvider(config.environment)
+        warnAboutOldTfAzureProvider(config.environment, config.product)
         warnAboutDeprecatedPostgres()
 
         env.TF_VAR_subscription = config.subscription

--- a/vars/warnAboutDeprecatedChartConfig.groovy
+++ b/vars/warnAboutDeprecatedChartConfig.groovy
@@ -30,37 +30,31 @@ def call(Map<String, String> params) {
 
   sh 'chmod +x check-deprecated-charts.sh'
 
-  helmChartDeprecationConfig.each { chart, deprecatedVersions ->
-    deprecatedVersions.each { deprecation ->
-      try {
-        sh "./check-deprecated-charts.sh $product $component $chart $deprecation.version "
-      } catch (ignored) {
-        WarningCollector.addPipelineWarning("deprecated_helmcharts", "Version of $chart helm chart below $deprecation.version is deprecated, please upgrade to latest release https://github.com/hmcts/chart-$chart/releases", LocalDate.parse(deprecation.date_deadline))
-      }
+  helmChartDeprecationConfig.each { chart, deprecation ->
+    try {
+      sh "./check-deprecated-charts.sh $product $component $chart $deprecation.version"
+    } catch (ignored) {
+      WarningCollector.addPipelineWarning("deprecated_helmcharts", "Version of $chart helm chart below $deprecation.version is deprecated, please upgrade to latest release https://github.com/hmcts/chart-$chart/releases", LocalDate.parse(deprecation.date_deadline))
     }
   }
   sh 'rm -f check-deprecated-charts.sh'
 
   sh 'chmod +x check-deprecated-gradle-dependency.sh'
-  gradleDeprecationConfig.each { dependency, deprecatedVersions ->
-    deprecatedVersions.each { deprecation ->
-      try {
-        sh "./check-deprecated-gradle-dependency.sh $dependency $deprecation.version "
-      } catch (ignored) {
-        WarningCollector.addPipelineWarning("deprecated_gradle_library", "Versions below $dependency: $deprecation.version are deprecated, please upgrade to the latest release", LocalDate.parse(deprecation.date_deadline))
-      }
+  gradleDeprecationConfig.each { dependency, deprecation ->
+    try {
+      sh "./check-deprecated-gradle-dependency.sh $dependency $deprecation.version "
+    } catch (ignored) {
+      WarningCollector.addPipelineWarning("deprecated_gradle_library", "Versions below $dependency: $deprecation.version are deprecated, please upgrade to the latest release", LocalDate.parse(deprecation.date_deadline))
     }
   }
   sh 'rm -f check-deprecated-gradle-dependency.sh'
 
   sh 'chmod +x check-deprecated-npm-dependency.sh'
-  npmDeprecationConfig.each { dependency, deprecatedVersions ->
-    deprecatedVersions.each { deprecation ->
-      try {
-        sh "./check-deprecated-npm-dependency.sh $dependency $deprecation.version "
-      } catch (ignored) {
-        WarningCollector.addPipelineWarning("deprecated_npm_library", "Versions below $dependency: $deprecation.version are deprecated, please upgrade to the latest release", LocalDate.parse(deprecation.date_deadline))
-      }
+  npmDeprecationConfig.each { dependency, deprecation ->
+    try {
+      sh "./check-deprecated-npm-dependency.sh $dependency $deprecation.version "
+    } catch (ignored) {
+      WarningCollector.addPipelineWarning("deprecated_npm_library", "Versions below $dependency: $deprecation.version are deprecated, please upgrade to the latest release", LocalDate.parse(deprecation.date_deadline))
     }
   }
   sh 'rm -f check-deprecated-npm-dependency.sh'

--- a/vars/warnAboutOldTfAzureProvider.groovy
+++ b/vars/warnAboutOldTfAzureProvider.groovy
@@ -19,8 +19,7 @@ def call() {
       // maybe script needs output here to make a useful slack message?
     } catch(ignored) {
       WarningCollector.addPipelineWarning("updated_terraform_versions", "Please do some T.B.D.", LocalDate.parse(deprecation.date_deadline))
-    } finally {
-      sh 'rm -f warn-about-old-tf-azure-provider.sh'
-    }
+    } 
   }
+  sh 'rm -f warn-about-old-tf-azure-provider.sh'
 }

--- a/vars/warnAboutOldTfAzureProvider.groovy
+++ b/vars/warnAboutOldTfAzureProvider.groovy
@@ -32,7 +32,8 @@ def call(String environment) {
 
     WarningCollector.addPipelineWarning(
       "updated_terraform_versions",
-      "Please update your terraform dependencies in ${environment} as per the following: \n\n${formattedMessage}"
+      "Please update your terraform dependencies in ${environment} as per the following: \n\n${formattedMessage}",
+      LocalDate.now()
     )
   }
   sh 'rm -f warn-about-old-tf-azure-provider.sh'

--- a/vars/warnAboutOldTfAzureProvider.groovy
+++ b/vars/warnAboutOldTfAzureProvider.groovy
@@ -6,7 +6,6 @@ def call(String environment) {
    
   def tfDeprecationConfig = new DeprecationConfig(this).getDeprecationConfig().terraform
   writeFile file: 'warn-about-old-tf-azure-provider.sh', text: libraryResource('uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh')
-  def 
 
   tfDeprecationConfig.each { dependency, deprecation ->
     try {

--- a/vars/warnAboutOldTfAzureProvider.groovy
+++ b/vars/warnAboutOldTfAzureProvider.groovy
@@ -27,9 +27,10 @@ def call(String environment) {
   }
   if (slackDeprecationMessage) {
     def formattedMessage = slackDeprecationMessage.collect { deprecation ->
-      """- Dependency: ${deprecation.dependency}
-    Message: ${deprecation.message}
-    Deadline: ${deprecation.deadline}"""
+      """\
+      - Dependency: ${deprecation.dependency}
+        Message: ${deprecation.message}
+        Deadline: ${deprecation.deadline}""".stripIndent()
     }.join("\n\n")
 
     def earliestDeadline = deprecationDeadlines.min()

--- a/vars/warnAboutOldTfAzureProvider.groovy
+++ b/vars/warnAboutOldTfAzureProvider.groovy
@@ -13,7 +13,7 @@ def call() {
     try {
       sh """
       chmod +x warn-about-old-tf-azure-provider.sh
-      ./warn-about-old-tf-azure-provider.sh $dependency $deprecation.version $deprecation
+      ./warn-about-old-tf-azure-provider.sh $dependency $deprecation
       """
 
       // maybe script needs output here to make a useful slack message?

--- a/vars/warnAboutOldTfAzureProvider.groovy
+++ b/vars/warnAboutOldTfAzureProvider.groovy
@@ -14,7 +14,7 @@ def call(String environment) {
       ./warn-about-old-tf-azure-provider.sh $dependency $deprecation.version
       """
     } catch(ignored) {
-      WarningCollector.addPipelineWarning("updated_terraform_versions", "Please update your terraform ${dependency} to the latest acceptable version ${deprecation.version} in ${environment}", LocalDate.parse(deprecation.date_deadline))
+      WarningCollector.addPipelineWarning("updated_terraform_versions", "Environment -- ${environment}: Please update your terraform ${dependency} to the latest acceptable version ${deprecation.version}.", LocalDate.parse(deprecation.date_deadline))
     } 
   }
   sh 'rm -f warn-about-old-tf-azure-provider.sh'

--- a/vars/warnAboutOldTfAzureProvider.groovy
+++ b/vars/warnAboutOldTfAzureProvider.groovy
@@ -19,7 +19,7 @@ def call(String environment, String product) {
     } catch(ignored) {
       slackDeprecationMessage << [
           dependency: dependency,
-          message: "minimum required is ${deprecation.version},",
+          message: "minimum required is ${deprecation.version}",
           deadline: deprecation.date_deadline
       ]
       deprecationDeadlines << deprecation.date_deadline
@@ -27,7 +27,7 @@ def call(String environment, String product) {
   }
   if (slackDeprecationMessage) {
     def formattedMessage = slackDeprecationMessage.collect { deprecation ->
-      "${deprecation.dependency} - ${deprecation.message}, update by ${deprecation.deadline}"
+      "* `${deprecation.dependency}` - ${deprecation.message}, update by ${deprecation.deadline}"
     }.join("\n\n")
 
     def earliestDeadline = deprecationDeadlines.min()

--- a/vars/warnAboutOldTfAzureProvider.groovy
+++ b/vars/warnAboutOldTfAzureProvider.groovy
@@ -1,13 +1,14 @@
 import uk.gov.hmcts.pipeline.deprecation.WarningCollector
 import uk.gov.hmcts.pipeline.DeprecationConfig
 import java.time.LocalDate
+import groovy.json.JsonOutput
 
 def call() {
    
   def tfDeprecationConfig = new DeprecationConfig(this).getDeprecationConfig().terraform
-
+  def slackDeprecationMessage = []
+  def processedDependencies = [:]
   writeFile file: 'warn-about-old-tf-azure-provider.sh', text: libraryResource('uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh')
-
 
   tfDeprecationConfig.each { dependency, deprecation ->
     try {
@@ -16,8 +17,24 @@ def call() {
       ./warn-about-old-tf-azure-provider.sh $dependency $deprecation.version
       """
     } catch(ignored) {
-      WarningCollector.addPipelineWarning("updated_terraform_versions", "Please update your terraform ${dependency} to the latest acceptable version ${deprecation.version}", LocalDate.parse(deprecation.date_deadline))
+      // Only add to slack message new messages
+      if !(processedDependencies.containsKey(dependency)) {
+        slackDeprecationMessage << [
+          dependency: dependency,
+          message: "Please update your terraform ${dependency} to the latest acceptable version ${deprecation.version}",
+          deadline: deprecation.date_deadline
+        ]
+        processedDependencies[dependency] = true
+      }
     } 
   }
   sh 'rm -f warn-about-old-tf-azure-provider.sh'
+
+  if (slackDeprecationMessage) {
+    def jsonMessage = JsonOutput.toJson(slackDeprecationMessage)
+    WarningCollector.addPipelineWarning(
+      "updated_terraform_versions",
+      "Please update your terraform dependencies as per the following details: ${jsonMessage}"
+    )
+  }
 }

--- a/vars/warnAboutOldTfAzureProvider.groovy
+++ b/vars/warnAboutOldTfAzureProvider.groovy
@@ -19,7 +19,7 @@ def call(String environment, String product) {
     } catch(ignored) {
       slackDeprecationMessage << [
           dependency: dependency,
-          message: "minimum required is ${deprecation.version}",
+          message: "minimum required is *${deprecation.version}*",
           deadline: deprecation.date_deadline
       ]
       deprecationDeadlines << deprecation.date_deadline
@@ -27,7 +27,7 @@ def call(String environment, String product) {
   }
   if (slackDeprecationMessage) {
     def formattedMessage = slackDeprecationMessage.collect { deprecation ->
-      "* `${deprecation.dependency}` - ${deprecation.message}, update by ${deprecation.deadline}"
+      "`${deprecation.dependency}` - ${deprecation.message}, update by ${deprecation.deadline}"
     }.join("\n\n")
 
     def earliestDeadline = deprecationDeadlines.min()

--- a/vars/warnAboutOldTfAzureProvider.groovy
+++ b/vars/warnAboutOldTfAzureProvider.groovy
@@ -34,7 +34,8 @@ def call() {
     def jsonMessage = JsonOutput.toJson(slackDeprecationMessage)
     WarningCollector.addPipelineWarning(
       "updated_terraform_versions",
-      "Please update your terraform dependencies as per the following details: ${jsonMessage}"
+      "Please update your terraform dependencies as per the following details: ${jsonMessage}",
+      LocalDate.now()
     )
   }
 }

--- a/vars/warnAboutOldTfAzureProvider.groovy
+++ b/vars/warnAboutOldTfAzureProvider.groovy
@@ -18,7 +18,7 @@ def call() {
       """
     } catch(ignored) {
       // Only add to slack message new messages
-      if !(processedDependencies.containsKey(dependency)) {
+      if (!processedDependencies.containsKey(dependency)) {
         slackDeprecationMessage << [
           dependency: dependency,
           message: "Please update your terraform ${dependency} to the latest acceptable version ${deprecation.version}",

--- a/vars/warnAboutOldTfAzureProvider.groovy
+++ b/vars/warnAboutOldTfAzureProvider.groovy
@@ -2,7 +2,7 @@ import uk.gov.hmcts.pipeline.deprecation.WarningCollector
 import uk.gov.hmcts.pipeline.DeprecationConfig
 import java.time.LocalDate
 
-def call(String environment) {
+def call(String environment, String product) {
    
   def tfDeprecationConfig = new DeprecationConfig(this).getDeprecationConfig().terraform
   writeFile file: 'warn-about-old-tf-azure-provider.sh', text: libraryResource('uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh')
@@ -28,15 +28,15 @@ def call(String environment) {
   if (slackDeprecationMessage) {
     def formattedMessage = slackDeprecationMessage.collect { deprecation ->
       """\
-      - Dependency: ${deprecation.dependency}
-        Message: ${deprecation.message}
-        Deadline: ${deprecation.deadline}""".stripIndent()
+      Dependency: ${deprecation.dependency}
+      Message: ${deprecation.message}
+      Deadline: ${deprecation.deadline}""".stripIndent()
     }.join("\n\n")
 
     def earliestDeadline = deprecationDeadlines.min()
     WarningCollector.addPipelineWarning(
       "updated_terraform_versions",
-      "\n\nPlease update the following terraform dependencies in ${environment}: \n\n${formattedMessage}\n\n",
+      "\n\nPlease update the following terraform dependencies in ${environment} for ${product}: \n\n${formattedMessage}\n\n",
       LocalDate.parse(earliestDeadline)
     )
   }

--- a/vars/warnAboutOldTfAzureProvider.groovy
+++ b/vars/warnAboutOldTfAzureProvider.groovy
@@ -15,11 +15,8 @@ def call() {
       chmod +x warn-about-old-tf-azure-provider.sh
       ./warn-about-old-tf-azure-provider.sh $dependency $deprecation.version
       """
-
-      // maybe script needs output here to make a useful slack message?
-      // How to handle deprecation dates for the providers?
     } catch(ignored) {
-      WarningCollector.addPipelineWarning("updated_terraform_versions", "Please do some T.B.D.", LocalDate.parse(deprecation.date_deadline))
+      WarningCollector.addPipelineWarning("updated_terraform_versions", "Please update your terraform ${dependency} to the latest acceptable version ${deprecation.version}", LocalDate.parse(deprecation.date_deadline))
     } 
   }
   sh 'rm -f warn-about-old-tf-azure-provider.sh'

--- a/vars/warnAboutOldTfAzureProvider.groovy
+++ b/vars/warnAboutOldTfAzureProvider.groovy
@@ -1,14 +1,12 @@
 import uk.gov.hmcts.pipeline.deprecation.WarningCollector
 import uk.gov.hmcts.pipeline.DeprecationConfig
 import java.time.LocalDate
-import groovy.json.JsonOutput
 
-def call() {
+def call(String environment) {
    
   def tfDeprecationConfig = new DeprecationConfig(this).getDeprecationConfig().terraform
-  def slackDeprecationMessage = []
-  def processedDependencies = [:]
   writeFile file: 'warn-about-old-tf-azure-provider.sh', text: libraryResource('uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh')
+  def 
 
   tfDeprecationConfig.each { dependency, deprecation ->
     try {
@@ -17,25 +15,8 @@ def call() {
       ./warn-about-old-tf-azure-provider.sh $dependency $deprecation.version
       """
     } catch(ignored) {
-      // Only add to slack message new messages
-      if (!processedDependencies.containsKey(dependency)) {
-        slackDeprecationMessage << [
-          dependency: dependency,
-          message: "Please update your terraform ${dependency} to the latest acceptable version ${deprecation.version}",
-          deadline: deprecation.date_deadline
-        ]
-        processedDependencies[dependency] = true
-      }
+      WarningCollector.addPipelineWarning("updated_terraform_versions", "Please update your terraform ${dependency} to the latest acceptable version ${deprecation.version} in ${environment}", LocalDate.parse(deprecation.date_deadline))
     } 
   }
   sh 'rm -f warn-about-old-tf-azure-provider.sh'
-
-  if (slackDeprecationMessage) {
-    def jsonMessage = JsonOutput.toJson(slackDeprecationMessage)
-    WarningCollector.addPipelineWarning(
-      "updated_terraform_versions",
-      "Please update your terraform dependencies as per the following details: ${jsonMessage}",
-      LocalDate.now()
-    )
-  }
 }

--- a/vars/warnAboutOldTfAzureProvider.groovy
+++ b/vars/warnAboutOldTfAzureProvider.groovy
@@ -13,10 +13,11 @@ def call() {
     try {
       sh """
       chmod +x warn-about-old-tf-azure-provider.sh
-      ./warn-about-old-tf-azure-provider.sh $dependency $deprecation
+      ./warn-about-old-tf-azure-provider.sh $dependency $deprecation.version
       """
 
       // maybe script needs output here to make a useful slack message?
+      // How to handle deprecation dates for the providers?
     } catch(ignored) {
       WarningCollector.addPipelineWarning("updated_terraform_versions", "Please do some T.B.D.", LocalDate.parse(deprecation.date_deadline))
     } 

--- a/vars/warnAboutOldTfAzureProvider.groovy
+++ b/vars/warnAboutOldTfAzureProvider.groovy
@@ -28,14 +28,14 @@ def call(String environment) {
   if (slackDeprecationMessage) {
     def formattedMessage = slackDeprecationMessage.collect { deprecation ->
       """- Dependency: ${deprecation.dependency}
-      Message: ${deprecation.message}
-      Deadline: ${deprecation.deadline}"""
+    Message: ${deprecation.message}
+    Deadline: ${deprecation.deadline}"""
     }.join("\n\n")
 
     def earliestDeadline = deprecationDeadlines.min()
     WarningCollector.addPipelineWarning(
       "updated_terraform_versions",
-      "\n\nPlease update your terraform dependencies in ${environment} as per the following: \n\n${formattedMessage}\n\n",
+      "\n\nPlease update the following terraform dependencies in ${environment}: \n\n${formattedMessage}\n\n",
       LocalDate.parse(earliestDeadline)
     )
   }

--- a/vars/warnAboutOldTfAzureProvider.groovy
+++ b/vars/warnAboutOldTfAzureProvider.groovy
@@ -1,19 +1,26 @@
 import uk.gov.hmcts.pipeline.deprecation.WarningCollector
-
+import uk.gov.hmcts.pipeline.DeprecationConfig
 import java.time.LocalDate
 
 def call() {
+   
+  def tfDeprecationConfig = new DeprecationConfig(this).getDeprecationConfig().terraform
 
   writeFile file: 'warn-about-old-tf-azure-provider.sh', text: libraryResource('uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh')
 
-  try {
-    sh """
-    chmod +x warn-about-old-tf-azure-provider.sh
-    ./warn-about-old-tf-azure-provider.sh
-    """
-  } catch(ignored) {
-    WarningCollector.addPipelineWarning("updated_azurerm_provider", "Please upgrade azurerm to the latest 3.x version, and terraform to 1.x For examples see: https://github.com/hmcts/spring-boot-template/pull/412 and https://github.com/hmcts/draft-store/pull/1168", LocalDate.of(2023, 02, 28))
-  } finally {
-    sh 'rm -f warn-about-old-tf-azure-provider.sh'
+
+  tfDeprecationConfig.each { dependency, deprecation ->
+    try {
+      sh """
+      chmod +x warn-about-old-tf-azure-provider.sh
+      ./warn-about-old-tf-azure-provider.sh $dependency $deprecation.version
+      """
+
+      // maybe script needs output here to make a useful slack message?
+    } catch(ignored) {
+      WarningCollector.addPipelineWarning("updated_terraform_versions", "Please do some T.B.D.", LocalDate.parse(deprecation.date_deadline))
+    } finally {
+      sh 'rm -f warn-about-old-tf-azure-provider.sh'
+    }
   }
 }

--- a/vars/warnAboutOldTfAzureProvider.groovy
+++ b/vars/warnAboutOldTfAzureProvider.groovy
@@ -13,7 +13,7 @@ def call() {
     try {
       sh """
       chmod +x warn-about-old-tf-azure-provider.sh
-      ./warn-about-old-tf-azure-provider.sh $dependency $deprecation.version
+      ./warn-about-old-tf-azure-provider.sh $dependency $deprecation.version $deprecation
       """
 
       // maybe script needs output here to make a useful slack message?

--- a/vars/warnAboutOldTfAzureProvider.groovy
+++ b/vars/warnAboutOldTfAzureProvider.groovy
@@ -19,7 +19,7 @@ def call(String environment, String product) {
     } catch(ignored) {
       slackDeprecationMessage << [
           dependency: dependency,
-          message: "Please update ${dependency} to the latest acceptable version ${deprecation.version}",
+          message: "minimum required is ${deprecation.version},",
           deadline: deprecation.date_deadline
       ]
       deprecationDeadlines << deprecation.date_deadline
@@ -27,16 +27,13 @@ def call(String environment, String product) {
   }
   if (slackDeprecationMessage) {
     def formattedMessage = slackDeprecationMessage.collect { deprecation ->
-      """\
-      Dependency: ${deprecation.dependency}
-      Message: ${deprecation.message}
-      Deadline: ${deprecation.deadline}""".stripIndent()
+      "${deprecation.dependency} - ${deprecation.message}, update by ${deprecation.deadline}"
     }.join("\n\n")
 
     def earliestDeadline = deprecationDeadlines.min()
     WarningCollector.addPipelineWarning(
       "updated_terraform_versions",
-      "\n\nPlease update the following terraform dependencies in ${environment} for ${product}: \n\n${formattedMessage}\n\n",
+      "\n\nOutdated terraform configuration in ${environment} for ${product}: \n\n${formattedMessage}\n\n",
       LocalDate.parse(earliestDeadline)
     )
   }


### PR DESCRIPTION
As part of https://tools.hmcts.net/jira/browse/DTSPO-17348 we require a central location for nagger details and an update to jenkins functionality for terraform nagger

Previously:

- Hardcoded value for major azurerm provider version
- Hardcoded value for major terraform version 
- slack message sent for each deprecation

Changes:

- This PR updates jenkins-library to use a new central deprecation map location shared by ADO
- Adds functionality for us to dynamically compare terraform versions and terraform provider versions to app configuration (no longer just major versions and no longer just azurerm provider)
- Adds some updates for slack messages for terraform deprecations so it's nicely formatted


All versions and dates are identical as the old mapping for helm / gradle / npm versions
New deprecation map location https://github.com/hmcts/cnp-deprecation-map/pull/3

All naggers for terraform have a date of `"2024-12-30"` for now too, so even if there is outdated repos they will not be broken

Because of the way the Pipeline Warning collector work (only accepting one date) - I have chosen to adopt the soonest possible deprecation date to put in the warning message in the case where more than one deprecation is noticed, so that the statement "Your configuration will stop working by X date" is still technically true. 
All the warnings are collected into a formatted string whilst we go over the deprecation map and then sent in one terraform deprecation slack message as below. This is grouped per env now. The other option was to add a pipeline warning for each deprecation but that got a little bit repetitive in the message, and I think grouping looks nicer

- Example slack message where both terraform version and a provider version are below the required version:
<img width="612" alt="image" src="https://github.com/hmcts/cnp-jenkins-library/assets/47995122/6cde13b0-676e-433e-8914-4fda56a08d56">


- Example slack message where the terraform version will need updating:
<img width="553" alt="image" src="https://github.com/hmcts/cnp-jenkins-library/assets/47995122/54efc989-d899-47ea-941f-4f969c27f07f">


