### PR TITLE
Fixing rake task name to follow ruby conventions

### DIFF
--- a/src/uk/gov/hmcts/contino/RubyBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/RubyBuilder.groovy
@@ -17,7 +17,8 @@ class RubyBuilder extends AbstractBuilder {
   }
 
   def fortifyScan() {
-    bundle("exec rake fortifyScan")
+    bundle("exec rake fortify_scan")
+
   }
 
   def test() {


### PR DESCRIPTION
Ruby naming convention for task is snake_case format.