### PR TITLE
Allow Java21 on yarn builds

### DIFF
--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -397,11 +397,11 @@ EOF
     super.setupToolVersion()
     // Java required on nodejs pipeline, if data import only available as java job, but project itself is nodejs
     def statusCodeJava21 = steps.sh script: 'grep -F "JavaLanguageVersion.of(21)" build.gradle', returnStatus: true
-    if (statusCodeJava21 == 0) {
-      def javaHomeLocation = steps.sh(script: 'ls -d /usr/lib/jvm/temurin-21-jdk-*', returnStdout: true, label: 'Detect Java location').trim()
-      steps.env.JAVA_HOME = javaHomeLocation
-      steps.env.PATH = "${steps.env.JAVA_HOME}/bin:${steps.env.PATH}"
-    }
+    localSteps.sh "echo setting_java_version"
+
+    def javaHomeLocation = steps.sh(script: 'ls -d /usr/lib/jvm/temurin-21-jdk-*', returnStdout: true, label: 'Detect Java location').trim()
+    steps.env.JAVA_HOME = javaHomeLocation
+    steps.env.PATH = "${steps.env.JAVA_HOME}/bin:${steps.env.PATH}"
 
     localSteps.sh "java -version"
     nagAboutOldNodeJSVersions()

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -395,6 +395,7 @@ EOF
   @Override
   def setupToolVersion() {
     super.setupToolVersion()
+    localSteps.sh "echo java_version_lookup"
     localSteps.sh "java -version"
     nagAboutOldNodeJSVersions()
   }

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -395,7 +395,17 @@ EOF
   @Override
   def setupToolVersion() {
     super.setupToolVersion()
-    localSteps.sh "echo java_version_lookup"
+    // Java required on nodejs pipeline, if data import only available as java job, but project itself is nodejs
+    def statusCodeJava21 = steps.sh script: 'grep -F "JavaLanguageVersion.of(21)" build.gradle', returnStatus: true
+    if (statusCodeJava21 == 0) {
+      def javaHomeLocation = steps.sh(script: 'ls -d /usr/lib/jvm/temurin-21-jdk-*', returnStdout: true, label: 'Detect Java location').trim()
+      steps.env.JAVA_HOME = javaHomeLocation
+      steps.env.PATH = "${steps.env.JAVA_HOME}/bin:${steps.env.PATH}"
+    }
+
+    // Workaround jacocoTestReport issue https://github.com/gradle/gradle/issues/18508#issuecomment-1049998305
+    steps.env.GRADLE_OPTS = "--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED"
+    gradle("--version") // ensure wrapper has been downloaded
     localSteps.sh "java -version"
     nagAboutOldNodeJSVersions()
   }

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -396,7 +396,9 @@ EOF
   def setupToolVersion() {
     super.setupToolVersion()
     // Java required on nodejs pipeline, if data import only available as java job, but project itself is nodejs
-    def statusCodeJava21 = steps.sh script: 'grep -F "JavaLanguageVersion.of(21)" aat/build.gradle', returnStatus: true
+    def statusCodeJava21 = steps.sh(script: """
+      find . -name "build.gradle" -exec grep -l "JavaLanguageVersion.of(21)" {} + > /dev/null
+      """, returnStatus: true)    
     if (statusCodeJava21 == 0) {
       def javaHomeLocation = steps.sh(script: 'ls -d /usr/lib/jvm/temurin-21-jdk-*', returnStdout: true, label: 'Detect Java location').trim()
       steps.env.JAVA_HOME = javaHomeLocation

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -396,12 +396,12 @@ EOF
   def setupToolVersion() {
     super.setupToolVersion()
     // Java required on nodejs pipeline, if data import only available as java job, but project itself is nodejs
-    def statusCodeJava21 = steps.sh script: 'grep -F "JavaLanguageVersion.of(21)" build.gradle', returnStatus: true
-    localSteps.sh "echo setting_java_version"
-
-    def javaHomeLocation = steps.sh(script: 'ls -d /usr/lib/jvm/temurin-21-jdk-*', returnStdout: true, label: 'Detect Java location').trim()
-    steps.env.JAVA_HOME = javaHomeLocation
-    steps.env.PATH = "${steps.env.JAVA_HOME}/bin:${steps.env.PATH}"
+    def statusCodeJava21 = steps.sh script: 'grep -F "JavaLanguageVersion.of(21)" aat/build.gradle', returnStatus: true
+    if (statusCodeJava21 == 0) {
+      def javaHomeLocation = steps.sh(script: 'ls -d /usr/lib/jvm/temurin-21-jdk-*', returnStdout: true, label: 'Detect Java location').trim()
+      steps.env.JAVA_HOME = javaHomeLocation
+      steps.env.PATH = "${steps.env.JAVA_HOME}/bin:${steps.env.PATH}"
+    }
 
     localSteps.sh "java -version"
     nagAboutOldNodeJSVersions()

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -395,6 +395,7 @@ EOF
   @Override
   def setupToolVersion() {
     super.setupToolVersion()
+    localSteps.sh "java -version"
     nagAboutOldNodeJSVersions()
   }
 

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -403,9 +403,6 @@ EOF
       steps.env.PATH = "${steps.env.JAVA_HOME}/bin:${steps.env.PATH}"
     }
 
-    // Workaround jacocoTestReport issue https://github.com/gradle/gradle/issues/18508#issuecomment-1049998305
-    steps.env.GRADLE_OPTS = "--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED"
-    gradle("--version") // ensure wrapper has been downloaded
     localSteps.sh "java -version"
     nagAboutOldNodeJSVersions()
   }


### PR DESCRIPTION
Weird edge case where a nodejs pipeline requires a java based job

On a typical java build, we have this logic during that groovy call: https://github.com/hmcts/cnp-jenkins-library/blob/034812d8daebc9396c43e48ae3d6333b60083a31/src/uk/gov/hmcts/contino/GradleBuilder.groovy#L250-L272
But your build here uses yarn, which uses [YarnBuilder](https://github.com/hmcts/cnp-jenkins-library/blob/034812d8daebc9396c43e48ae3d6333b60083a31/src/uk/gov/hmcts/contino/YarnBuilder.groovy) — my change on the branch added a java -version lookup https://github.com/hmcts/cnp-jenkins-library/compare/master...java-home-for-node-builds — if you look at the console log of that PR 444 i opened, you’ll see this:

```
16:11:53  + echo java_version_lookup
16:11:53  java_version_lookup
16:11:53  [Pipeline] sh
16:11:53  + java -version
16:11:53  openjdk version "17.0.12" 2024-07-16
16:11:53  OpenJDK Runtime Environment (build 17.0.12+7-Ubuntu-1ubuntu220.04)
16:11:53  OpenJDK 64-Bit Server VM (build 17.0.12+7-Ubuntu-1ubuntu220.04, mixed mode, sharing)
```

This change allows users to use java21 in Yarn Builds if they wish to


Probably there's not many other cases using java on node builds, but I still made this conditional so it doesn't break anything once merged
