### PR TITLE
DTSPO-24173 - adding alertFilter config

### DIFF
--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -246,6 +246,7 @@ def call(params) {
                 stageWithAgent('Security scan', product) {
                   warnError('Failure in securityScan') {
                     env.ZAP_URL_EXCLUSIONS = config.securityScanUrlExclusions
+                    env.ALERT_FILTERS = config.securityScanAlertFilters
                     env.SCAN_TYPE = config.securityScanType
                     pcr.callAround('securityScan') {
                       timeout(time: config.securityScanTimeout, unit: 'MINUTES') {

--- a/vars/sectionNightlyTests.groovy
+++ b/vars/sectionNightlyTests.groovy
@@ -95,6 +95,7 @@ def call(pcr, config, pipelineType, String product, String component, String sub
       stageWithAgent('Security scan', product) {
         warnError('Failure in securityScan') {
           env.ZAP_URL_EXCLUSIONS = config.securityScanUrlExclusions
+          env.ALERT_FILTERS = config.securityScanAlertFilters
           env.SCAN_TYPE = config.securityScanType
           pcr.callAround('securityScan') {
             timeout(time: config.securityScanTimeout, unit: 'MINUTES') {


### PR DESCRIPTION
DTSPO-24173 - when comparing the Zap scan logic "urlExclusion" with "alertFilter" there appears to be missing configuration. This PR adds the missing bits of code to match the urlExclusions param.
