### PR TITLE
Fix variable assignment syntax in audit script

### DIFF
--- a/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
+++ b/resources/uk/gov/hmcts/pipeline/yarn/yarn-audit-with-suppressions.sh
@@ -140,7 +140,7 @@ fi
 
 if [ ! -s yarn-audit-result ]; then
   echo "yarn audit returned no results, assuming no vulnerabilities found"
-  FOUND_VULNERABILITIES = 0
+  FOUND_VULNERABILITIES=0
 else
   check_file_valid_json yarn-audit-result
   check_audit_file_format yarn-audit-result


### PR DESCRIPTION
Resolves https://sds-build.hmcts.net/job/HMCTS/job/pre-portal/job/PR-1039/2/consoleText 

```
/yarn-audit-with-suppressions.sh: line 143: FOUND_VULNERABILITIES: command not found
```
