### PR TITLE
Increase properties-volume-spring-boot-starter is deprecated by 2 days

### DIFF
--- a/vars/warnAboutDeprecatedChartConfig.groovy
+++ b/vars/warnAboutDeprecatedChartConfig.groovy
@@ -54,7 +54,7 @@ def call(Map<String, String> params) {
   try {
     sh './check-deprecated-properties-volume-spring-boot-starter.sh'
   } catch (ignored) {
-    WarningCollector.addPipelineWarning("deprecated_gradle_library", "The properties-volume-spring-boot-starter is deprecated since spring-boot: 2.4.0, please follow steps to resolve.", LocalDate.of(2024, 7, 19))
+    WarningCollector.addPipelineWarning("deprecated_gradle_library", "The properties-volume-spring-boot-starter is deprecated since spring-boot: 2.4.0, please follow steps to resolve.", LocalDate.of(2024, 7, 24))
   }
   sh 'rm -f check-deprecated-properties-volume-spring-boot-starter.sh'
 


### PR DESCRIPTION
Increase properties-volume-spring-boot-starter is deprecated by 2 days

- Requested by a team: https://hmcts-reform.slack.com/archives/C8SR5CAMU/p1721645914904969

They are aware of the deprecated version and planning to rollout this week. 

This PR is to unblock a business critical fix