### PR TITLE
DTSPO-17617 - Update onDemand logic

### DIFF
--- a/vars/spinInfra.groovy
+++ b/vars/spinInfra.groovy
@@ -70,7 +70,7 @@ def call(Map<String, ?> params) {
         }
 
         if (Environment.toTagName(config.environment) == "sandbox" &&
-            (!config.product == "plum" || !config.product == "toffee")) {
+            (config.product != "plum" && config.product != "toffee")) {
             tags = tags + [startupMode: "onDemand"]
         }
 


### PR DESCRIPTION
The pipeline test apps like apple were not getting the `onDemand` tag as expected.

Updating the logic to fix this.