### PR TITLE
Increase helm timeout - temp help for ASO issues

### DIFF
--- a/src/uk/gov/hmcts/contino/Helm.groovy
+++ b/src/uk/gov/hmcts/contino/Helm.groovy
@@ -119,7 +119,7 @@ class Helm {
     this.steps.writeFile file: 'aks-debug-info.sh', text: this.steps.libraryResource('uk/gov/hmcts/helm/aks-debug-info.sh')
 
     this.steps.sh ("chmod +x aks-debug-info.sh")
-    def optionsStr = (options + ["--install", "--wait", "--timeout 500s"]).join(' ')
+    def optionsStr = (options + ["--install", "--wait", "--timeout 800s"]).join(' ')
     def valuesStr =  "${' -f ' + values.flatten().join(' -f ')}"
     steps.sh(label: "helm upgrade", script: "helm upgrade ${releaseName}  ${this.chartLocation} ${valuesStr} ${optionsStr} || ./aks-debug-info.sh ${releaseName} ${this.namespace} ")
     this.steps.sh 'rm aks-debug-info.sh'

--- a/src/uk/gov/hmcts/contino/Helm.groovy
+++ b/src/uk/gov/hmcts/contino/Helm.groovy
@@ -119,7 +119,7 @@ class Helm {
     this.steps.writeFile file: 'aks-debug-info.sh', text: this.steps.libraryResource('uk/gov/hmcts/helm/aks-debug-info.sh')
 
     this.steps.sh ("chmod +x aks-debug-info.sh")
-    def optionsStr = (options + ["--install", "--wait", "--timeout 800s"]).join(' ')
+    def optionsStr = (options + ["--install", "--wait", "--timeout 1000s"]).join(' ')
     def valuesStr =  "${' -f ' + values.flatten().join(' -f ')}"
     steps.sh(label: "helm upgrade", script: "helm upgrade ${releaseName}  ${this.chartLocation} ${valuesStr} ${optionsStr} || ./aks-debug-info.sh ${releaseName} ${this.namespace} ")
     this.steps.sh 'rm aks-debug-info.sh'

--- a/test/uk/gov/hmcts/contino/HelmTest.groovy
+++ b/test/uk/gov/hmcts/contino/HelmTest.groovy
@@ -49,7 +49,7 @@ class HelmTest extends Specification {
 
     then:
     1 * steps.sh({it.containsKey('script') &&
-      it.get('script').contains("helm upgrade ${CHART}-pr-1  ${CHART_PATH}  -f val1 -f val2 --namespace cnp --install --wait --timeout 800s") &&
+      it.get('script').contains("helm upgrade ${CHART}-pr-1  ${CHART_PATH}  -f val1 -f val2 --namespace cnp --install --wait --timeout 1000s") &&
       it.get('script').contains("|| ./aks-debug-info.sh ${CHART}-pr-1 cnp")
     })
   }

--- a/test/uk/gov/hmcts/contino/HelmTest.groovy
+++ b/test/uk/gov/hmcts/contino/HelmTest.groovy
@@ -49,7 +49,7 @@ class HelmTest extends Specification {
 
     then:
     1 * steps.sh({it.containsKey('script') &&
-      it.get('script').contains("helm upgrade ${CHART}-pr-1  ${CHART_PATH}  -f val1 -f val2 --namespace cnp --install --wait --timeout 500s") &&
+      it.get('script').contains("helm upgrade ${CHART}-pr-1  ${CHART_PATH}  -f val1 -f val2 --namespace cnp --install --wait --timeout 800s") &&
       it.get('script').contains("|| ./aks-debug-info.sh ${CHART}-pr-1 cnp")
     })
   }


### PR DESCRIPTION
Linked to issues on Preview with Azure Service Operator.
Azure resources (postgres db/sb topics/sb queues/storage container etc).
Want to increase this timeout so more pass and we have less cycles of not deploy quick enough, be deleted again and retry deploying. Hope is that this leads to more passing first time, and then there is less pressure on ASO/Azure.

We will still continue with the Msft support ticket and ASO team on slack.

From some recent logs from ASO we are seeing a big gap between Reconcile Invoked and the About to send resource to Azure log. And the resources end up being deleted soon after they start deploying because of this timeout.

Notes:
*
*
*
