### PR TITLE
Add support for yarn v4

### DIFF
--- a/resources/uk/gov/hmcts/pipeline/yarn/format-v4-audit.js
+++ b/resources/uk/gov/hmcts/pipeline/yarn/format-v4-audit.js
@@ -1,0 +1,103 @@
+
+const fs = require("fs");
+
+async function main() {
+  const v3input = fs.readFileSync('/dev/stdin', "utf-8");
+
+  const v3lines = v3input.split("\n").filter(line => line.length > 0);
+  const v3json = v3lines.map(line => JSON.parse(line));
+
+  const advisories = await Promise.all(v3json.map(getAdvisory));
+  const yarnLock = fs.readFileSync('yarn.lock', 'utf8');
+  const numDependencies = yarnLock.match(/resolution: "/g).length;
+  const advisoriesById = advisories.reduce((acc, advisory) => {
+    acc[advisory.id] = advisory;
+    return acc;
+  }, {});
+
+  console.log(JSON.stringify({
+    actions: [],
+    advisories: advisoriesById,
+    metadata: {
+      dependencies: numDependencies,
+      devDependencies: 0,
+      optionalDependencies: 0,
+      totalDependencies: numDependencies,
+      vulnerabilities: {
+        critical: advisories.filter(advisory => advisory.severity === 'critical').length,
+        high: advisories.filter(advisory => advisory.severity === 'high').length,
+        info: advisories.filter(advisory => advisory.severity === 'info').length,
+        low: advisories.filter(advisory => advisory.severity === 'low').length,
+        moderate: advisories.filter(advisory => advisory.severity === 'moderate').length
+      }
+    },
+    muted: []
+  }, null, 2));
+}
+
+async function getAdvisory(advisory) {
+  const partialResult = {
+    access: "public",
+    created: null,
+    cves: [],
+    cvss: null,
+    cwe: [],
+    deleted: null,
+    findings: [{
+      paths: advisory.children.Dependents,
+      version: advisory.children["Tree Versions"][0]
+    }],
+    found_by: null,
+    github_advisory_id: null,
+    id: advisory.children.ID,
+    metadata: null,
+    module_name: advisory.value,
+    npm_advisory_id: null,
+    overview: advisory.children.Issue,
+    patched_versions: null,
+    recommendation: null,
+    references: "",
+    reported_by: null,
+    severity: advisory.children.Severity,
+    title: advisory.children.Issue,
+    updated: null,
+    url: null,
+    vulnerable_versions: advisory.children["Vulnerable Versions"]
+  }
+
+  const githubJson = !advisory.children.URL
+    ? {}
+    : await getGitHubAdvisory(advisory.children.URL);
+
+  return { ...partialResult, ...githubJson };
+}
+
+async function getGitHubAdvisory(htmlUrl) {
+  const url = htmlUrl.replace('github.com', 'api.github.com');
+  const request = await fetch(url, {
+    headers: {
+      "Authorization": "Bearer " + process.env.GIT_CREDENTIALS_ID,
+      "X-GitHub-Api-Version": "2022-11-28"
+    }
+  });
+
+  const githubJson = await request.json();
+
+  return {
+    created: githubJson.published_at,
+    cves: [githubJson.cve_id],
+    cvss: githubJson.cvss,
+    cwe: githubJson.cwes?.map(cwe => cwe.cwe_id),
+    deleted: githubJson.withdrawn_at,
+    github_advisory_id: githubJson.ghsa_id,
+    overview: githubJson.description,
+    patched_versions: githubJson.vulnerabilities?.[0].first_patched_version,
+    recommendation: `Upgrade to ${githubJson.vulnerabilities?.[0].first_patched_version}`,
+    title: githubJson.summary,
+    updated: githubJson.updated_at,
+    url: githubJson.html_url,
+    vulnerable_versions: githubJson.vulnerabilities?.[0].vulnerable_version_range
+  }
+}
+
+main().catch(console.log);

--- a/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
+++ b/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
@@ -89,7 +89,7 @@ else
   yarn npm audit --recursive --environment production --json --ignore 1096460 > yarn-audit-result || true
 fi
 
-if [ "$YARN_VERSION" == "v4" ]; then
+if [ "$YARN_VERSION" == "4" ]; then
   cat yarn-audit-result | node format-v4-audit.js > yarn-audit-result-formatted
 else
   cp yarn-audit-result yarn-audit-result-formatted
@@ -104,7 +104,7 @@ if [[ ! -s sorted-yarn-audit-issues ]];  then
   # Check for unneeded suppressions when no vulnerabilities are present
   if [ -f yarn-audit-known-issues ]; then
     # Convert JSON array into sorted list of suppressed issues
-    if [ "$YARN_VERSION" == "v4" ]; then
+    if [ "$YARN_VERSION" == "4" ]; then
       cat yarn-audit-known-issues | node format-v4-audit.js > yarn-audit-known-issues-formatted
     else
       cp yarn-audit-known-issues yarn-audit-known-issues-formatted
@@ -127,7 +127,7 @@ if [ ! -f yarn-audit-known-issues ]; then
   exit 1
 else
   # Test for old format of yarn-audit-known-issues
-  if [ "$YARN_VERSION" == "v4" ]; then
+  if [ "$YARN_VERSION" == "4" ]; then
     cat yarn-audit-known-issues | node format-v4-audit.js > yarn-audit-known-issues-formatted
   else
     cp yarn-audit-known-issues yarn-audit-known-issues-formatted

--- a/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
+++ b/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
@@ -88,7 +88,6 @@ if [ "$today" -gt "$exclude_until" ]; then
 else
   yarn npm audit --recursive --environment production --json --ignore 1096460 > yarn-audit-result || true
 fi
-echo "Yarn audit completed."
 
 if [ "$YARN_VERSION" == "v4" ]; then
   cat yarn-audit-result | node format-v4-audit.js > yarn-audit-result-formatted
@@ -133,6 +132,8 @@ else
   else
     cp yarn-audit-known-issues yarn-audit-known-issues-formatted
   fi
+
+  cat yarn-audit-known-issues-formatted
 
   if ! jq 'has("actions", "advisories", "metadata")' yarn-audit-known-issues-formatted | grep -q true; then
     print_borked_known_issues

--- a/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
+++ b/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
@@ -133,8 +133,6 @@ else
     cp yarn-audit-known-issues yarn-audit-known-issues-formatted
   fi
 
-  cat yarn-audit-known-issues-formatted
-
   if ! jq 'has("actions", "advisories", "metadata")' yarn-audit-known-issues-formatted | grep -q true; then
     print_borked_known_issues
     exit 1

--- a/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
+++ b/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
@@ -88,8 +88,15 @@ if [ "$today" -gt "$exclude_until" ]; then
 else
   yarn npm audit --recursive --environment production --json --ignore 1096460 > yarn-audit-result || true
 fi
+echo "Yarn audit completed."
 
-jq -cr '.advisories | to_entries[].value' < yarn-audit-result | sort > sorted-yarn-audit-issues
+if [ "$YARN_VERSION" == "v4" ]; then
+  cat yarn-audit-result | node format-v4-audit.js > yarn-audit-result-formatted
+else
+  cp yarn-audit-result yarn-audit-result-formatted
+fi
+
+jq -cr '.advisories | to_entries[].value' < yarn-audit-result-formatted | sort > sorted-yarn-audit-issues
 
 # Check if there were any vulnerabilities
 if [[ ! -s sorted-yarn-audit-issues ]];  then
@@ -98,7 +105,13 @@ if [[ ! -s sorted-yarn-audit-issues ]];  then
   # Check for unneeded suppressions when no vulnerabilities are present
   if [ -f yarn-audit-known-issues ]; then
     # Convert JSON array into sorted list of suppressed issues
-    jq -cr '.advisories | to_entries[].value' yarn-audit-known-issues \
+    if [ "$YARN_VERSION" == "v4" ]; then
+      cat yarn-audit-known-issues | node format-v4-audit.js > yarn-audit-known-issues-formatted
+    else
+      cp yarn-audit-known-issues yarn-audit-known-issues-formatted
+    fi
+
+    jq -cr '.advisories | to_entries[].value' yarn-audit-known-issues-formatted \
     | sort > sorted-yarn-audit-known-issues
 
     # When no vulnerabilities are found, all suppressions are unneeded
@@ -115,18 +128,24 @@ if [ ! -f yarn-audit-known-issues ]; then
   exit 1
 else
   # Test for old format of yarn-audit-known-issues
-  if ! jq 'has("actions", "advisories", "metadata")' yarn-audit-known-issues | grep -q true; then
+  if [ "$YARN_VERSION" == "v4" ]; then
+    cat yarn-audit-known-issues | node format-v4-audit.js > yarn-audit-known-issues-formatted
+  else
+    cp yarn-audit-known-issues yarn-audit-known-issues-formatted
+  fi
+
+  if ! jq 'has("actions", "advisories", "metadata")' yarn-audit-known-issues-formatted | grep -q true; then
     print_borked_known_issues
     exit 1
   fi
 
   # Handle edge case for when audit returns in different orders for the two files
   # Convert JSON array into sorted list of issues.
-  jq -cr '.advisories | to_entries[].value' yarn-audit-known-issues \
+  jq -cr '.advisories | to_entries[].value' yarn-audit-known-issues-formatted \
   | sort > sorted-yarn-audit-known-issues
 
   # Retain old data ingestion style for cosmosDB
-  jq -cr '.advisories| to_entries[] | {"type": "auditAdvisory", "data": { "advisory": .value }}' yarn-audit-known-issues > yarn-audit-known-issues-result
+  jq -cr '.advisories| to_entries[] | {"type": "auditAdvisory", "data": { "advisory": .value }}' yarn-audit-known-issues-formatted > yarn-audit-known-issues-result
 
   # Check each issue in sorted-yarn-audit-result is also present in sorted-yarn-audit-known-issues
   while IFS= read -r line; do

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -140,7 +140,7 @@ class YarnBuilder extends AbstractBuilder {
 
       steps.sh """
          export PATH=\$HOME/.local/bin:\$PATH
-         export YARN_VERSION=\$(jq -r '.packageManager' package.json | sed 's/yarn@//' | echo \"\${v%%.*}\" )
+         export YARN_VERSION=\$(jq -r '.packageManager' package.json | sed 's/yarn@//' | grep -o '^[^.]*')
          chmod +x yarn-audit-with-suppressions.sh
         ./yarn-audit-with-suppressions.sh
       """

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -136,7 +136,7 @@ class YarnBuilder extends AbstractBuilder {
       corepackEnable()
       steps.writeFile(file: 'yarn-audit-with-suppressions.sh', text: steps.libraryResource('uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh'))
       steps.writeFile(file: 'prettyPrintAudit.sh', text: steps.libraryResource('uk/gov/hmcts/pipeline/yarn/prettyPrintAudit.sh'))
-      steps.writeFile(file: 'prettyPrintAudit.sh', text: steps.libraryResource('uk/gov/hmcts/pipeline/yarn/format-v4-audit.js'))
+      steps.writeFile(file: 'format-v4-audit.js', text: steps.libraryResource('uk/gov/hmcts/pipeline/yarn/format-v4-audit.js'))
 
       steps.sh """
          export PATH=\$HOME/.local/bin:\$PATH

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -136,10 +136,12 @@ class YarnBuilder extends AbstractBuilder {
       corepackEnable()
       steps.writeFile(file: 'yarn-audit-with-suppressions.sh', text: steps.libraryResource('uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh'))
       steps.writeFile(file: 'prettyPrintAudit.sh', text: steps.libraryResource('uk/gov/hmcts/pipeline/yarn/prettyPrintAudit.sh'))
+      steps.writeFile(file: 'prettyPrintAudit.sh', text: steps.libraryResource('uk/gov/hmcts/pipeline/yarn/format-v4-audit.js'))
 
       steps.sh """
          export PATH=\$HOME/.local/bin:\$PATH
-        chmod +x yarn-audit-with-suppressions.sh
+         export YARN_VERSION=\$(jq -r '.packageManager' package.json | sed 's/yarn@//' | echo \"\${v%%.*}\" )
+         chmod +x yarn-audit-with-suppressions.sh
         ./yarn-audit-with-suppressions.sh
       """
     } finally {

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -146,8 +146,8 @@ class YarnBuilder extends AbstractBuilder {
       """
     } finally {
       steps.sh """
-        cat yarn-audit-result | jq -c '. | {type: "auditSummary", data: .metadata}' > yarn-audit-issues-result-summary
-        cat yarn-audit-result | jq -cr '.advisories| to_entries[] | {"type": "auditAdvisory", "data": { "advisory": .value }}' >> yarn-audit-issues-advisories
+        cat yarn-audit-result-formatted | jq -c '. | {type: "auditSummary", data: .metadata}' > yarn-audit-issues-result-summary
+        cat yarn-audit-result-formatted | jq -cr '.advisories| to_entries[] | {"type": "auditAdvisory", "data": { "advisory": .value }}' >> yarn-audit-issues-advisories
         cat yarn-audit-issues-result-summary yarn-audit-issues-advisories > yarn-audit-issues-result
       """
       String issues = steps.readFile('yarn-audit-issues-result')


### PR DESCRIPTION
Adds a formatter to convert yarn v4 audit output to the v3 format. It uses the GitHub API to replicate as much of the information as it can.