### PR TITLE
OnlyDeploy option

### DIFF
--- a/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
@@ -35,6 +35,7 @@ class AppPipelineConfig extends CommonPipelineConfig implements Serializable {
   String s2sServiceName
   String highLevelDataSetupKeyVaultName
   boolean dockerTestBuild = false
+  boolean onlyDeploy = false
   boolean skipHighLevelDataSetupProd = false
 
   int crossBrowserTestTimeout

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -215,7 +215,6 @@ def call(params) {
 
     if (config.onlyDeploy) {
       branches.remove("Unit tests and Sonar scan")
-      branches.remove("Tech Stack")
       branches.remove("Fortify scan")
     }
 

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -43,11 +43,11 @@ def call(params) {
   }
   boolean dockerFileExists = fileExists('Dockerfile')
   warnAboutJitpackRemoval(product: product, component: component)
-  
+
   stage('ACR Migration Check') {
     warnAboutOldAcrReferences(env.GIT_URL ?: 'unknown')
   }
-  
+
   onPathToLive {
     stageWithAgent("Build", product) {
       onPR {
@@ -181,6 +181,12 @@ def call(params) {
           }
         }
       }
+      echo 'Checking for only_deploy label to determine if we should skip build and tests'
+      def onlyDeployLabels = gitHubAPI.getLabelsbyPattern(env.BRANCH_NAME, 'only_deploy')
+      if (onlyDeployLabels.contains('only_deploy')) {
+        echo 'only_deploy label found, skipping build and tests'
+        config.onlyDeploy = true
+      }
     }
 
     if (config.fortifyScan && branches["Fortify scan"] == null) {
@@ -203,6 +209,12 @@ def call(params) {
           }
         }
       }
+    }
+
+    if (config.onlyDeploy) {
+      branches.remove("Unit tests and Sonar scan")
+      branches.remove("Tech Stack")
+      branches.remove("Fortify scan")
     }
 
     stageWithAgent("Static checks / Container build", product) {
@@ -236,7 +248,7 @@ def call(params) {
       }
     }
 
-    if (config.pactBrokerEnabled && config.pactConsumerTestsEnabled && noSkipImgBuild) {
+    if (config.pactBrokerEnabled && config.pactConsumerTestsEnabled && noSkipImgBuild && !config.onlyDeploy) {
       stageWithAgent("Pact Consumer Verification", product) {
         timeoutWithMsg(time: 20, unit: 'MINUTES', action: 'Pact Consumer Verification') {
           def version = env.GIT_COMMIT.length() > 7 ? env.GIT_COMMIT.substring(0, 7) : env.GIT_COMMIT

--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -88,12 +88,12 @@ def call(params) {
       )
     }
     withSubscriptionLogin(subscription) {
-      if (config.pactBrokerEnabled && config.pactConsumerCanIDeployEnabled) {
+      if (config.pactBrokerEnabled && config.pactConsumerCanIDeployEnabled && !config.onlyDeploy) {
         stageWithAgent("Pact Consumer Can I Deploy", product) {
           builder.runConsumerCanIDeploy()
         }
       }
-      if (config.pactBrokerEnabled && config.pactProviderVerificationsEnabled) {
+      if (config.pactBrokerEnabled && config.pactProviderVerificationsEnabled && !config.onlyDeploy) {
         stageWithAgent("Pact Provider Verification", product) {
           def version = env.GIT_COMMIT.length() > 7 ? env.GIT_COMMIT.substring(0, 7) : env.GIT_COMMIT
           def isOnMaster = new ProjectBranch(env.BRANCH_NAME).isMaster()
@@ -109,340 +109,342 @@ def call(params) {
       }
       if (config.serviceApp) {
         withTeamSecrets(config, environment) {
-          stageWithAgent("Smoke Test - AKS ${environment}", product) {
-            testEnv(aksUrl) {
-              def success = true
-              try {
-                pcr.callAround("smoketest:${environment}") {
-                  timeoutWithMsg(time: 120, unit: 'MINUTES', action: 'Smoke Test - AKS') {
-                    builder.smokeTest()
-                  }
-                }
-              } catch (err) {
-                success = false
-                throw err
-              } finally {
-                savePodsLogs(dockerImage, params, "smoke")
-                if (!success) {
-                  clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
-                }
-              }
-            }
-          }
-
-          onFunctionalTestEnvironment(environment) {
-            if (testLabels.contains('enable_full_functional_tests')) {
-              stageWithAgent('Functional test (Full)', product) {
-                testEnv(aksUrl) {
-                  def passed = true
-                  try {
-                    pcr.callAround("fullFunctionalTest:${environment}") {
-                      timeoutWithMsg(time: config.fullFunctionalTestTimeout, unit: 'MINUTES', action: 'Functional tests') {
-                        builder.fullFunctionalTest()
-                      }
-                    }
-                  } catch (err) {
-                    passed = false
-                  } finally {
-                    savePodsLogs(dockerImage, params, "full-functional")
-                  }
-                  if (!passed) {
-                    clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
-                    error('Functional test (Full) failed')
-                  }
-                }
-              }
-            } else {
-              stageWithAgent("Functional Test - ${environment}", product) {
-                testEnv(aksUrl) {
-                  def passed = true
-                  try {
-                    pcr.callAround("functionalTest:${environment}") {
-                      timeoutWithMsg(time: 40, unit: 'MINUTES', action: 'Functional Test - AKS') {
-                        builder.functionalTest()
-                      }
-                    }
-                  } catch (err) {
-                    passed = false
-                  } finally {
-                    savePodsLogs(dockerImage, params, "functional")
-                  }
-                  if (!passed) {
-                    clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
-                    error('Functional test failed')
-                  }
-                }
-              }
-            }
-          }
-
-          if (config.performanceTest) {
-            stageWithAgent("Performance Test - ${environment}", product) {
+          if (!config.onlyDeploy) {
+            stageWithAgent("Smoke Test - AKS ${environment}", product) {
               testEnv(aksUrl) {
-                pcr.callAround("performanceTest:${environment}") {
-                  timeoutWithMsg(time: 120, unit: 'MINUTES', action: "Performance Test - ${environment} (staging slot)") {
-                    builder.performanceTest()
-                    publishPerformanceReports(params)
-                  }
-                }
-              }
-            }
-          }
-          // Performance Test Pipeline: Setup -> Parallel Testing
-          if ((config.performanceTestStages || config.gatlingLoadTests) && environment in config.performanceTestEnvironments) {
-
-            // Load performance test secrets once for all stages - Secrets are stored only within the
-            // rpe-shared-perftest KV for all environments (they are DT API keys and not env specific)
-            def perfKeyVaultUrl = "https://rpe-shared-perftest.vault.azure.net"   //https://et-perftest.vault.azure.net/
-            def perfSecrets = [
-              [$class: 'AzureKeyVaultSecret', secretType: 'Secret', name: 'perf-synthetic-monitor-token', version: '', envVariable: 'PERF_SYNTHETIC_MONITOR_TOKEN'],
-              [$class: 'AzureKeyVaultSecret', secretType: 'Secret', name: 'perf-metrics-token', version: '', envVariable: 'PERF_METRICS_TOKEN'],
-              [$class: 'AzureKeyVaultSecret', secretType: 'Secret', name: 'perf-event-token', version: '', envVariable: 'PERF_EVENT_TOKEN'],
-              [$class: 'AzureKeyVaultSecret', secretType: 'Secret', name: 'perf-synthetic-update-token', version: '', envVariable: 'PERF_SYNTHETIC_UPDATE_TOKEN']
-            ]
-
-            // Add IDAM test support URL secret if IDAM test user is enabled
-            if (config.idamTestUser) {
-              perfSecrets << [$class: 'AzureKeyVaultSecret', secretType: 'Secret', name: 'idam-test-support-url', version: '', envVariable: 'IDAM_TEST_SUPPORT_URL']
-            }
-
-            withAzureKeyvault(
-              azureKeyVaultSecrets: perfSecrets,
-              keyVaultURLOverride: perfKeyVaultUrl
-            ) {
-
-              // Stage 1: Dynatrace Setup - Post build info, events, and metrics first
-              // Run setup for any performance testing (synthetic or gatling) to ensure DT events/metrics are sent
-              stageWithAgent("Dynatrace Performance Setup - ${environment}", product) {
-                testEnv(aksUrl) {
-                  def success = true
-                  try {
-                    pcr.callAround("dynatracePerformanceSetup:${environment}") {
-                      timeoutWithMsg(time: 5, unit: 'MINUTES', action: "Dynatrace Performance Setup - ${environment}") {
-                        dynatracePerformanceSetup([
-                          product: product,
-                          component: component,
-                          environment: environment,
-                          configPath: config.performanceTestConfigPath,
-                          idamTestUserEnabled: config.idamTestUser,
-                          idamTestUserEmail: config.idamTestUserEmail,
-                          idamTestUserForename: config.idamTestUserForename,
-                          idamTestUserSurname: config.idamTestUserSurname,
-                          idamTestUserPassword: config.idamTestUserPassword,
-                          idamTestUserRoles: config.idamTestUserRoles
-                        ])
-                      }
-                    }
-                  } catch (err) {
-                    success = false
-                    echo "Dynatrace setup failed: ${err.message}"
-                    // Don't fail the build for setup issues, continue with tests
-                  } finally {
-                    savePodsLogs(dockerImage, params, "dynatrace-setup")
-                  }
-                }
-              }
-
-            // Stage 2: Run performance tests in parallel (if both enabled) or sequential (if only one enabled)
-            def testStages = [:]
-
-            if (config.performanceTestStages) {
-              testStages['Dynatrace Synthetic Tests'] = {
-                stageWithAgent("Dynatrace Synthetic Tests - ${environment}", product) {
-                  testEnv(aksUrl) {
-                    def success = true
-                    try {
-                      pcr.callAround("dynatraceSyntheticTest:${environment}") {
-                        timeoutWithMsg(time: config.performanceTestStagesTimeout, unit: 'MINUTES', action: "Dynatrace Synthetic Tests - ${environment}") {
-                          dynatraceSyntheticTest([
-                            product: product,
-                            component: component,
-                            environment: environment,
-                            performanceTestStagesEnabled: config.performanceTestStages,
-                            gatlingLoadTestsEnabled: config.gatlingLoadTests
-                          ])
-                        }
-                      }
-                    } catch (err) {
-                      success = false
-                      throw err
-                    } finally {
-                      savePodsLogs(dockerImage, params, "dynatrace-synthetic")
-                      if (!success) {
-                        clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
-                      }
+                def success = true
+                try {
+                  pcr.callAround("smoketest:${environment}") {
+                    timeoutWithMsg(time: 120, unit: 'MINUTES', action: 'Smoke Test - AKS') {
+                      builder.smokeTest()
                     }
                   }
-                }
-              }
-            }
-
-            if (config.gatlingLoadTests) {
-              testStages['Gatling Load Tests'] = {
-                stageWithAgent("Gatling Load Tests - ${environment}", product) {
-                  testEnv(aksUrl) {
-                    def success = true
-                    try {
-                      pcr.callAround("gatlingLoadTests:${environment}") {
-                        timeoutWithMsg(time: config.gatlingLoadTestTimeout, unit: 'MINUTES', action: "Gatling Load Tests - ${environment}") {
-                          gatlingExternalLoadTest([
-                            product: product,
-                            component: component,
-                            environment: environment,
-                            subscription: subscription,
-                            gatlingRepo: config.gatlingRepo,
-                            gatlingBranch: config.gatlingBranch,
-                            gatlingSimulation: config.gatlingSimulation
-                          ])
-                        }
-                      }
-                    } catch (err) {
-                      success = false
-                      throw err
-                    } finally {
-                      savePodsLogs(dockerImage, params, "gatling-load-tests")
-                      if (!success) {
-                        clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
-                      }
-                    }
-                  }
-                }
-              }
-            }
-
-              // Execute test stages
-              if (testStages.size() > 1) {
-                echo "Running Dynatrace Synthetic Tests and Gatling Load Tests in parallel..."
-                parallel(testStages)
-              } else {
-                echo "Running single performance test stage..."
-                testStages.values().first().call()
-              }
-
-              // Stage 3: Site Reliability Guardian Evaluation (if enabled)
-              if (config.srgEvaluation) {
-                stageWithAgent("Site Reliability Guardian Evaluation - ${environment}", product) {
-                  testEnv(aksUrl) {
-                    try {
-                      pcr.callAround("srgEvaluation:${environment}") {
-                        evaluateDynatraceSRG([
-                          environment: environment,
-                          srgServiceName: config.srgServiceName,
-                          performanceTestStartTime: env.PERF_TEST_START_TIME,
-                          performanceTestEndTime: env.PERF_TEST_END_TIME,
-                          gatlingTestStartTime: env.GATLING_TEST_START_TIME,
-                          gatlingTestEndTime: env.GATLING_TEST_END_TIME,
-                          srgFailureBehavior: config.srgFailureBehavior,
-                          product: product,
-                          component: component
-                        ])
-                      }
-                    } catch (Exception e) {
-                      echo "SRG evaluation stage failed: ${e.message}"
-                      if (config.srgFailureBehavior == 'fail') {
-                        clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
-                        throw e
-                      }
-                    }
-                  }
-                }
-              }
-            } // End withAzureKeyvault block
-          } // End if (config.performanceTestStages || config.gatlingLoadTests)
-
-          onMaster {
-            if (config.crossBrowserTest) {
-              stageWithAgent("CrossBrowser Test - AKS ${environment}", product) {
-                testEnv(aksUrl) {
-                  pcr.callAround("crossBrowserTest:${environment}") {
-                    builder.crossBrowserTest()
-                  }
-                }
-              }
-            }
-            if (config.mutationTest) {
-              stageWithAgent("Mutation Test - AKS ${environment}", product) {
-                testEnv(aksUrl) {
-                  pcr.callAround("mutationTest:${environment}") {
-                    builder.mutationTest()
-                  }
-                }
-              }
-            }
-            if (config.fullFunctionalTest) {
-              stageWithAgent("FullFunctional Test - AKS ${environment}", product) {
-                testEnv(aksUrl) {
-                  pcr.callAround("fullFunctionalTest:${environment}") {
-                    builder.fullFunctionalTest()
-                  }
-                }
-              }
-            }
-            if (config.e2eTest) {
-              stageWithAgent("E2E Test - AKS ${environment}", product) {
-                testEnv(aksUrl) {
-                  def passed = catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                    pcr.callAround("E2eTest:${environment}") {
-                      builder.e2eTest()
-                    }
-                  }
-                  savePodsLogs(dockerImage, params, "e2e")
-                  if (passed == false) {
+                } catch (err) {
+                  success = false
+                  throw err
+                } finally {
+                  savePodsLogs(dockerImage, params, "smoke")
+                  if (!success) {
                     clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
-                    error('E2E test failed')
                   }
                 }
               }
             }
-          }
+
+            onFunctionalTestEnvironment(environment) {
+              if (testLabels.contains('enable_full_functional_tests')) {
+                stageWithAgent('Functional test (Full)', product) {
+                  testEnv(aksUrl) {
+                    def passed = true
+                    try {
+                      pcr.callAround("fullFunctionalTest:${environment}") {
+                        timeoutWithMsg(time: config.fullFunctionalTestTimeout, unit: 'MINUTES', action: 'Functional tests') {
+                          builder.fullFunctionalTest()
+                        }
+                      }
+                    } catch (err) {
+                      passed = false
+                    } finally {
+                      savePodsLogs(dockerImage, params, "full-functional")
+                    }
+                    if (!passed) {
+                      clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
+                      error('Functional test (Full) failed')
+                    }
+                  }
+                }
+              } else {
+                stageWithAgent("Functional Test - ${environment}", product) {
+                  testEnv(aksUrl) {
+                    def passed = true
+                    try {
+                      pcr.callAround("functionalTest:${environment}") {
+                        timeoutWithMsg(time: 40, unit: 'MINUTES', action: 'Functional Test - AKS') {
+                          builder.functionalTest()
+                        }
+                      }
+                    } catch (err) {
+                      passed = false
+                    } finally {
+                      savePodsLogs(dockerImage, params, "functional")
+                    }
+                    if (!passed) {
+                      clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
+                      error('Functional test failed')
+                    }
+                  }
+                }
+              }
+            }
+
+            if (config.performanceTest) {
+              stageWithAgent("Performance Test - ${environment}", product) {
+                testEnv(aksUrl) {
+                  pcr.callAround("performanceTest:${environment}") {
+                    timeoutWithMsg(time: 120, unit: 'MINUTES', action: "Performance Test - ${environment} (staging slot)") {
+                      builder.performanceTest()
+                      publishPerformanceReports(params)
+                    }
+                  }
+                }
+              }
+            }
+            // Performance Test Pipeline: Setup -> Parallel Testing
+            if ((config.performanceTestStages || config.gatlingLoadTests) && environment in config.performanceTestEnvironments) {
+
+              // Load performance test secrets once for all stages - Secrets are stored only within the
+              // rpe-shared-perftest KV for all environments (they are DT API keys and not env specific)
+              def perfKeyVaultUrl = "https://rpe-shared-perftest.vault.azure.net"   //https://et-perftest.vault.azure.net/
+              def perfSecrets = [
+                [$class: 'AzureKeyVaultSecret', secretType: 'Secret', name: 'perf-synthetic-monitor-token', version: '', envVariable: 'PERF_SYNTHETIC_MONITOR_TOKEN'],
+                [$class: 'AzureKeyVaultSecret', secretType: 'Secret', name: 'perf-metrics-token', version: '', envVariable: 'PERF_METRICS_TOKEN'],
+                [$class: 'AzureKeyVaultSecret', secretType: 'Secret', name: 'perf-event-token', version: '', envVariable: 'PERF_EVENT_TOKEN'],
+                [$class: 'AzureKeyVaultSecret', secretType: 'Secret', name: 'perf-synthetic-update-token', version: '', envVariable: 'PERF_SYNTHETIC_UPDATE_TOKEN']
+              ]
+
+              // Add IDAM test support URL secret if IDAM test user is enabled
+              if (config.idamTestUser) {
+                perfSecrets << [$class: 'AzureKeyVaultSecret', secretType: 'Secret', name: 'idam-test-support-url', version: '', envVariable: 'IDAM_TEST_SUPPORT_URL']
+              }
+
+              withAzureKeyvault(
+                azureKeyVaultSecrets: perfSecrets,
+                keyVaultURLOverride: perfKeyVaultUrl
+              ) {
+
+                // Stage 1: Dynatrace Setup - Post build info, events, and metrics first
+                // Run setup for any performance testing (synthetic or gatling) to ensure DT events/metrics are sent
+                stageWithAgent("Dynatrace Performance Setup - ${environment}", product) {
+                  testEnv(aksUrl) {
+                    def success = true
+                    try {
+                      pcr.callAround("dynatracePerformanceSetup:${environment}") {
+                        timeoutWithMsg(time: 5, unit: 'MINUTES', action: "Dynatrace Performance Setup - ${environment}") {
+                          dynatracePerformanceSetup([
+                            product             : product,
+                            component           : component,
+                            environment         : environment,
+                            configPath          : config.performanceTestConfigPath,
+                            idamTestUserEnabled : config.idamTestUser,
+                            idamTestUserEmail   : config.idamTestUserEmail,
+                            idamTestUserForename: config.idamTestUserForename,
+                            idamTestUserSurname : config.idamTestUserSurname,
+                            idamTestUserPassword: config.idamTestUserPassword,
+                            idamTestUserRoles   : config.idamTestUserRoles
+                          ])
+                        }
+                      }
+                    } catch (err) {
+                      success = false
+                      echo "Dynatrace setup failed: ${err.message}"
+                      // Don't fail the build for setup issues, continue with tests
+                    } finally {
+                      savePodsLogs(dockerImage, params, "dynatrace-setup")
+                    }
+                  }
+                }
+
+                // Stage 2: Run performance tests in parallel (if both enabled) or sequential (if only one enabled)
+                def testStages = [:]
+
+                if (config.performanceTestStages) {
+                  testStages['Dynatrace Synthetic Tests'] = {
+                    stageWithAgent("Dynatrace Synthetic Tests - ${environment}", product) {
+                      testEnv(aksUrl) {
+                        def success = true
+                        try {
+                          pcr.callAround("dynatraceSyntheticTest:${environment}") {
+                            timeoutWithMsg(time: config.performanceTestStagesTimeout, unit: 'MINUTES', action: "Dynatrace Synthetic Tests - ${environment}") {
+                              dynatraceSyntheticTest([
+                                product                     : product,
+                                component                   : component,
+                                environment                 : environment,
+                                performanceTestStagesEnabled: config.performanceTestStages,
+                                gatlingLoadTestsEnabled     : config.gatlingLoadTests
+                              ])
+                            }
+                          }
+                        } catch (err) {
+                          success = false
+                          throw err
+                        } finally {
+                          savePodsLogs(dockerImage, params, "dynatrace-synthetic")
+                          if (!success) {
+                            clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+
+                if (config.gatlingLoadTests) {
+                  testStages['Gatling Load Tests'] = {
+                    stageWithAgent("Gatling Load Tests - ${environment}", product) {
+                      testEnv(aksUrl) {
+                        def success = true
+                        try {
+                          pcr.callAround("gatlingLoadTests:${environment}") {
+                            timeoutWithMsg(time: config.gatlingLoadTestTimeout, unit: 'MINUTES', action: "Gatling Load Tests - ${environment}") {
+                              gatlingExternalLoadTest([
+                                product          : product,
+                                component        : component,
+                                environment      : environment,
+                                subscription     : subscription,
+                                gatlingRepo      : config.gatlingRepo,
+                                gatlingBranch    : config.gatlingBranch,
+                                gatlingSimulation: config.gatlingSimulation
+                              ])
+                            }
+                          }
+                        } catch (err) {
+                          success = false
+                          throw err
+                        } finally {
+                          savePodsLogs(dockerImage, params, "gatling-load-tests")
+                          if (!success) {
+                            clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+
+                // Execute test stages
+                if (testStages.size() > 1) {
+                  echo "Running Dynatrace Synthetic Tests and Gatling Load Tests in parallel..."
+                  parallel(testStages)
+                } else {
+                  echo "Running single performance test stage..."
+                  testStages.values().first().call()
+                }
+
+                // Stage 3: Site Reliability Guardian Evaluation (if enabled)
+                if (config.srgEvaluation) {
+                  stageWithAgent("Site Reliability Guardian Evaluation - ${environment}", product) {
+                    testEnv(aksUrl) {
+                      try {
+                        pcr.callAround("srgEvaluation:${environment}") {
+                          evaluateDynatraceSRG([
+                            environment             : environment,
+                            srgServiceName          : config.srgServiceName,
+                            performanceTestStartTime: env.PERF_TEST_START_TIME,
+                            performanceTestEndTime  : env.PERF_TEST_END_TIME,
+                            gatlingTestStartTime    : env.GATLING_TEST_START_TIME,
+                            gatlingTestEndTime      : env.GATLING_TEST_END_TIME,
+                            srgFailureBehavior      : config.srgFailureBehavior,
+                            product                 : product,
+                            component               : component
+                          ])
+                        }
+                      } catch (Exception e) {
+                        echo "SRG evaluation stage failed: ${e.message}"
+                        if (config.srgFailureBehavior == 'fail') {
+                          clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
+                          throw e
+                        }
+                      }
+                    }
+                  }
+                }
+              } // End withAzureKeyvault block
+            } // End if (config.performanceTestStages || config.gatlingLoadTests)
+
+            onMaster {
+              if (config.crossBrowserTest) {
+                stageWithAgent("CrossBrowser Test - AKS ${environment}", product) {
+                  testEnv(aksUrl) {
+                    pcr.callAround("crossBrowserTest:${environment}") {
+                      builder.crossBrowserTest()
+                    }
+                  }
+                }
+              }
+              if (config.mutationTest) {
+                stageWithAgent("Mutation Test - AKS ${environment}", product) {
+                  testEnv(aksUrl) {
+                    pcr.callAround("mutationTest:${environment}") {
+                      builder.mutationTest()
+                    }
+                  }
+                }
+              }
+              if (config.fullFunctionalTest) {
+                stageWithAgent("FullFunctional Test - AKS ${environment}", product) {
+                  testEnv(aksUrl) {
+                    pcr.callAround("fullFunctionalTest:${environment}") {
+                      builder.fullFunctionalTest()
+                    }
+                  }
+                }
+              }
+              if (config.e2eTest) {
+                stageWithAgent("E2E Test - AKS ${environment}", product) {
+                  testEnv(aksUrl) {
+                    def passed = catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                      pcr.callAround("E2eTest:${environment}") {
+                        builder.e2eTest()
+                      }
+                    }
+                    savePodsLogs(dockerImage, params, "e2e")
+                    if (passed == false) {
+                      clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
+                      error('E2E test failed')
+                    }
+                  }
+                }
+              }
+            }
 
 //          E2E Tests:
-          onPR {
-            if (testLabels.contains('enable_e2e_test')) {
-              stageWithAgent("E2E Test - AKS ${environment}", product) {
-                testEnv(aksUrl) {
-                  def passed = catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                    pcr.callAround("E2eTest:${environment}") {
-                      builder.e2eTest()
+            onPR {
+              if (testLabels.contains('enable_e2e_test')) {
+                stageWithAgent("E2E Test - AKS ${environment}", product) {
+                  testEnv(aksUrl) {
+                    def passed = catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                      pcr.callAround("E2eTest:${environment}") {
+                        builder.e2eTest()
+                      }
                     }
-                  }
-                  savePodsLogs(dockerImage, params, "e2e")
-                  if (passed == false) {
-                    clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
-                    error('E2E test failed')
+                    savePodsLogs(dockerImage, params, "e2e")
+                    if (passed == false) {
+                      clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
+                      error('E2E test failed')
+                    }
                   }
                 }
               }
             }
-          }
 
 //          Performance Tests:
-          onPR {
-            if (testLabels.contains('enable_performance_test')) {
-              stageWithAgent("Performance test", product) {
-                warnError('Failure in performanceTest') {
-                  pcr.callAround('PerformanceTest') {
-                    timeoutWithMsg(time: config.perfTestTimeout, unit: 'MINUTES', action: 'Performance test') {
-                      try {
-                        builder.performanceTest()
-                      } finally {
-                        savePodsLogs(dockerImage, params, "performance")
+            onPR {
+              if (testLabels.contains('enable_performance_test')) {
+                stageWithAgent("Performance test", product) {
+                  warnError('Failure in performanceTest') {
+                    pcr.callAround('PerformanceTest') {
+                      timeoutWithMsg(time: config.perfTestTimeout, unit: 'MINUTES', action: 'Performance test') {
+                        try {
+                          builder.performanceTest()
+                        } finally {
+                          savePodsLogs(dockerImage, params, "performance")
+                        }
                       }
                     }
                   }
                 }
               }
-            }
-            if (testLabels.contains('enable_security_scan')) {
-              testEnv(aksUrl) {
-                stageWithAgent('Security scan', product) {
-                  warnError('Failure in securityScan') {
-                    env.ZAP_URL_EXCLUSIONS = config.securityScanUrlExclusions
-                    env.ALERT_FILTERS = config.securityScanAlertFilters
-                    env.SCAN_TYPE = config.securityScanType
-                    pcr.callAround('securityScan') {
-                      timeout(time: config.securityScanTimeout, unit: 'MINUTES') {
-                        builder.securityScan()
+              if (testLabels.contains('enable_security_scan')) {
+                testEnv(aksUrl) {
+                  stageWithAgent('Security scan', product) {
+                    warnError('Failure in securityScan') {
+                      env.ZAP_URL_EXCLUSIONS = config.securityScanUrlExclusions
+                      env.ALERT_FILTERS = config.securityScanAlertFilters
+                      env.SCAN_TYPE = config.securityScanType
+                      pcr.callAround('securityScan') {
+                        timeout(time: config.securityScanTimeout, unit: 'MINUTES') {
+                          builder.securityScan()
+                        }
                       }
                     }
                   }
@@ -453,10 +455,18 @@ def call(params) {
         }
       }
     }
+    if (config.onlyDeploy) {
+      stageWithAgent('Deployment only pipeline', product) {
+        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+          throw new RuntimeException("\"Deployment only pipeline - skipping helm uninstall to keep application deployed and failing build to prevent merge")
+        }
+      }
+    } else {
       def isOnMaster = new ProjectBranch(env.BRANCH_NAME).isMaster()
       if (isOnMaster || !enableHelmLabel) {
         helmUninstall(dockerImage, params, pcr)
       }
     }
   }
+}
 

--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -109,342 +109,340 @@ def call(params) {
       }
       if (config.serviceApp) {
         withTeamSecrets(config, environment) {
-          if (!config.onlyDeploy) {
-            stageWithAgent("Smoke Test - AKS ${environment}", product) {
-              testEnv(aksUrl) {
-                def success = true
-                try {
-                  pcr.callAround("smoketest:${environment}") {
-                    timeoutWithMsg(time: 120, unit: 'MINUTES', action: 'Smoke Test - AKS') {
-                      builder.smokeTest()
-                    }
+          stageWithAgent("Smoke Test - AKS ${environment}", product) {
+            testEnv(aksUrl) {
+              def success = true
+              try {
+                pcr.callAround("smoketest:${environment}") {
+                  timeoutWithMsg(time: 120, unit: 'MINUTES', action: 'Smoke Test - AKS') {
+                    builder.smokeTest()
                   }
-                } catch (err) {
-                  success = false
-                  throw err
-                } finally {
-                  savePodsLogs(dockerImage, params, "smoke")
-                  if (!success) {
-                    clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
-                  }
+                }
+              } catch (err) {
+                success = false
+                throw err
+              } finally {
+                savePodsLogs(dockerImage, params, "smoke")
+                if (!success) {
+                  clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
                 }
               }
             }
+          }
 
-            onFunctionalTestEnvironment(environment) {
-              if (testLabels.contains('enable_full_functional_tests')) {
-                stageWithAgent('Functional test (Full)', product) {
-                  testEnv(aksUrl) {
-                    def passed = true
-                    try {
-                      pcr.callAround("fullFunctionalTest:${environment}") {
-                        timeoutWithMsg(time: config.fullFunctionalTestTimeout, unit: 'MINUTES', action: 'Functional tests') {
-                          builder.fullFunctionalTest()
-                        }
-                      }
-                    } catch (err) {
-                      passed = false
-                    } finally {
-                      savePodsLogs(dockerImage, params, "full-functional")
-                    }
-                    if (!passed) {
-                      clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
-                      error('Functional test (Full) failed')
-                    }
-                  }
-                }
-              } else {
-                stageWithAgent("Functional Test - ${environment}", product) {
-                  testEnv(aksUrl) {
-                    def passed = true
-                    try {
-                      pcr.callAround("functionalTest:${environment}") {
-                        timeoutWithMsg(time: 40, unit: 'MINUTES', action: 'Functional Test - AKS') {
-                          builder.functionalTest()
-                        }
-                      }
-                    } catch (err) {
-                      passed = false
-                    } finally {
-                      savePodsLogs(dockerImage, params, "functional")
-                    }
-                    if (!passed) {
-                      clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
-                      error('Functional test failed')
-                    }
-                  }
-                }
-              }
-            }
-
-            if (config.performanceTest) {
-              stageWithAgent("Performance Test - ${environment}", product) {
+          onFunctionalTestEnvironment(environment) {
+            if (testLabels.contains('enable_full_functional_tests')) {
+              stageWithAgent('Functional test (Full)', product) {
                 testEnv(aksUrl) {
-                  pcr.callAround("performanceTest:${environment}") {
-                    timeoutWithMsg(time: 120, unit: 'MINUTES', action: "Performance Test - ${environment} (staging slot)") {
-                      builder.performanceTest()
-                      publishPerformanceReports(params)
+                  def passed = true
+                  try {
+                    pcr.callAround("fullFunctionalTest:${environment}") {
+                      timeoutWithMsg(time: config.fullFunctionalTestTimeout, unit: 'MINUTES', action: 'Functional tests') {
+                        builder.fullFunctionalTest()
+                      }
                     }
+                  } catch (err) {
+                    passed = false
+                  } finally {
+                    savePodsLogs(dockerImage, params, "full-functional")
+                  }
+                  if (!passed) {
+                    clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
+                    error('Functional test (Full) failed')
+                  }
+                }
+              }
+            } else {
+              stageWithAgent("Functional Test - ${environment}", product) {
+                testEnv(aksUrl) {
+                  def passed = true
+                  try {
+                    pcr.callAround("functionalTest:${environment}") {
+                      timeoutWithMsg(time: 40, unit: 'MINUTES', action: 'Functional Test - AKS') {
+                        builder.functionalTest()
+                      }
+                    }
+                  } catch (err) {
+                    passed = false
+                  } finally {
+                    savePodsLogs(dockerImage, params, "functional")
+                  }
+                  if (!passed) {
+                    clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
+                    error('Functional test failed')
                   }
                 }
               }
             }
-            // Performance Test Pipeline: Setup -> Parallel Testing
-            if ((config.performanceTestStages || config.gatlingLoadTests) && environment in config.performanceTestEnvironments) {
+          }
 
-              // Load performance test secrets once for all stages - Secrets are stored only within the
-              // rpe-shared-perftest KV for all environments (they are DT API keys and not env specific)
-              def perfKeyVaultUrl = "https://rpe-shared-perftest.vault.azure.net"   //https://et-perftest.vault.azure.net/
-              def perfSecrets = [
-                [$class: 'AzureKeyVaultSecret', secretType: 'Secret', name: 'perf-synthetic-monitor-token', version: '', envVariable: 'PERF_SYNTHETIC_MONITOR_TOKEN'],
-                [$class: 'AzureKeyVaultSecret', secretType: 'Secret', name: 'perf-metrics-token', version: '', envVariable: 'PERF_METRICS_TOKEN'],
-                [$class: 'AzureKeyVaultSecret', secretType: 'Secret', name: 'perf-event-token', version: '', envVariable: 'PERF_EVENT_TOKEN'],
-                [$class: 'AzureKeyVaultSecret', secretType: 'Secret', name: 'perf-synthetic-update-token', version: '', envVariable: 'PERF_SYNTHETIC_UPDATE_TOKEN']
-              ]
+          if (config.performanceTest) {
+            stageWithAgent("Performance Test - ${environment}", product) {
+              testEnv(aksUrl) {
+                pcr.callAround("performanceTest:${environment}") {
+                  timeoutWithMsg(time: 120, unit: 'MINUTES', action: "Performance Test - ${environment} (staging slot)") {
+                    builder.performanceTest()
+                    publishPerformanceReports(params)
+                  }
+                }
+              }
+            }
+          }
+          // Performance Test Pipeline: Setup -> Parallel Testing
+          if ((config.performanceTestStages || config.gatlingLoadTests) && environment in config.performanceTestEnvironments) {
 
-              // Add IDAM test support URL secret if IDAM test user is enabled
-              if (config.idamTestUser) {
-                perfSecrets << [$class: 'AzureKeyVaultSecret', secretType: 'Secret', name: 'idam-test-support-url', version: '', envVariable: 'IDAM_TEST_SUPPORT_URL']
+            // Load performance test secrets once for all stages - Secrets are stored only within the
+            // rpe-shared-perftest KV for all environments (they are DT API keys and not env specific)
+            def perfKeyVaultUrl = "https://rpe-shared-perftest.vault.azure.net"   //https://et-perftest.vault.azure.net/
+            def perfSecrets = [
+              [$class: 'AzureKeyVaultSecret', secretType: 'Secret', name: 'perf-synthetic-monitor-token', version: '', envVariable: 'PERF_SYNTHETIC_MONITOR_TOKEN'],
+              [$class: 'AzureKeyVaultSecret', secretType: 'Secret', name: 'perf-metrics-token', version: '', envVariable: 'PERF_METRICS_TOKEN'],
+              [$class: 'AzureKeyVaultSecret', secretType: 'Secret', name: 'perf-event-token', version: '', envVariable: 'PERF_EVENT_TOKEN'],
+              [$class: 'AzureKeyVaultSecret', secretType: 'Secret', name: 'perf-synthetic-update-token', version: '', envVariable: 'PERF_SYNTHETIC_UPDATE_TOKEN']
+            ]
+
+            // Add IDAM test support URL secret if IDAM test user is enabled
+            if (config.idamTestUser) {
+              perfSecrets << [$class: 'AzureKeyVaultSecret', secretType: 'Secret', name: 'idam-test-support-url', version: '', envVariable: 'IDAM_TEST_SUPPORT_URL']
+            }
+
+            withAzureKeyvault(
+              azureKeyVaultSecrets: perfSecrets,
+              keyVaultURLOverride: perfKeyVaultUrl
+            ) {
+
+              // Stage 1: Dynatrace Setup - Post build info, events, and metrics first
+              // Run setup for any performance testing (synthetic or gatling) to ensure DT events/metrics are sent
+              stageWithAgent("Dynatrace Performance Setup - ${environment}", product) {
+                testEnv(aksUrl) {
+                  def success = true
+                  try {
+                    pcr.callAround("dynatracePerformanceSetup:${environment}") {
+                      timeoutWithMsg(time: 5, unit: 'MINUTES', action: "Dynatrace Performance Setup - ${environment}") {
+                        dynatracePerformanceSetup([
+                          product: product,
+                          component: component,
+                          environment: environment,
+                          configPath: config.performanceTestConfigPath,
+                          idamTestUserEnabled: config.idamTestUser,
+                          idamTestUserEmail: config.idamTestUserEmail,
+                          idamTestUserForename: config.idamTestUserForename,
+                          idamTestUserSurname: config.idamTestUserSurname,
+                          idamTestUserPassword: config.idamTestUserPassword,
+                          idamTestUserRoles: config.idamTestUserRoles
+                        ])
+                      }
+                    }
+                  } catch (err) {
+                    success = false
+                    echo "Dynatrace setup failed: ${err.message}"
+                    // Don't fail the build for setup issues, continue with tests
+                  } finally {
+                    savePodsLogs(dockerImage, params, "dynatrace-setup")
+                  }
+                }
               }
 
-              withAzureKeyvault(
-                azureKeyVaultSecrets: perfSecrets,
-                keyVaultURLOverride: perfKeyVaultUrl
-              ) {
+            // Stage 2: Run performance tests in parallel (if both enabled) or sequential (if only one enabled)
+            def testStages = [:]
 
-                // Stage 1: Dynatrace Setup - Post build info, events, and metrics first
-                // Run setup for any performance testing (synthetic or gatling) to ensure DT events/metrics are sent
-                stageWithAgent("Dynatrace Performance Setup - ${environment}", product) {
+            if (config.performanceTestStages) {
+              testStages['Dynatrace Synthetic Tests'] = {
+                stageWithAgent("Dynatrace Synthetic Tests - ${environment}", product) {
                   testEnv(aksUrl) {
                     def success = true
                     try {
-                      pcr.callAround("dynatracePerformanceSetup:${environment}") {
-                        timeoutWithMsg(time: 5, unit: 'MINUTES', action: "Dynatrace Performance Setup - ${environment}") {
-                          dynatracePerformanceSetup([
-                            product             : product,
-                            component           : component,
-                            environment         : environment,
-                            configPath          : config.performanceTestConfigPath,
-                            idamTestUserEnabled : config.idamTestUser,
-                            idamTestUserEmail   : config.idamTestUserEmail,
-                            idamTestUserForename: config.idamTestUserForename,
-                            idamTestUserSurname : config.idamTestUserSurname,
-                            idamTestUserPassword: config.idamTestUserPassword,
-                            idamTestUserRoles   : config.idamTestUserRoles
+                      pcr.callAround("dynatraceSyntheticTest:${environment}") {
+                        timeoutWithMsg(time: config.performanceTestStagesTimeout, unit: 'MINUTES', action: "Dynatrace Synthetic Tests - ${environment}") {
+                          dynatraceSyntheticTest([
+                            product: product,
+                            component: component,
+                            environment: environment,
+                            performanceTestStagesEnabled: config.performanceTestStages,
+                            gatlingLoadTestsEnabled: config.gatlingLoadTests
                           ])
                         }
                       }
                     } catch (err) {
                       success = false
-                      echo "Dynatrace setup failed: ${err.message}"
-                      // Don't fail the build for setup issues, continue with tests
+                      throw err
                     } finally {
-                      savePodsLogs(dockerImage, params, "dynatrace-setup")
-                    }
-                  }
-                }
-
-                // Stage 2: Run performance tests in parallel (if both enabled) or sequential (if only one enabled)
-                def testStages = [:]
-
-                if (config.performanceTestStages) {
-                  testStages['Dynatrace Synthetic Tests'] = {
-                    stageWithAgent("Dynatrace Synthetic Tests - ${environment}", product) {
-                      testEnv(aksUrl) {
-                        def success = true
-                        try {
-                          pcr.callAround("dynatraceSyntheticTest:${environment}") {
-                            timeoutWithMsg(time: config.performanceTestStagesTimeout, unit: 'MINUTES', action: "Dynatrace Synthetic Tests - ${environment}") {
-                              dynatraceSyntheticTest([
-                                product                     : product,
-                                component                   : component,
-                                environment                 : environment,
-                                performanceTestStagesEnabled: config.performanceTestStages,
-                                gatlingLoadTestsEnabled     : config.gatlingLoadTests
-                              ])
-                            }
-                          }
-                        } catch (err) {
-                          success = false
-                          throw err
-                        } finally {
-                          savePodsLogs(dockerImage, params, "dynatrace-synthetic")
-                          if (!success) {
-                            clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
-                          }
-                        }
+                      savePodsLogs(dockerImage, params, "dynatrace-synthetic")
+                      if (!success) {
+                        clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
                       }
                     }
                   }
                 }
+              }
+            }
 
-                if (config.gatlingLoadTests) {
-                  testStages['Gatling Load Tests'] = {
-                    stageWithAgent("Gatling Load Tests - ${environment}", product) {
-                      testEnv(aksUrl) {
-                        def success = true
-                        try {
-                          pcr.callAround("gatlingLoadTests:${environment}") {
-                            timeoutWithMsg(time: config.gatlingLoadTestTimeout, unit: 'MINUTES', action: "Gatling Load Tests - ${environment}") {
-                              gatlingExternalLoadTest([
-                                product          : product,
-                                component        : component,
-                                environment      : environment,
-                                subscription     : subscription,
-                                gatlingRepo      : config.gatlingRepo,
-                                gatlingBranch    : config.gatlingBranch,
-                                gatlingSimulation: config.gatlingSimulation
-                              ])
-                            }
-                          }
-                        } catch (err) {
-                          success = false
-                          throw err
-                        } finally {
-                          savePodsLogs(dockerImage, params, "gatling-load-tests")
-                          if (!success) {
-                            clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-
-                // Execute test stages
-                if (testStages.size() > 1) {
-                  echo "Running Dynatrace Synthetic Tests and Gatling Load Tests in parallel..."
-                  parallel(testStages)
-                } else {
-                  echo "Running single performance test stage..."
-                  testStages.values().first().call()
-                }
-
-                // Stage 3: Site Reliability Guardian Evaluation (if enabled)
-                if (config.srgEvaluation) {
-                  stageWithAgent("Site Reliability Guardian Evaluation - ${environment}", product) {
-                    testEnv(aksUrl) {
-                      try {
-                        pcr.callAround("srgEvaluation:${environment}") {
-                          evaluateDynatraceSRG([
-                            environment             : environment,
-                            srgServiceName          : config.srgServiceName,
-                            performanceTestStartTime: env.PERF_TEST_START_TIME,
-                            performanceTestEndTime  : env.PERF_TEST_END_TIME,
-                            gatlingTestStartTime    : env.GATLING_TEST_START_TIME,
-                            gatlingTestEndTime      : env.GATLING_TEST_END_TIME,
-                            srgFailureBehavior      : config.srgFailureBehavior,
-                            product                 : product,
-                            component               : component
+            if (config.gatlingLoadTests) {
+              testStages['Gatling Load Tests'] = {
+                stageWithAgent("Gatling Load Tests - ${environment}", product) {
+                  testEnv(aksUrl) {
+                    def success = true
+                    try {
+                      pcr.callAround("gatlingLoadTests:${environment}") {
+                        timeoutWithMsg(time: config.gatlingLoadTestTimeout, unit: 'MINUTES', action: "Gatling Load Tests - ${environment}") {
+                          gatlingExternalLoadTest([
+                            product: product,
+                            component: component,
+                            environment: environment,
+                            subscription: subscription,
+                            gatlingRepo: config.gatlingRepo,
+                            gatlingBranch: config.gatlingBranch,
+                            gatlingSimulation: config.gatlingSimulation
                           ])
                         }
-                      } catch (Exception e) {
-                        echo "SRG evaluation stage failed: ${e.message}"
-                        if (config.srgFailureBehavior == 'fail') {
-                          clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
-                          throw e
-                        }
                       }
-                    }
-                  }
-                }
-              } // End withAzureKeyvault block
-            } // End if (config.performanceTestStages || config.gatlingLoadTests)
-
-            onMaster {
-              if (config.crossBrowserTest) {
-                stageWithAgent("CrossBrowser Test - AKS ${environment}", product) {
-                  testEnv(aksUrl) {
-                    pcr.callAround("crossBrowserTest:${environment}") {
-                      builder.crossBrowserTest()
-                    }
-                  }
-                }
-              }
-              if (config.mutationTest) {
-                stageWithAgent("Mutation Test - AKS ${environment}", product) {
-                  testEnv(aksUrl) {
-                    pcr.callAround("mutationTest:${environment}") {
-                      builder.mutationTest()
-                    }
-                  }
-                }
-              }
-              if (config.fullFunctionalTest) {
-                stageWithAgent("FullFunctional Test - AKS ${environment}", product) {
-                  testEnv(aksUrl) {
-                    pcr.callAround("fullFunctionalTest:${environment}") {
-                      builder.fullFunctionalTest()
-                    }
-                  }
-                }
-              }
-              if (config.e2eTest) {
-                stageWithAgent("E2E Test - AKS ${environment}", product) {
-                  testEnv(aksUrl) {
-                    def passed = catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                      pcr.callAround("E2eTest:${environment}") {
-                        builder.e2eTest()
+                    } catch (err) {
+                      success = false
+                      throw err
+                    } finally {
+                      savePodsLogs(dockerImage, params, "gatling-load-tests")
+                      if (!success) {
+                        clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
                       }
-                    }
-                    savePodsLogs(dockerImage, params, "e2e")
-                    if (passed == false) {
-                      clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
-                      error('E2E test failed')
                     }
                   }
                 }
               }
             }
+
+              // Execute test stages
+              if (testStages.size() > 1) {
+                echo "Running Dynatrace Synthetic Tests and Gatling Load Tests in parallel..."
+                parallel(testStages)
+              } else {
+                echo "Running single performance test stage..."
+                testStages.values().first().call()
+              }
+
+              // Stage 3: Site Reliability Guardian Evaluation (if enabled)
+              if (config.srgEvaluation) {
+                stageWithAgent("Site Reliability Guardian Evaluation - ${environment}", product) {
+                  testEnv(aksUrl) {
+                    try {
+                      pcr.callAround("srgEvaluation:${environment}") {
+                        evaluateDynatraceSRG([
+                          environment: environment,
+                          srgServiceName: config.srgServiceName,
+                          performanceTestStartTime: env.PERF_TEST_START_TIME,
+                          performanceTestEndTime: env.PERF_TEST_END_TIME,
+                          gatlingTestStartTime: env.GATLING_TEST_START_TIME,
+                          gatlingTestEndTime: env.GATLING_TEST_END_TIME,
+                          srgFailureBehavior: config.srgFailureBehavior,
+                          product: product,
+                          component: component
+                        ])
+                      }
+                    } catch (Exception e) {
+                      echo "SRG evaluation stage failed: ${e.message}"
+                      if (config.srgFailureBehavior == 'fail') {
+                        clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
+                        throw e
+                      }
+                    }
+                  }
+                }
+              }
+            } // End withAzureKeyvault block
+          } // End if (config.performanceTestStages || config.gatlingLoadTests)
+
+          onMaster {
+            if (config.crossBrowserTest) {
+              stageWithAgent("CrossBrowser Test - AKS ${environment}", product) {
+                testEnv(aksUrl) {
+                  pcr.callAround("crossBrowserTest:${environment}") {
+                    builder.crossBrowserTest()
+                  }
+                }
+              }
+            }
+            if (config.mutationTest) {
+              stageWithAgent("Mutation Test - AKS ${environment}", product) {
+                testEnv(aksUrl) {
+                  pcr.callAround("mutationTest:${environment}") {
+                    builder.mutationTest()
+                  }
+                }
+              }
+            }
+            if (config.fullFunctionalTest) {
+              stageWithAgent("FullFunctional Test - AKS ${environment}", product) {
+                testEnv(aksUrl) {
+                  pcr.callAround("fullFunctionalTest:${environment}") {
+                    builder.fullFunctionalTest()
+                  }
+                }
+              }
+            }
+            if (config.e2eTest) {
+              stageWithAgent("E2E Test - AKS ${environment}", product) {
+                testEnv(aksUrl) {
+                  def passed = catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                    pcr.callAround("E2eTest:${environment}") {
+                      builder.e2eTest()
+                    }
+                  }
+                  savePodsLogs(dockerImage, params, "e2e")
+                  if (passed == false) {
+                    clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
+                    error('E2E test failed')
+                  }
+                }
+              }
+            }
+          }
 
 //          E2E Tests:
-            onPR {
-              if (testLabels.contains('enable_e2e_test')) {
-                stageWithAgent("E2E Test - AKS ${environment}", product) {
-                  testEnv(aksUrl) {
-                    def passed = catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                      pcr.callAround("E2eTest:${environment}") {
-                        builder.e2eTest()
-                      }
+          onPR {
+            if (testLabels.contains('enable_e2e_test')) {
+              stageWithAgent("E2E Test - AKS ${environment}", product) {
+                testEnv(aksUrl) {
+                  def passed = catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                    pcr.callAround("E2eTest:${environment}") {
+                      builder.e2eTest()
                     }
-                    savePodsLogs(dockerImage, params, "e2e")
-                    if (passed == false) {
-                      clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
-                      error('E2E test failed')
+                  }
+                  savePodsLogs(dockerImage, params, "e2e")
+                  if (passed == false) {
+                    clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
+                    error('E2E test failed')
+                  }
+                }
+              }
+            }
+          }
+
+//          Performance Tests:
+          onPR {
+            if (testLabels.contains('enable_performance_test')) {
+              stageWithAgent("Performance test", product) {
+                warnError('Failure in performanceTest') {
+                  pcr.callAround('PerformanceTest') {
+                    timeoutWithMsg(time: config.perfTestTimeout, unit: 'MINUTES', action: 'Performance test') {
+                      try {
+                        builder.performanceTest()
+                      } finally {
+                        savePodsLogs(dockerImage, params, "performance")
+                      }
                     }
                   }
                 }
               }
             }
-
-//          Performance Tests:
-            onPR {
-              if (testLabels.contains('enable_performance_test')) {
-                stageWithAgent("Performance test", product) {
-                  warnError('Failure in performanceTest') {
-                    pcr.callAround('PerformanceTest') {
-                      timeoutWithMsg(time: config.perfTestTimeout, unit: 'MINUTES', action: 'Performance test') {
-                        try {
-                          builder.performanceTest()
-                        } finally {
-                          savePodsLogs(dockerImage, params, "performance")
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-              if (testLabels.contains('enable_security_scan')) {
-                testEnv(aksUrl) {
-                  stageWithAgent('Security scan', product) {
-                    warnError('Failure in securityScan') {
-                      env.ZAP_URL_EXCLUSIONS = config.securityScanUrlExclusions
-                      env.ALERT_FILTERS = config.securityScanAlertFilters
-                      env.SCAN_TYPE = config.securityScanType
-                      pcr.callAround('securityScan') {
-                        timeout(time: config.securityScanTimeout, unit: 'MINUTES') {
-                          builder.securityScan()
-                        }
+            if (testLabels.contains('enable_security_scan')) {
+              testEnv(aksUrl) {
+                stageWithAgent('Security scan', product) {
+                  warnError('Failure in securityScan') {
+                    env.ZAP_URL_EXCLUSIONS = config.securityScanUrlExclusions
+                    env.ALERT_FILTERS = config.securityScanAlertFilters
+                    env.SCAN_TYPE = config.securityScanType
+                    pcr.callAround('securityScan') {
+                      timeout(time: config.securityScanTimeout, unit: 'MINUTES') {
+                        builder.securityScan()
                       }
                     }
                   }


### PR DESCRIPTION
Notes:
* Adds a config option pulled from GitHub labels to only deploy skipping all tests, dependencies and coverage checks, ultimately failing the build after deployment (so it can't be merged without running the full pipeline) for ease of deployment for development/testing for PoCs/spikes
