### PR TITLE
Update sauce connect syntax to match v5 version update

### DIFF
--- a/vars/withSauceConnect.groovy
+++ b/vars/withSauceConnect.groovy
@@ -8,8 +8,7 @@
  */
 def call(String sauceid, Closure body) {
     sauce(sauceid) {
-              sauceconnect(options: '--shared-tunnel --verbose --no-remove-colliding-tunnels --tunnel-identifier reformtunnel', useGeneratedTunnelIdentifier: false,
-                useLatestSauceConnect: true, verboseLogging: true) {
+            sauceconnect(options: '--shared-tunnel --verbose --tunnel-pool --tunnel-name reformtunnel', useGeneratedTunnelIdentifier: false, verboseLogging: true) {
             body()
         }
     }


### PR DESCRIPTION
This change is an update to the sauce connect syntax to match v5.
The plugin has upgraded over time and the latest version had breaking changes to syntax which needed to be updated to match those found in V5: https://docs.saucelabs.com/dev/cli/sauce-connect-5/run/ 