### PR TITLE
Add error handling in case of failing Gatling Plugin

### DIFF
--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -364,13 +364,26 @@ EOF
       // performance repo
       def gatlingCommand = simulation ? "gatlingRun --simulation=${simulation}" : "gatlingRun"
       gradle(gatlingCommand)
-      this.localSteps.gatlingArchive()
+      archiveGatlingReports()
     } else {
       WarningCollector.addPipelineWarning("gatling_docker_deprecated",
         "Please use the gatling plugin instead of the docker image " +
           "See <https://github.com/hmcts/cnp-plum-recipes-service/pull/817/files|example>", LocalDate.of(2023, 9, 1)
       )
       super.executeGatling()
+    }
+  }
+
+  private void archiveGatlingReports() {
+    try {
+      this.localSteps.gatlingArchive()
+    } catch (Exception e) {
+      localSteps.echo("Gatling plugin archive step failed: ${e.class.simpleName}: ${e.message}")
+      localSteps.echo("Falling back to artifact archiving for Gatling reports")
+      localSteps.archiveArtifacts(
+        artifacts: "${localSteps.env.GATLING_REPORTS_PATH}/**/*",
+        allowEmptyArchive: true
+      )
     }
   }
 }


### PR DESCRIPTION
**Change**

Add exception handling around the Gatling Archiver plugin step so whenever it throws an exception due to being badly coded it doesn't just fail the entire pipeline after Gatling performance tests have run successfully.
I noticed this on our Sandbox Toffee Recipes app where we have performance tests enabled and after fixing some other issues I noticed that the plugin just kept failing after performance tests have run with following:
```
...
17:39:35  Created document in database: sds-jenkins, container: pipeline-metrics
17:39:35  [Pipeline] deleteDir
17:39:35  [Pipeline] }
17:39:35  [Pipeline] // timeout
17:39:35  [Pipeline] }
17:39:35  [Pipeline] // node
17:39:35  [Pipeline] }
17:39:35  [Pipeline] // retry
17:39:35  [Pipeline] End of Pipeline
17:39:35  Also:   org.jenkinsci.plugins.workflow.actions.ErrorAction$ErrorId: 1bb236ac-fe20-460b-909b-5bf544a1c979
17:39:35  java.lang.StringIndexOutOfBoundsException: Range [0, -1) out of bounds for length 4
17:39:35  	at java.base/jdk.internal.util.Preconditions$1.apply(Unknown Source)
17:39:35  	at java.base/jdk.internal.util.Preconditions$1.apply(Unknown Source)
17:39:35  	at java.base/jdk.internal.util.Preconditions$4.apply(Unknown Source)
17:39:35  	at java.base/jdk.internal.util.Preconditions$4.apply(Unknown Source)
17:39:35  	at java.base/jdk.internal.util.Preconditions.outOfBounds(Unknown Source)
17:39:35  	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckFromToIndex(Unknown Source)
17:39:35  	at java.base/jdk.internal.util.Preconditions.checkFromToIndex(Unknown Source)
17:39:35  	at java.base/java.lang.String.checkBoundsBeginEnd(Unknown Source)
17:39:35  	at java.base/java.lang.String.substring(Unknown Source)
17:39:35  	at PluginClassLoader for gatling//io.gatling.jenkins.GatlingPublisher.saveFullReports(GatlingPublisher.java:145)
17:39:35  	at PluginClassLoader for gatling//io.gatling.jenkins.GatlingPublisher.perform(GatlingPublisher.java:78)
17:39:35  	at PluginClassLoader for gatling//io.gatling.jenkins.steps.GatlingArchiverStepExecution.run(GatlingArchiverStepExecution.java:46)
17:39:35  	at PluginClassLoader for gatling//io.gatling.jenkins.steps.GatlingArchiverStepExecution.run(GatlingArchiverStepExecution.java:26)
17:39:35  	at PluginClassLoader for workflow-step-api//org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution$1$1.call(AbstractSynchronousNonBlockingStepExecution.java:47)
17:39:35  	at hudson.security.ACL.impersonate2(ACL.java:446)
17:39:35  	at PluginClassLoader for workflow-step-api//org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution$1.run(AbstractSynchronousNonBlockingStepExecution.java:44)
17:39:35  	at PluginClassLoader for opentelemetry-api//io.opentelemetry.context.Context.lambda$wrap$1(Context.java:241)
17:39:35  	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
17:39:35  	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
17:39:35  	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
17:39:35  	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
17:39:35  	at java.base/java.lang.Thread.run(Unknown Source)
```

I found source code for this plugin [here](https://github.com/jenkinsci/gatling-plugin/blob/master/src/main/java/io/gatling/jenkins/GatlingPublisher.java#L142) basically the plugin assumes that every report it will find must have a dash `-` and unexpected exception is thrown when this doesn't exist.
For whatever reason the plugin assumes everything in the build directory must be a Gatling report and will process reports such as unit tests etc. and then try to substring their names with the dash as shown above which then causes the issue.
There is no way to configure more specific path so the only option is to get rid of this plugin or deal with exception so the pipeline can still function  🤷 

**Testing**
- Issue can be seen on this build: https://sds-sandbox-build.hmcts.net/job/Pipeline_Test_Sandbox/job/sds-toffee-recipes-service/view/change-requests/job/PR-688/12/
- Fix tested on this build: https://sds-sandbox-build.hmcts.net/job/Pipeline_Test_Sandbox/job/sds-toffee-recipes-service/view/change-requests/job/PR-688/16/