### PR TITLE
Disable High Level Data setup on prod with a flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,11 @@ Branch | HighDataSetup Stage
 `demo` | `demo`
 `ithc` | `ithc`
 
+If your service is not yet built on prod, you can disable prod HighLevelDataSetup by setting `skipHighLevelDataSetupProd` flag to `true`.
+
+```
+  enableHighLevelDataSetup("", true)
+```
 
 #### Extending the opinionated pipeline
 

--- a/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
@@ -33,6 +33,7 @@ class AppPipelineConfig extends CommonPipelineConfig implements Serializable {
   String s2sServiceName
   String highLevelDataSetupKeyVaultName
   boolean dockerTestBuild = false
+  boolean skipHighLevelDataSetupProd = false
 
   int crossBrowserTestTimeout
   int perfTestTimeout = 15

--- a/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
@@ -118,14 +118,12 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
     config.pactConsumerCanIDeployEnabled = roles.contains(PactRoles.CONSUMER_DEPLOY_CHECK)
   }
 
-  void enableHighLevelDataSetup(String highLevelDataSetupKeyvaultName = "") {
+  void enableHighLevelDataSetup(String highLevelDataSetupKeyvaultName = "", boolean skipHighLevelDataSetupProd = false) {
     config.highLevelDataSetup = true
     config.highLevelDataSetupKeyVaultName = highLevelDataSetupKeyvaultName
+    config.skipHighLevelDataSetupProd = skipHighLevelDataSetupProd
   }
 
-  void disableHighLevelDataSetup() {
-    config.highLevelDataSetup = false
-  }
 
   void enableFortifyScan(String fortifyVaultName = "") {
     config.fortifyScan = true

--- a/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
@@ -123,6 +123,10 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
     config.highLevelDataSetupKeyVaultName = highLevelDataSetupKeyvaultName
   }
 
+  void disableHighLevelDataSetup() {
+    config.highLevelDataSetup = false
+  }
+
   void enableFortifyScan(String fortifyVaultName = "") {
     config.fortifyScan = true
     config.fortifyVaultName = fortifyVaultName

--- a/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
+++ b/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
@@ -175,6 +175,15 @@ class AppPipelineConfigTest extends Specification {
         assertThat(pipelineConfig.highLevelDataSetupKeyVaultName).isEqualTo("highLevelDataSetupKeyVaultName")
     }
 
+    def "ensure enable high level data setup with skipHighLevelDataSetupProd"() {
+      when:
+      dsl.enableHighLevelDataSetup("", true)
+      then:
+      assertThat(pipelineConfig.highLevelDataSetup).isTrue()
+      assertThat(pipelineConfig.highLevelDataSetupKeyVaultName).isEqualTo("")
+      assertThat(pipelineConfig.skipHighLevelDataSetupProd).isEqualTo(true)
+    }
+
     def "ensure enable fortify scan without fortifyVaultName"() {
     when:
     dsl.enableFortifyScan()

--- a/vars/highLevelDataSetup.groovy
+++ b/vars/highLevelDataSetup.groovy
@@ -1,5 +1,6 @@
 #!groovy
 import uk.gov.hmcts.contino.Builder
+import uk.gov.hmcts.contino.Environment
 import uk.gov.hmcts.contino.PipelineCallbacksRunner
 import uk.gov.hmcts.contino.AppPipelineConfig
 
@@ -24,6 +25,10 @@ def call(params) {
   }
 
   if (config.highLevelDataSetup) {
+    if (config.skipHighLevelDataSetupProd && new Environment(env).prodName == environment) {
+      echo "Skipping high level data setup for prod environment"
+      return
+    }
     def highLevelDataSetupKeyVaultName = config.highLevelDataSetupKeyVaultName
 
     stageWithAgent("High Level Data Setup - ${environment}", product) {


### PR DESCRIPTION
Notes:
* Currently we cannot disable high level data setup on prod alone while running on AAT
* It needs prod infra to be built (to look for key vault secrets), teams usually create custom scripts/ methods instead of high level data setup.
* It is common for any new service to be on AAT only for a while before prod infra is approved.
* Being tested on https://github.com/hmcts/pcs-api/pull/653/files
