### PR TITLE
allowEmptyResults exclusion for civil

### DIFF
--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -70,7 +70,7 @@ class GradleBuilder extends AbstractBuilder {
       gradle("--rerun-tasks functional")
     } finally {
       if (product == "civil") {
-        localSteps.junit allowEmptyResults: true, '**/test-results/functional/*.xml,**/test-results/functionalTest/*.xml'
+        localSteps.junit allowEmptyResults: true, testResults: '**/test-results/functional/*.xml,**/test-results/functionalTest/*.xml'
       } else {
         localSteps.junit '**/test-results/functional/*.xml,**/test-results/functionalTest/*.xml'
       }

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -69,7 +69,11 @@ class GradleBuilder extends AbstractBuilder {
       // --rerun-tasks ensures that subsequent calls to tests against different slots are executed.
       gradle("--rerun-tasks functional")
     } finally {
-      localSteps.junit '**/test-results/functional/*.xml,**/test-results/functionalTest/*.xml'
+      if (product == "civil") {
+        localSteps.junit allowEmptyResults: true, '**/test-results/functional/*.xml,**/test-results/functionalTest/*.xml'
+      } else {
+        localSteps.junit '**/test-results/functional/*.xml,**/test-results/functionalTest/*.xml'
+      }
     }
   }
 


### PR DESCRIPTION
allowEmptyResults for gradle functional tests for civil due to their new retry mechanism, which will only rerun failed tests in the next run (provided no new changes).

Civil now expect to sometimes have empty functional test results where a build has failed for a reason other than functional tests - it will be automatically retried but if no functional tests have failed none will be rerun (provided no new changes).
This gives them an exception and allows these results to be empty.

Other teams will have the default behaviour as always

Test with civil: https://build.hmcts.net/blue/organizations/jenkins/HMCTS_a_to_c%2Fcivil-service/detail/PR-6784/6/pipeline/289 
Test with other team: https://build.hmcts.net/blue/organizations/jenkins/HMCTS_j_to_z%2Fservice-auth-provider-app/detail/PR-1093/2/pipeline/258/

dtspo-26470
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)
