### PR TITLE
DTSPO-24490 Update deprecation scripts to pass exceptions per repo

### DIFF
--- a/src/uk/gov/hmcts/pipeline/DeprecationConfig.groovy
+++ b/src/uk/gov/hmcts/pipeline/DeprecationConfig.groovy
@@ -1,25 +1,47 @@
 package uk.gov.hmcts.pipeline
 
 class DeprecationConfig {
+    def steps
+    static def deprecationConfigInternal
 
-  def steps
-  static def deprecationConfigInternal
-
-  DeprecationConfig(steps){
-    this.steps = steps
-  }
-
-  def getDeprecationConfig() {
-    if (deprecationConfigInternal == null) {
-      def response = steps.httpRequest(
-        consoleLogResponseBody: true,
-        timeout: 10,
-        url: "https://raw.githubusercontent.com/hmcts/cnp-deprecation-map/master/nagger-versions.yaml",
-        validResponseCodes: '200'
-      )
-      deprecationConfigInternal = steps.readYaml(text: response.content)
+    DeprecationConfig(steps) {
+        this.steps = steps
     }
-    return deprecationConfigInternal
-  }
 
+    def getDeprecationConfig(String repoUrl = null) {
+        if (deprecationConfigInternal == null) {
+            def response = steps.httpRequest(
+                consoleLogResponseBody: true,
+                timeout: 10,
+                url: "https://raw.githubusercontent.com/hmcts/cnp-deprecation-map/master/nagger-versions.yaml",
+                validResponseCodes: '200'
+            )
+            deprecationConfigInternal = steps.readYaml(text: response.content)
+        }
+
+        // If no repoUrl is passed, return the raw deprecation configuration
+        if (!repoUrl) {
+            return deprecationConfigInternal
+        }
+
+        // Normalize repoUrl: trim, toLowerCase, and remove trailing ".git" if present.
+        def normalizedRepoUrl = repoUrl.trim().toLowerCase().replaceAll(/\.git$/, "")
+
+        // Process exceptions only when a repoUrl is provided
+        def configWithExceptions = deprecationConfigInternal.clone()
+        configWithExceptions.each { key, dependencies ->
+            dependencies.each { dependency, details ->
+                def exceptions = details.exceptions ?: []
+                exceptions.each { exception ->
+                    // Normalize exception repo to lowercase and remove trailing ".git" before comparison
+                    def normalizedExceptionRepo = exception.repo.trim().toLowerCase().replaceAll(/\.git$/, "")
+                    if (normalizedRepoUrl == normalizedExceptionRepo) {
+                        details.date_deadline = exception.date_deadline
+                    }
+                }
+            }
+        }
+
+        return configWithExceptions
+    }
 }

--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -68,7 +68,7 @@ def call(params) {
               }
               params.environment = params.environment.replace('idam-', '') // hack to workaround incorrect idam environment value
               log.info("Using AKS environment: ${params.environment}")
-              warnAboutDeprecatedChartConfig product: product, component: component
+              warnAboutDeprecatedChartConfig(product: product, component: component, repoUrl: (env.GIT_URL ?: 'unknown'))
               aksUrl = helmInstall(dockerImage, params)
               log.info("deployed component URL: ${aksUrl}")
               onPR {

--- a/vars/spinInfra.groovy
+++ b/vars/spinInfra.groovy
@@ -115,7 +115,7 @@ def call(Map<String, ?> params) {
             -backend-config "key=${config.productName}/${environmentDeploymentTarget}/terraform.tfstate"
         """
 
-        warnAboutOldTfAzureProvider(config.environment, config.product)
+        warnAboutOldTfAzureProvider(config.environment, config.product, builtFrom)
         warnAboutDeprecatedPostgres()
         
         env.TF_VAR_subscription = config.subscription

--- a/vars/warnAboutDeprecatedChartConfig.groovy
+++ b/vars/warnAboutDeprecatedChartConfig.groovy
@@ -5,20 +5,27 @@ import uk.gov.hmcts.pipeline.DeprecationConfig
 
 def call(Map<String, String> params) {
 
+  def repoUrl = params.repoUrl ?: null
   def product = params.product
   def component = params.component
 
-  def helmChartDeprecationConfig = new DeprecationConfig(this).getDeprecationConfig().helm
-  def gradleDeprecationConfig = new DeprecationConfig(this).getDeprecationConfig().gradle
-  def npmDeprecationConfig = new DeprecationConfig(this).getDeprecationConfig().npm
+  def helmChartDeprecationConfig = repoUrl ? 
+      new DeprecationConfig(this).getDeprecationConfig(repoUrl).helm : 
+      new DeprecationConfig(this).getDeprecationConfig().helm
+  
+  def gradleDeprecationConfig = repoUrl ? 
+      new DeprecationConfig(this).getDeprecationConfig(repoUrl).gradle : 
+      new DeprecationConfig(this).getDeprecationConfig().gradle
 
+  def npmDeprecationConfig = repoUrl ? 
+      new DeprecationConfig(this).getDeprecationConfig(repoUrl).npm : 
+      new DeprecationConfig(this).getDeprecationConfig().npm
 
   writeFile file: 'check-helm-api-version.sh', text: libraryResource('uk/gov/hmcts/helm/check-helm-api-version.sh')
   writeFile file: 'check-deprecated-charts.sh', text: libraryResource('uk/gov/hmcts/helm/check-deprecated-charts.sh')
   writeFile file: 'check-deprecated-gradle-dependency.sh', text: libraryResource('uk/gov/hmcts/gradle/check-deprecated-gradle-dependency.sh')
   writeFile file: 'check-deprecated-properties-volume-spring-boot-starter.sh', text: libraryResource('uk/gov/hmcts/gradle/check-deprecated-properties-volume-spring-boot-starter.sh')
   writeFile file: 'check-deprecated-npm-dependency.sh', text: libraryResource('uk/gov/hmcts/npm/check-deprecated-npm-dependency.sh')
-
 
   try {
     sh """
@@ -30,7 +37,6 @@ def call(Map<String, String> params) {
   }
 
   sh 'chmod +x check-deprecated-charts.sh'
-
   helmChartDeprecationConfig.each { chart, deprecation ->
     try {
       sh "./check-deprecated-charts.sh $product $component $chart $deprecation.version"
@@ -49,7 +55,7 @@ def call(Map<String, String> params) {
     }
   }
   sh 'rm -f check-deprecated-gradle-dependency.sh'
-  
+
   sh 'chmod +x check-deprecated-properties-volume-spring-boot-starter.sh'
   try {
     sh './check-deprecated-properties-volume-spring-boot-starter.sh'

--- a/vars/warnAboutOldTfAzureProvider.groovy
+++ b/vars/warnAboutOldTfAzureProvider.groovy
@@ -2,23 +2,26 @@ import uk.gov.hmcts.pipeline.deprecation.WarningCollector
 import uk.gov.hmcts.pipeline.DeprecationConfig
 import java.time.LocalDate
 
-def call(String environment, String product) {
+def call(String environment, String product, String repoUrl = null) {
 
-  def tfDeprecationConfig = new DeprecationConfig(this).getDeprecationConfig().terraform
-  writeFile file: 'warn-about-old-tf-azure-provider.sh', text: libraryResource('uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh')
+    def tfDeprecationConfig = repoUrl ? 
+        new DeprecationConfig(this).getDeprecationConfig(repoUrl).terraform : 
+        new DeprecationConfig(this).getDeprecationConfig().terraform
 
-  def slackDeprecationMessage = []
-  def deprecationDeadlines = []
+    writeFile file: 'warn-about-old-tf-azure-provider.sh', text: libraryResource('uk/gov/hmcts/helm/warn-about-old-tf-azure-provider.sh')
 
-  tfDeprecationConfig.each { dependency, deprecation ->
-    try {
-      sh """
-      chmod +x warn-about-old-tf-azure-provider.sh
-      ./warn-about-old-tf-azure-provider.sh $dependency $deprecation.version
-      """
-    } catch(ignored) {
-      WarningCollector.addPipelineWarning("updated_tf_versions" ,"`${dependency}` - minimum required: *${deprecation.version}*.",  LocalDate.parse(deprecation.date_deadline))
+    def slackDeprecationMessage = []
+    def deprecationDeadlines = []
+
+    tfDeprecationConfig.each { dependency, deprecation ->
+        try {
+            sh """
+            chmod +x warn-about-old-tf-azure-provider.sh
+            ./warn-about-old-tf-azure-provider.sh $dependency $deprecation.version
+            """
+        } catch(ignored) {
+            WarningCollector.addPipelineWarning("updated_tf_versions" ,"`${dependency}` - minimum required: *${deprecation.version}*.",  LocalDate.parse(deprecation.date_deadline))
+        }
     }
-  }
-  sh 'rm -f warn-about-old-tf-azure-provider.sh'
+    sh 'rm -f warn-about-old-tf-azure-provider.sh'
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-24490

Notes:
* Update to deprecation check logic to include exceptions on repo basis.
* Allow exceptions to be configured like below in file: https://github.com/hmcts/cnp-deprecation-map/blob/DTSPO-24490/nagger-versions.yaml

```
helm:
  nodejs:
    version: "3.2.0"
    date_deadline: "2025-03-31"
    release_api: "https://api.github.com/repos/hmcts/chart-nodejs/releases"
    exceptions:
          - repo: "https://github.com/hmcts/labs-abhivan-nodejs.git"
            date_deadline: "2026-03-31"
```