### PR TITLE
DTSPO-22692 - Remove az acr helm

### DIFF
--- a/src/uk/gov/hmcts/contino/Helm.groovy
+++ b/src/uk/gov/hmcts/contino/Helm.groovy
@@ -51,7 +51,7 @@ class Helm {
   }
 
   def addRepo() {
-    this.acr.az "acr helm repo add --subscription ${registrySubscription} --name ${registryName}"
+    this.steps.sh(script: "helm repo add --subscription ${registrySubscription} --name ${registryName}", returnStdout: true).trim()
   }
 
   def authenticateAcr() {

--- a/src/uk/gov/hmcts/contino/Helm.groovy
+++ b/src/uk/gov/hmcts/contino/Helm.groovy
@@ -38,7 +38,6 @@ class Helm {
     authenticateAcr()
     configureAcr()
     removeRepo()
-    // addRepo()
   }
 
   def configureAcr() {
@@ -48,11 +47,6 @@ class Helm {
   def removeRepo() {
     this.steps.echo "Clear out helm repo before re-adding"
     this.steps.sh(label: "helm repo rm ${registryName}", script: 'helm repo rm $REGISTRY_NAME || echo "Helm repo may not exist on disk, skipping remove"', env: [REGISTRY_NAME: registryName])
-  }
-
-  def addRepo() {
-    this.steps.sh(script: "helm repo add ${registryName} https://${registryName}.azurecr.io/helm/v1/repo", returnStdout: true).trim()
-    this.steps.sh(script: "helm repo add ${registryName}-oci oci://${registryName}.azurecr.io/helm", returnStdout: true).trim()
   }
 
   def authenticateAcr() {
@@ -70,7 +64,6 @@ class Helm {
     this.steps.echo "Version of chart locally is: ${version}"
     def resultOfSearch
     try {
-        // addRepo()
         this.steps.sh(script: "helm pull ${registryName}/${this.chartName} --version ${version} -d .", returnStdout: true).trim()
         resultOfSearch = version
     } catch(ignored) {
@@ -92,7 +85,6 @@ class Helm {
 
   def publishToGitIfNotExists(List<String> values) {
     authenticateAcr()
-    // addRepo()
     lint(values)
 
     def version = this.steps.sh(script: "helm inspect chart ${this.chartLocation}  | grep ^version | cut -d  ':' -f 2", returnStdout: true).trim()

--- a/src/uk/gov/hmcts/contino/Helm.groovy
+++ b/src/uk/gov/hmcts/contino/Helm.groovy
@@ -38,7 +38,7 @@ class Helm {
     authenticateAcr()
     configureAcr()
     removeRepo()
-    addRepo()
+    // addRepo()
   }
 
   def configureAcr() {
@@ -70,7 +70,7 @@ class Helm {
     this.steps.echo "Version of chart locally is: ${version}"
     def resultOfSearch
     try {
-        addRepo()
+        // addRepo()
         this.steps.sh(script: "helm pull ${registryName}/${this.chartName} --version ${version} -d .", returnStdout: true).trim()
         resultOfSearch = version
     } catch(ignored) {
@@ -92,7 +92,7 @@ class Helm {
 
   def publishToGitIfNotExists(List<String> values) {
     authenticateAcr()
-    addRepo()
+    // addRepo()
     lint(values)
 
     def version = this.steps.sh(script: "helm inspect chart ${this.chartLocation}  | grep ^version | cut -d  ':' -f 2", returnStdout: true).trim()

--- a/src/uk/gov/hmcts/contino/Helm.groovy
+++ b/src/uk/gov/hmcts/contino/Helm.groovy
@@ -51,7 +51,8 @@ class Helm {
   }
 
   def addRepo() {
-    this.steps.sh(script: "helm repo add --subscription ${registrySubscription} --name ${registryName}", returnStdout: true).trim()
+    this.steps.sh(script: "helm repo add ${registryName} https://${registryName}.azurecr.io/helm/v1/repo", returnStdout: true).trim()
+    this.steps.sh(script: "helm repo add ${registryName}-oci oci://${registryName}.azurecr.io/helm", returnStdout: true).trim()
   }
 
   def authenticateAcr() {


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-22692

Removing `az acr helm` commands as these are deprecated and are helm v2 only.

Removing the `addRepo` function as it should not be required now. `az acr login` is ran before the chart is pulled which should be sufficient.

https://learn.microsoft.com/en-gb/azure/container-registry/container-registry-helm-repos

Tested also with https://github.com/hmcts/cnp-plum-recipes-service/pull/1098 and the chart pull still works.