### PR TITLE
Revert "Temporarily disable artifactory"

### DIFF
--- a/resources/uk/gov/hmcts/gradle/init.gradle
+++ b/resources/uk/gov/hmcts/gradle/init.gradle
@@ -4,18 +4,16 @@ def mirrorHost = nonProdName == "sandbox" || nonProdName == "sbox" ? 'artifactor
 def mirrorUrl = "https://${mirrorHost}.platform.hmcts.net/artifactory/maven-remotes"
 
 allprojects {
-  /*
   repositories {
     maven {
       url mirrorUrl
     }
-  }*/
+  }
   buildscript {
     repositories {
-      /*
       maven {
         url mirrorUrl
-      }*/
+      }
       mavenCentral()
     }
     dependencies {
@@ -27,7 +25,7 @@ allprojects {
     doLast { println project.version }
   }
 }
-/*
+
 settingsEvaluated { settings ->
   settings.pluginManagement {
     repositories {
@@ -36,7 +34,7 @@ settingsEvaluated { settings ->
       }
     }
   }
-}*/
+}
 
 allprojects {
   afterEvaluate { project ->


### PR DESCRIPTION
Reverts hmcts/cnp-jenkins-library#1266

We have now fully deployed artifactory via helm charts and have tested this works on a branch of jenkins-library
Tested a few more places too, happy that this is working
Checks are unrelated issues

Reverting this PR lets builds use artifactory again