### PR TITLE
DTSPO-17617 - remove onDemand from test repos

### DIFF
--- a/vars/spinInfra.groovy
+++ b/vars/spinInfra.groovy
@@ -72,7 +72,7 @@ def call(Map<String, ?> params) {
         if (Environment.toTagName(config.environment) == "sandbox" &&
             !builtFrom.toLowerCase().contains("cnp-plum")) {
             tags = tags + [startupMode: "onDemand"]
-          } else if { (Environment.toTagName(config.environment) == "sandbox" &&
+          } else if (Environment.toTagName(config.environment) == "sandbox" &&
             !builtFrom.toLowerCase().contains("sds-toffee")) {
             tags = tags + [startupMode: "onDemand"]
         }

--- a/vars/spinInfra.groovy
+++ b/vars/spinInfra.groovy
@@ -70,7 +70,7 @@ def call(Map<String, ?> params) {
         }
 
         if (Environment.toTagName(config.environment) == "sandbox" &&
-            !builtFrom.toLowerCase().contains("cnp-plum")) {
+            !config.Product == "plum") {
             tags = tags + [startupMode: "onDemand"]
           // } else if (Environment.toTagName(config.environment) == "sandbox" &&
           //   !builtFrom.toLowerCase().contains("sds-toffee")) {

--- a/vars/spinInfra.groovy
+++ b/vars/spinInfra.groovy
@@ -68,7 +68,8 @@ def call(Map<String, ?> params) {
         if (Environment.toTagName(config.environment) != "production") {
           tags = tags + [autoShutdown: "true"]
         }
-        if (Environment.toTagName(config.environment) == "sandbox") {
+        if (Environment.toTagName(config.environment) == "sandbox" &&
+          builtFrom != "https://github.com/HMCTS/cnp-plum-recipes-service.git") {
           tags = tags + [startupMode: "onDemand"]
         }
         if (changeUrl && changeUrl != "null" && changeUrl != "") {

--- a/vars/spinInfra.groovy
+++ b/vars/spinInfra.groovy
@@ -70,7 +70,7 @@ def call(Map<String, ?> params) {
         }
 
         if (Environment.toTagName(config.environment) == "sandbox" &&
-            !config.Product == "plum") {
+            (!config.product == "plum" || !config.product == "toffee")) {
             tags = tags + [startupMode: "onDemand"]
           // } else if (Environment.toTagName(config.environment) == "sandbox" &&
           //   !builtFrom.toLowerCase().contains("sds-toffee")) {

--- a/vars/spinInfra.groovy
+++ b/vars/spinInfra.groovy
@@ -69,7 +69,7 @@ def call(Map<String, ?> params) {
           tags = tags + [autoShutdown: "true"]
         }
         if (Environment.toTagName(config.environment) == "sandbox" &&
-            (!builtFrom.toLowerCase().contains("cnp-plum") || !builtFrom.toLowerCase().contains("sds-toffee"))) {
+            !builtFrom.toLowerCase().contains("cnp-plum")) {
             tags = tags + [startupMode: "onDemand"]
           }
         if (changeUrl && changeUrl != "null" && changeUrl != "") {

--- a/vars/spinInfra.groovy
+++ b/vars/spinInfra.groovy
@@ -69,7 +69,7 @@ def call(Map<String, ?> params) {
           tags = tags + [autoShutdown: "true"]
         }
         if (Environment.toTagName(config.environment) == "sandbox" &&
-          builtFrom != "https://github.com/HMCTS/cnp-plum-recipes-service.git") {
+          (builtFrom.toLowerCase().contains("cnp-plum") || builtFrom.toLowerCase().contains("sds-toffee"))) {
           tags = tags + [startupMode: "onDemand"]
         }
         if (changeUrl && changeUrl != "null" && changeUrl != "") {

--- a/vars/spinInfra.groovy
+++ b/vars/spinInfra.groovy
@@ -69,7 +69,7 @@ def call(Map<String, ?> params) {
           tags = tags + [autoShutdown: "true"]
         }
         if (Environment.toTagName(config.environment) == "sandbox" &&
-          (builtFrom.toLowerCase().!contains("cnp-plum") || builtFrom.toLowerCase().!contains("sds-toffee"))) {
+          (!builtFrom.toLowerCase().contains("cnp-plum") || !builtFrom.toLowerCase().contains("sds-toffee"))) {
           tags = tags + [startupMode: "onDemand"]
         }
         if (changeUrl && changeUrl != "null" && changeUrl != "") {

--- a/vars/spinInfra.groovy
+++ b/vars/spinInfra.groovy
@@ -69,7 +69,9 @@ def call(Map<String, ?> params) {
           tags = tags + [autoShutdown: "true"]
         }
         if (Environment.toTagName(config.environment) == "sandbox" &&
-          !builtFrom.toLowerCase().contains("cnp-plum")) {
+            (!builtFrom.toLowerCase().contains("cnp-plum") || !builtFrom.toLowerCase().contains("sds-toffee"))) {
+            tags = tags + [startupMode: "onDemand"]
+          }
           tags = tags + [startupMode: "onDemand"]
         }
         if (changeUrl && changeUrl != "null" && changeUrl != "") {

--- a/vars/spinInfra.groovy
+++ b/vars/spinInfra.groovy
@@ -69,7 +69,7 @@ def call(Map<String, ?> params) {
           tags = tags + [autoShutdown: "true"]
         }
         if (Environment.toTagName(config.environment) == "sandbox" &&
-          (!builtFrom.toLowerCase().contains("cnp-plum") || !builtFrom.toLowerCase().contains("sds-toffee"))) {
+          !builtFrom.toLowerCase().contains("cnp-plum")) {
           tags = tags + [startupMode: "onDemand"]
         }
         if (changeUrl && changeUrl != "null" && changeUrl != "") {

--- a/vars/spinInfra.groovy
+++ b/vars/spinInfra.groovy
@@ -72,9 +72,6 @@ def call(Map<String, ?> params) {
         if (Environment.toTagName(config.environment) == "sandbox" &&
             (!config.product == "plum" || !config.product == "toffee")) {
             tags = tags + [startupMode: "onDemand"]
-          // } else if (Environment.toTagName(config.environment) == "sandbox" &&
-          //   !builtFrom.toLowerCase().contains("sds-toffee")) {
-          //   tags = tags + [startupMode: "onDemand"]
         }
 
         if (changeUrl && changeUrl != "null" && changeUrl != "") {

--- a/vars/spinInfra.groovy
+++ b/vars/spinInfra.groovy
@@ -72,9 +72,9 @@ def call(Map<String, ?> params) {
         if (Environment.toTagName(config.environment) == "sandbox" &&
             !builtFrom.toLowerCase().contains("cnp-plum")) {
             tags = tags + [startupMode: "onDemand"]
-          } else if (Environment.toTagName(config.environment) == "sandbox" &&
-            !builtFrom.toLowerCase().contains("sds-toffee")) {
-            tags = tags + [startupMode: "onDemand"]
+          // } else if (Environment.toTagName(config.environment) == "sandbox" &&
+          //   !builtFrom.toLowerCase().contains("sds-toffee")) {
+          //   tags = tags + [startupMode: "onDemand"]
         }
 
         if (changeUrl && changeUrl != "null" && changeUrl != "") {

--- a/vars/spinInfra.groovy
+++ b/vars/spinInfra.groovy
@@ -72,8 +72,6 @@ def call(Map<String, ?> params) {
             (!builtFrom.toLowerCase().contains("cnp-plum") || !builtFrom.toLowerCase().contains("sds-toffee"))) {
             tags = tags + [startupMode: "onDemand"]
           }
-          tags = tags + [startupMode: "onDemand"]
-        }
         if (changeUrl && changeUrl != "null" && changeUrl != "") {
           tags = tags + [changeUrl: changeUrl]
         }

--- a/vars/spinInfra.groovy
+++ b/vars/spinInfra.groovy
@@ -68,10 +68,15 @@ def call(Map<String, ?> params) {
         if (Environment.toTagName(config.environment) != "production") {
           tags = tags + [autoShutdown: "true"]
         }
+
         if (Environment.toTagName(config.environment) == "sandbox" &&
             !builtFrom.toLowerCase().contains("cnp-plum")) {
             tags = tags + [startupMode: "onDemand"]
-          }
+          } else if { (Environment.toTagName(config.environment) == "sandbox" &&
+            !builtFrom.toLowerCase().contains("sds-toffee")) {
+            tags = tags + [startupMode: "onDemand"]
+        }
+
         if (changeUrl && changeUrl != "null" && changeUrl != "") {
           tags = tags + [changeUrl: changeUrl]
         }

--- a/vars/spinInfra.groovy
+++ b/vars/spinInfra.groovy
@@ -69,7 +69,7 @@ def call(Map<String, ?> params) {
           tags = tags + [autoShutdown: "true"]
         }
         if (Environment.toTagName(config.environment) == "sandbox" &&
-          (builtFrom.toLowerCase().contains("cnp-plum") || builtFrom.toLowerCase().contains("sds-toffee"))) {
+          (builtFrom.toLowerCase().!contains("cnp-plum") || builtFrom.toLowerCase().!contains("sds-toffee"))) {
           tags = tags + [startupMode: "onDemand"]
         }
         if (changeUrl && changeUrl != "null" && changeUrl != "") {


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-17617

Plum and toffee flexible servers have been reduced to burstable SKU which is cheaper.
Adding a condition here so the sandbox pipelines don't set the onDemand tag which will ensure these servers are started every morning
This will allow daily checks to succeed without manual intervention, whilst ensuring little or no extra cost.