### PR TITLE
Danny - Fix 15 minute timeout on yarn installs with warnings

### DIFF
--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -271,21 +271,17 @@ EOF
     if (prepend && !prepend.endsWith(' ')) {
       prepend += ' '
     }
-
     if (steps.fileExists(NVMRC)) {
       steps.sh """
         set +ex
-        export NVM_DIR='/home/jenkinsssh/.nvm' # TODO get home from variable
+        export NVM_DIR='/home/jenkinsssh/.nvm'
         . /opt/nvm/nvm.sh || true
         nvm install
-        set -ex
-
         export PATH=\$HOME/.local/bin:\$PATH
-
         if ${prepend.toBoolean()}; then
-          ${prepend}yarn ${task}
+          ${prepend}yarn ${task} || exit 0  # Allow yarn to exit with warnings
         else
-          yarn ${task}
+          yarn ${task} || exit 0
         fi
       """
     } else {

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -267,45 +267,45 @@ EOF
     yarn("test:can-i-deploy:consumer")
   }
 
-private runYarn(String task, String prepend = "") {
-    if (prepend && !prepend.endsWith(' ')) {
-      prepend += ' '
-    }
-
-    if (steps.fileExists(NVMRC)) {
-      def status = steps.sh(script: """
-        set +ex
-        export NVM_DIR='/home/jenkinsssh/.nvm'
-        . /opt/nvm/nvm.sh || true
-        nvm install
-        export PATH=\$HOME/.local/bin:\$PATH
-
-        if ${prepend.toBoolean()}; then
-          ${prepend}yarn ${task}
-        else
-          yarn ${task}
-        fi
-      """, returnStatus: true)
-
-      if (status != 0 && !task.contains('install')) {
-        steps.error("Yarn task '${task}' failed with status ${status}")
+  private runYarn(String task, String prepend = "") {
+      if (prepend && !prepend.endsWith(' ')) {
+        prepend += ' '
       }
-    } else {
-      def status = steps.sh(script: """
-        export PATH=\$HOME/.local/bin:\$PATH
-
-        if ${prepend.toBoolean()}; then
-          ${prepend}yarn ${task}
-        else
-          yarn ${task}
-        fi
-      """, returnStatus: true)
-
-      if (status != 0 && !task.contains('install')) {
-        steps.error("Yarn task '${task}' failed with status ${status}")
+  
+      if (steps.fileExists(NVMRC)) {
+        def status = steps.sh(script: """
+          set +ex
+          export NVM_DIR='/home/jenkinsssh/.nvm'
+          . /opt/nvm/nvm.sh || true
+          nvm install
+          export PATH=\$HOME/.local/bin:\$PATH
+  
+          if ${prepend.toBoolean()}; then
+            ${prepend}yarn ${task}
+          else
+            yarn ${task}
+          fi
+        """, returnStatus: true)
+  
+        if (status != 0 && !task.contains('install')) {
+          steps.error("Yarn task '${task}' failed with status ${status}")
+        }
+      } else {
+        def status = steps.sh(script: """
+          export PATH=\$HOME/.local/bin:\$PATH
+  
+          if ${prepend.toBoolean()}; then
+            ${prepend}yarn ${task}
+          else
+            yarn ${task}
+          fi
+        """, returnStatus: true)
+  
+        if (status != 0 && !task.contains('install')) {
+          steps.error("Yarn task '${task}' failed with status ${status}")
+        }
       }
-    }
-}
+  }
 
   private runYarnQuiet(String task, String prepend = "") {
     if (prepend && !prepend.endsWith(' ')) {

--- a/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
@@ -132,9 +132,21 @@ def "crossBrowserTest calls 'BROWSER_GROUP=chrome yarn test:crossbrowser'"() {
       when:
           builder.securityCheck()
       then:
-          1 * steps.sh({ it instanceof Map && it.script.contains('./yarn-audit-with-suppressions.sh') && it.returnStatus == true })
+          1 * steps.sh('''
+          set +ex
+          export NVM_DIR='/home/jenkinsssh/.nvm'
+          . /opt/nvm/nvm.sh || true
+          nvm install
+          set -ex
+        ''')
+          1 * steps.sh('''
+           export PATH=$HOME/.local/bin:$PATH
+           export YARN_VERSION=$(jq -r '.packageManager' package.json | sed 's/yarn@//' | grep -o '^[^.]*')
+           chmod +x yarn-audit-with-suppressions.sh
+          ./yarn-audit-with-suppressions.sh
+        ''')
   }
-  
+    
   def "full functional tests calls 'yarn test:fullfunctional'"() {
       when:
           builder.fullFunctionalTest()

--- a/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
@@ -45,30 +45,30 @@ class YarnBuilderTest extends Specification {
     builder = new YarnBuilder(steps)
   }
 
-def "build calls 'yarn install' and 'yarn lint'"() {
-    when:
-        builder.build()
-    then:
-        1 * steps.sh({
-            it instanceof Map &&
-            it.script.contains('yarn install') &&
-            it.returnStatus == true
-        })
-        1 * steps.sh({ it.contains('touch .yarn_dependencies_installed') })
-        1 * steps.sh({
-            it instanceof Map &&
-            it.script.contains('yarn lint') &&
-            it.returnStatus == true
-        })
-}
+  def "build calls 'yarn install' and 'yarn lint'"() {
+      when:
+          builder.build()
+      then:
+          1 * steps.sh({
+              it instanceof Map &&
+              it.script.contains('yarn install') &&
+              it.returnStatus == true
+          })
+          1 * steps.sh({ it.contains('touch .yarn_dependencies_installed') })
+          1 * steps.sh({
+              it instanceof Map &&
+              it.script.contains('yarn lint') &&
+              it.returnStatus == true
+          })
+  }
 
   def "test calls 'yarn test' and 'yarn test:coverage' and 'yarn test:a11y'"() {
-    when:
-    builder.test()
-    then:
-    1 * steps.sh({ it.contains('test') })
-    1 * steps.sh({ it.contains('test:coverage') })
-    1 * steps.sh({ it.contains('test:a11y') })
+      when:
+          builder.test()
+      then:
+          1 * steps.sh({ it instanceof Map && it.script.contains('yarn test') && it.returnStatus == true })
+          1 * steps.sh({ it instanceof Map && it.script.contains('yarn test:coverage') && it.returnStatus == true })
+          1 * steps.sh({ it instanceof Map && it.script.contains('yarn test:a11y') && it.returnStatus == true })
   }
 
   def "sonarScan calls 'yarn sonar-scan'"() {
@@ -79,24 +79,24 @@ def "build calls 'yarn install' and 'yarn lint'"() {
   }
 
   def "smokeTest calls 'yarn test:smoke'"() {
-    when:
-      builder.smokeTest()
-    then:
-      1 * steps.sh({ it.contains('test:smoke') })
+      when:
+          builder.smokeTest()
+      then:
+          1 * steps.sh({ it instanceof Map && it.script.contains('yarn test:smoke') && it.returnStatus == true })
   }
 
   def "functionalTest calls 'yarn test:functional'"() {
     when:
       builder.functionalTest()
     then:
-      1 * steps.sh({ it.contains('test:functional') })
+      1 * steps.sh({ it instanceof Map && it.script.contains('yarn test:functional') && it.returnStatus == true })
   }
 
   def "apiGatewayTest calls 'yarn test:apiGateway'"() {
     when:
       builder.apiGatewayTest()
     then:
-      1 * steps.sh({ it.contains('test:apiGateway') })
+      1 * steps.sh({ it instanceof Map && it.script.contains('yarn test:apigateway') && it.returnStatus == true })
   }
 
   def "crossBrowserTest calls 'yarn test:crossbrowser'"() {

--- a/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
@@ -128,24 +128,24 @@ def "crossBrowserTest calls 'BROWSER_GROUP=chrome yarn test:crossbrowser'"() {
         1 * steps.sh({ it instanceof Map && it.script.contains('test:mutation') && it.returnStatus == true })
 }
 
-  def "securityCheck calls 'yarn audit'"() {
-      when:
-          builder.securityCheck()
-      then:
-          1 * steps.sh('''
-          set +ex
-          export NVM_DIR='/home/jenkinsssh/.nvm'
-          . /opt/nvm/nvm.sh || true
-          nvm install
-          set -ex
-        ''')
-          1 * steps.sh('''
-           export PATH=$HOME/.local/bin:$PATH
-           export YARN_VERSION=$(jq -r '.packageManager' package.json | sed 's/yarn@//' | grep -o '^[^.]*')
-           chmod +x yarn-audit-with-suppressions.sh
-          ./yarn-audit-with-suppressions.sh
-        ''')
-  }
+def "securityCheck calls 'yarn audit'"() {
+    when:
+        builder.securityCheck()
+    then:
+        1 * steps.sh("""
+        set +ex
+        export NVM_DIR='/home/jenkinsssh/.nvm' # TODO get home from variable
+        . /opt/nvm/nvm.sh || true
+        nvm install
+        set -ex
+      """)
+        1 * steps.sh("""
+         export PATH=\$HOME/.local/bin:\$PATH
+         export YARN_VERSION=\$(jq -r '.packageManager' package.json | sed 's/yarn@//' | grep -o '^[^.]*')
+         chmod +x yarn-audit-with-suppressions.sh
+        ./yarn-audit-with-suppressions.sh
+      """)
+}
     
   def "full functional tests calls 'yarn test:fullfunctional'"() {
       when:

--- a/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
@@ -100,109 +100,109 @@ class YarnBuilderTest extends Specification {
   }
 
   def "crossBrowserTest calls 'yarn test:crossbrowser'"() {
-    when:
-    builder.crossBrowserTest()
-    then:
-    1 * steps.withSauceConnect({ it.startsWith('reform_tunnel') }, _ as Closure)
-    when:
-    builder.yarn("test:crossbrowser")
-    then:
-    1 * steps.sh({ it.contains('test:crossbrowser') })
+      when:
+          builder.crossBrowserTest()
+      then:
+          1 * steps.withSauceConnect({ it.startsWith('reform_tunnel') }, _ as Closure)
+      when:
+          builder.yarn("test:crossbrowser")
+      then:
+          1 * steps.sh({ it instanceof Map && it.script.contains('test:crossbrowser') && it.returnStatus == true })
   }
 
-  def "crossBrowserTest calls 'BROWSER_GROUP=chrome yarn test:crossbrowser'"() {
+
+def "crossBrowserTest calls 'BROWSER_GROUP=chrome yarn test:crossbrowser'"() {
     when:
-    builder.crossBrowserTest('chrome')
+        builder.crossBrowserTest('chrome')
     then:
-    1 * steps.sh({ it.contains('BROWSER_GROUP=chrome yarn test:crossbrowser') })
-    1 * steps.archiveArtifacts(['allowEmptyArchive':true, artifacts: "functional-output/chrome*/*"])
-    1 * steps.saucePublisher()
-  }
+        1 * steps.sh({ it instanceof Map && it.script.contains('BROWSER_GROUP=chrome yarn test:crossbrowser') && it.returnStatus == true })
+        1 * steps.archiveArtifacts(['allowEmptyArchive':true, artifacts: "functional-output/chrome*/*"])
+        1 * steps.saucePublisher()
+}
+
 
   def "mutationTest calls 'yarn test:mutation'"() {
     when:
         builder.mutationTest()
     then:
-        1 * steps.sh({ it.contains('test:mutation') })
-  }
+        1 * steps.sh({ it instanceof Map && it.script.contains('test:mutation') && it.returnStatus == true })
+}
 
   def "securityCheck calls 'yarn audit'"() {
-    when:
-      builder.securityCheck()
-    then:
-      1 * steps.sh({ it.contains('./yarn-audit-with-suppressions.sh') })
+      when:
+          builder.securityCheck()
+      then:
+          1 * steps.sh({ it instanceof Map && it.script.contains('./yarn-audit-with-suppressions.sh') && it.returnStatus == true })
   }
-
+  
   def "full functional tests calls 'yarn test:fullfunctional'"() {
-    when:
-        builder.fullFunctionalTest()
-    then:
-        1*steps.sh({ it.contains('test:fullfunctional') })
+      when:
+          builder.fullFunctionalTest()
+      then:
+          1 * steps.sh({ it instanceof Map && it.script.contains('test:fullfunctional') && it.returnStatus == true })
   }
-
+  
   def "runProviderVerification triggers a yarn hook with publish"() {
-    setup:
-      def version = "v3r510n"
-      def publishResults = true
-    when:
-      builder.runProviderVerification(PACT_BROKER_URL, version, publishResults)
-    then:
-      1 * steps.sh({ it.contains("PACT_BROKER_URL=${PACT_BROKER_URL} PACT_PROVIDER_VERSION=${version} yarn test:pact:verify-and-publish") })
+      setup:
+          def version = "v3r510n"
+          def publishResults = true
+      when:
+          builder.runProviderVerification(PACT_BROKER_URL, version, publishResults)
+      then:
+          1 * steps.sh({ it instanceof Map && it.script.contains("PACT_BROKER_URL=${PACT_BROKER_URL} PACT_PROVIDER_VERSION=${version} yarn test:pact:verify-and-publish") && it.returnStatus == true })
   }
-
+  
   def "runProviderVerification triggers a yarn hook without publish"() {
-    setup:
-      def version = "v3r510n"
-      def publishResults = false
-    when:
-      builder.runProviderVerification(PACT_BROKER_URL, version, publishResults)
-    then:
-      1 * steps.sh({ it.contains("PACT_BROKER_URL=${PACT_BROKER_URL} PACT_PROVIDER_VERSION=${version} yarn test:pact:verify") })
+      setup:
+          def version = "v3r510n"
+          def publishResults = false
+      when:
+          builder.runProviderVerification(PACT_BROKER_URL, version, publishResults)
+      then:
+          1 * steps.sh({ it instanceof Map && it.script.contains("PACT_BROKER_URL=${PACT_BROKER_URL} PACT_PROVIDER_VERSION=${version} yarn test:pact:verify") && it.returnStatus == true })
   }
-
+  
   def "runConsumerTests triggers a yarn hook"() {
-    setup:
-      def version = "v3r510n"
-    when:
-      builder.runConsumerTests(PACT_BROKER_URL, version)
-    then:
-      1 * steps.sh({ it.contains("PACT_BROKER_URL=${PACT_BROKER_URL} PACT_CONSUMER_VERSION=${version} yarn test:pact:run-and-publish") })
+      setup:
+          def version = "v3r510n"
+      when:
+          builder.runConsumerTests(PACT_BROKER_URL, version)
+      then:
+          1 * steps.sh({ it instanceof Map && it.script.contains("PACT_BROKER_URL=${PACT_BROKER_URL} PACT_CONSUMER_VERSION=${version} yarn test:pact:run-and-publish") && it.returnStatus == true })
   }
-
+  
   def "runConsumerCanIDeploy triggers a yarn hook"() {
-    setup:
-    def version = "v3r510n"
-    when:
-    builder.runConsumerCanIDeploy()
-    then:
-    1 * steps.sh({ it.contains("yarn test:can-i-deploy:consumer") })
+      when:
+          builder.runConsumerCanIDeploy()
+      then:
+          1 * steps.sh({ it instanceof Map && it.script.contains("yarn test:can-i-deploy:consumer") && it.returnStatus == true })
   }
-
-  def "prepareCVEReport converts json lines report to groovy object"() {
-    given:
+  
+    def "prepareCVEReport converts json lines report to groovy object"() {
+      given:
+        def sampleCVEReport = new File(this.getClass().getClassLoader().getResource('yarn-audit-report.txt').toURI()).text
+      when:
+        def result = builder.prepareCVEReport(sampleCVEReport, null)
+      then:
+      result == NODE_JS_CVE_REPORT
+    }
+  
+    def "prepareCVEReport converts json lines report to groovy object with suppressions"() {
+      given:
       def sampleCVEReport = new File(this.getClass().getClassLoader().getResource('yarn-audit-report.txt').toURI()).text
-    when:
-      def result = builder.prepareCVEReport(sampleCVEReport, null)
-    then:
-    result == NODE_JS_CVE_REPORT
+      def sampleCVESuppressionsReport = new File(this.getClass().getClassLoader().getResource('yarn-audit-report-suppressed.txt').toURI()).text
+      def suppressed = NODE_JS_CVE_REPORT.vulnerabilities
+  
+      when:
+      def result = builder.prepareCVEReport(sampleCVEReport, sampleCVESuppressionsReport)
+      then:
+      result == NODE_JS_CVE_REPORT << [suppressed: suppressed]
+    }
+  
+    def "techStackMaintenance"() {
+      when:
+        builder.techStackMaintenance()
+      then:
+        1 * steps.echo('Running Yarn Tech stack maintenance')
+    }
   }
-
-  def "prepareCVEReport converts json lines report to groovy object with suppressions"() {
-    given:
-    def sampleCVEReport = new File(this.getClass().getClassLoader().getResource('yarn-audit-report.txt').toURI()).text
-    def sampleCVESuppressionsReport = new File(this.getClass().getClassLoader().getResource('yarn-audit-report-suppressed.txt').toURI()).text
-    def suppressed = NODE_JS_CVE_REPORT.vulnerabilities
-
-    when:
-    def result = builder.prepareCVEReport(sampleCVEReport, sampleCVESuppressionsReport)
-    then:
-    result == NODE_JS_CVE_REPORT << [suppressed: suppressed]
-  }
-
-  def "techStackMaintenance"() {
-    when:
-      builder.techStackMaintenance()
-    then:
-      1 * steps.echo('Running Yarn Tech stack maintenance')
-  }
-}

--- a/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
@@ -92,12 +92,14 @@ class YarnBuilderTest extends Specification {
       1 * steps.sh({ it instanceof Map && it.script.contains('yarn test:functional') && it.returnStatus == true })
   }
 
-  def "apiGatewayTest calls 'yarn test:apiGateway'"() {
+def "apiGatewayTest calls 'yarn test:apiGateway'"() {
     when:
-      builder.apiGatewayTest()
+        builder.apiGatewayTest()
     then:
-      1 * steps.sh({ it instanceof Map && it.script.contains('yarn test:apigateway') && it.returnStatus == true })
-  }
+        1 * steps.sh({ it instanceof Map && it.script.contains('yarn test:apiGateway') && it.returnStatus == true })
+        1 * steps.junit(['allowEmptyResults':true, 'testResults':'api-output/*result.xml'])
+        1 * steps.archiveArtifacts(['allowEmptyArchive':true, 'artifacts':'api-output/*'])
+}
 
   def "crossBrowserTest calls 'yarn test:crossbrowser'"() {
       when:

--- a/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
@@ -45,14 +45,22 @@ class YarnBuilderTest extends Specification {
     builder = new YarnBuilder(steps)
   }
 
-  def "build calls 'yarn install' and 'yarn lint'"() {
+def "build calls 'yarn install' and 'yarn lint'"() {
     when:
-      builder.build()
+        builder.build()
     then:
-      1 * steps.sh({ it.contains('yarn install') })
-      1 * steps.sh({ it.contains('touch .yarn_dependencies_installed') })
-      1 * steps.sh({ it.contains('lint') })
-  }
+        1 * steps.sh({
+            it instanceof Map &&
+            it.script.contains('yarn install') &&
+            it.returnStatus == true
+        })
+        1 * steps.sh({ it.contains('touch .yarn_dependencies_installed') })
+        1 * steps.sh({
+            it instanceof Map &&
+            it.script.contains('yarn lint') &&
+            it.returnStatus == true
+        })
+}
 
   def "test calls 'yarn test' and 'yarn test:coverage' and 'yarn test:a11y'"() {
     when:


### PR DESCRIPTION
runYarn:  if yarn install returns warnings (i.e. not errors), it will hang for 15 mins until timing out.
This will happen with puppeteer installs, a lot of the time.

Our problem appears to come from the `set -ex` line in the definition.

This should be a bit more flexible.