### PR TITLE
Fix spelling for `encodedDependencyList`

### DIFF
--- a/src/uk/gov/hmcts/ardoq/ArdoqClient.groovy
+++ b/src/uk/gov/hmcts/ardoq/ArdoqClient.groovy
@@ -52,7 +52,7 @@ class ArdoqClient {
              "vcsHost": "Github HMCTS",
              "hmctsApplication": "${applicationId}",
              "codeRepository": "${repositoryName}",
-             "encodedDependecyList": "${b64Dependencies}",
+             "encodedDependencyList": "${b64Dependencies}",
              "parser": "${parser}",
              "language": "${language}",
              "languageVersion": "${languageVersion}"

--- a/test/uk/gov/hmcts/contino/ArdoqClientTest.groovy
+++ b/test/uk/gov/hmcts/contino/ArdoqClientTest.groovy
@@ -67,7 +67,7 @@ class ArdoqClientTest extends Specification {
               "vcsHost": "Github HMCTS",
               "hmctsApplication": "appId",
               "codeRepository": "repoName",
-              "encodedDependecyList": "deps",
+              "encodedDependencyList": "deps",
               "parser": "yarn",
               "language": "java",
               "languageVersion": "1.8"


### PR DESCRIPTION
Fixing the spelling of `encodedDependencyList` because it was causing build-failures in projects