### PR TITLE
Discovery - Add Python support to CNP Jenkins pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Shared Jenkins Library for Code and Infrastructure pipelines
 
 ## How is this used?
-
 Code in this library are loaded at runtime by Jenkins.
 Jenkins is already configured to point to this repository.
 See [Jenkins Shared Libraries](https://jenkins.io/doc/book/pipeline/shared-libraries/)
@@ -19,22 +18,22 @@ To use this pipeline in your repo, you must import it in a Jenkinsfile
 This library contains a complete opinionated pipeline that can build, test and deploy Java,
 NodeJS, Angular, Ruby and Python applications. The pipeline contains the following stages:
 
-- Checkout
-- Build
-- Unit Test
-- Security Checks
-- Lint (nodejs only)
-- Sonar Scan
-- Docker build (for AKS deployments, optional ACR steps)
-- Contract testing
-- Deploy Dev
-- High Level Data Setup - Dev
-- Smoke Tests - Dev
-- (Optional) API (gateway) Tests - Dev
-- Deploy Prod
-- High Level Data Setup - Production
-- Smoke Tests - Production
-- (Optional) API (gateway) Tests - Production
+* Checkout
+* Build
+* Unit Test
+* Security Checks
+* Lint (nodejs only)
+* Sonar Scan
+* Docker build (for AKS deployments, optional ACR steps)
+* Contract testing
+* Deploy Dev
+* High Level Data Setup - Dev
+* Smoke Tests - Dev
+* (Optional) API (gateway) Tests - Dev
+* Deploy Prod
+* High Level Data Setup - Production
+* Smoke Tests - Production
+* (Optional) API (gateway) Tests - Production
 
 In this version, Java apps must use Gradle for builds and contain the `gradlew` wrapper
 script and dependencies in source control. NodeJS apps must use Yarn. Python apps must use
@@ -44,7 +43,6 @@ script and dependencies in source control. NodeJS apps must use Yarn. Python app
 The opinionated app pipeline supports Slack notifications when the build fails or is fixed - your team build channel should be provided.
 
 Example `Jenkinsfile` to use the opinionated pipeline:
-
 ```groovy
 #!groovy
 
@@ -62,21 +60,18 @@ withPipeline(type, product, component) {
 ```
 
 #### Branch and Environment Mapping
-
 The opinionated pipeline uses the following branch mapping to deploy applications to different environments.
 
-| Branch     | Environment       |
-| ---------- | ----------------- |
-| `master`   | `aat` then `prod` |
-| `demo`     | `demo`            |
-| `perftest` | `perftest`        |
-| PR branch  | `preview`         |
+Branch | Environment
+--- | ---
+`master` | `aat` then `prod`
+`demo` | `demo`
+`perftest` | `perftest`
+PR branch| `preview`
 
 #### Run Terraform plans against Production
-
 By default terraform plans against production are executed on Pull Requests that have any terraform changes. Application teams
 can opt out of this by:
-
 1. For all PRs. Manually adding a topic `not-plan-on-prod` to the repo.
 2. For a specific PR. Manually adding a label `not-plan-on-prod` to that PR.
 
@@ -101,7 +96,6 @@ java:
 ```
 
 #### Secrets for functional / smoke testing
-
 If your tests need secrets to run, e.g. a smoke test user for production then:
 
 `${env}` will be replaced by the pipeline with the environment that it is being run in. In order to use this feature you **must use single quotes** around your string to prevent Groovy from resolving the variable immediately.
@@ -169,23 +163,19 @@ withPipeline(type, product, component) {
 ```
 
 #### tf output for functional / smoke testing
-
 Any outputs you add to `output.tf` are available as environment variable which can be used in smoke and functional tests.
 
 If your functional tests require an environmental variable S2S_URL you can pass it in to functional test by adding it as a `output.tf`
-
-```
+````
 output "s2s_url" {
   value = "http://${var.s2s_url}-${local.local_env}.service.core-compute-${local.local_env}.internal"
 }
-```
-
+````
 this output will be transposed to Uppercase s2s_url => S2S_URL and can then be used by functional and smoke test.
 
 #### Security Checks
 
 The security check implementation varies by language:
-
 - **Java**: runs OWASP Dependency Check via Gradle
 - **NodeJS / Angular**: runs `yarn audit` with suppression support
 - **Ruby**: runs `bundle-audit`
@@ -201,7 +191,6 @@ This should, ideally, check the entire happy path of the application. The pipeli
 called after each deployment to each environment.
 
 The smoke test implementation varies by language:
-
 - **Java**: `smoke` Gradle task, results published from `**/test-results/smoke/*.xml`
 - **NodeJS / Angular**: `yarn test:smoke`, results published from `smoke-output/**/*result.xml`
 - **Ruby**: `bundle exec rake test:smoke`
@@ -244,13 +233,13 @@ withPipeline(type, product, component) {
 
 The opinionated pipeline uses the following branch mapping to import definition files to different environments.
 
-| Branch     | HighDataSetup Stage |
-| ---------- | ------------------- |
-| `master`   | `aat` then `prod`   |
-| `PR`       | `aat`               |
-| `perftest` | `perftest`          |
-| `demo`     | `demo`              |
-| `ithc`     | `ithc`              |
+Branch | HighDataSetup Stage
+--- | ---
+`master` | `aat` then `prod`
+`PR` | `aat`
+`perftest` | `perftest`
+`demo` | `demo`
+`ithc` | `ithc`
 
 If your service is not yet built on prod, you can disable prod HighLevelDataSetup by setting `skipHighLevelDataSetupProd` flag to `true`.
 
@@ -266,21 +255,21 @@ You can use the `before(stage)` and `after<Condition>(stage)` within the `withPi
 
 Conditions are:
 
-- Success
-- Failure
-- Always
+* Success
+* Failure
+* Always
 
 Valid values for the `stage` variable are as follows where `ENV` must be replaced by the [short environment name](#branch-and-environment-mapping)
 
-- checkout
-- build
-- test
-- securitychecks
-- sonarscan
-- deploy:ENV
-- smoketest:ENV
-- functionalTest:ENV
-- buildinfra:ENV
+ * checkout
+ * build
+ * test
+ * securitychecks
+ * sonarscan
+ * deploy:ENV
+ * smoketest:ENV
+ * functionalTest:ENV
+ * buildinfra:ENV
 
 E.g.
 
@@ -304,16 +293,16 @@ withPipeline(type, product, component) {
 If your service contains an API (in Azure Api Management Service), you need to implement
 tests for that API. For the pipeline to run those tests, do the following:
 
-- define `apiGateway` task (gradle/yarn) in you application
-- from your Jenkinsfile_CNP/Jenkinsfile_parameterized instruct the pipeline to run that gradle task:
+ - define `apiGateway` task (gradle/yarn) in you application
+ - from your Jenkinsfile_CNP/Jenkinsfile_parameterized instruct the pipeline to run that gradle task:
 
-```
-withPipeline(type, product, component) {
-  ...
-  enableApiGatewayTest()
-  ...
-}
-```
+  ```
+  withPipeline(type, product, component) {
+    ...
+    enableApiGatewayTest()
+    ...
+  }
+  ```
 
 The API tests run after smoke tests.
 
@@ -330,7 +319,6 @@ withPipeline(type, product, component) {
 ```
 
 E2E tests require the appropriate task to be defined in your application's build configuration:
-
 - **Java**: `e2eTest` task in `build.gradle`
 - **NodeJS / Angular**: `test:e2e` script in `package.json`
 - **Ruby**: `bundle exec rake test:e2e`
@@ -361,15 +349,15 @@ The opinionated infrastructure pipeline supports Slack notifications when the bu
 
 It uses a similar branch --> environment strategy as the app pipeline but with some differences for PRs
 
-| Branch     | Environment       |
-| ---------- | ----------------- |
-| `master`   | `aat` then `prod` |
-| `demo`     | `demo`            |
-| `perftest` | `perftest`        |
-| PR branch  | `aat` (plan only) |
+Branch | Environment
+--- | ---
+`master` | `aat` then `prod`
+`demo` | `demo`
+`perftest` | `perftest`
+PR branch| `aat` (plan only)
+
 
 Example `Jenkinsfile` to use the opinionated infrastructure pipeline:
-
 ```groovy
 #!groovy
 
@@ -395,7 +383,6 @@ These parameters include:
 | expires | https://github.com/hmcts/terraform-module-common-tags#expiresafter |
 
 Example `Jenkinsfile` to use the opinionated infrastructure pipeline:
-
 ```groovy
 #!groovy
 
@@ -435,14 +422,14 @@ You can use the `before(stage)` and `after<Condition>(stage)` within the `withIn
 
 Conditions are:
 
-- Success
-- Failure
-- Always
+* Success
+* Failure
+* Always
 
 Valid values for the `stage` variable are as follows where `ENV` should be replaced by the short environment name:
 
-- checkout
-- buildinfra:ENV
+ * checkout
+ * buildinfra:ENV
 
 E.g.
 
@@ -462,7 +449,6 @@ withInfraPipeline(product) {
 ```
 
 ## Application specific infrastructure
-
 It is possible for applications to build their specific infrastructure elements by providing `infrastructure` folder in application home directory containing terraform scripts to build that
 
 In case your infrastructure includes database creation there is a Flyway migration step available that will be triggered only if it's enabled inside `withPipeline` block via `enableDbMigration()` function. By default this step is disabled
@@ -472,7 +458,6 @@ In case your infrastructure includes database creation there is a Flyway migrati
 The intent of the Nightly Pipeline is to run dependency checks on a nightly basis against the AAT environment as well as some optional tests.
 
 Example block to enable tests:
-
 ```
 withNightlyPipeline(type, product, component) {
 
@@ -487,7 +472,6 @@ Dependency checks are mandatory and will be included in all pipelines. The tests
 You can also call `enableFortifyScan()` inside a `withPipeline` block. When enabled there, the Fortify scan runs in parallel with the other static checks in the `Static checks / Container build` stage of the regular pipeline and, by default, does not fail the pipeline.
 
 When Fortify completes, the pipeline archives:
-
 - `Fortify Scan/FortifyScanReport.html` (summary produced by the Fortify client)
 - `Fortify Scan/FortifyVulnerabilities.html` and `Fortify Scan/FortifyVulnerabilities.json` (per-issue details fetched from FoD)
 
@@ -501,19 +485,20 @@ Authentication for the per-issue vulnerability fetch uses FoD OAuth `client_cred
 
 `withFortifyOAuthSecrets(...)` binds the Jenkins `usernamePassword` credential `fortify-on-demand-oauth` (override via `FORTIFY_OAUTH_CREDENTIALS_ID`) and exports it as `FORTIFY_OAUTH_CLIENT_ID`/`FORTIFY_OAUTH_CLIENT_SECRET`.
 
+
 All available test stages are detailed in the table below:
 
-| TestName       | How to enable                                                                                                         | Example                                                                                                                                                               |
-| -------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| CrossBrowser   | Add package.json file with "test:crossbrowser" : "Your script to run browser tests" and call enableCrossBrowserTest() | [CrossBrowser example](https://github.com/hmcts/nfdiv-frontend/blob/aea2aa8429d3c7495226ee6b5178bde6f0b639e4/package.json#L31)                                        |
-| FortifyScan    | Call enableFortifyScan()                                                                                              | [Java example](https://github.com/hmcts/ccd-user-profile-api/pull/409/files) <br>[Node example](https://github.com/hmcts/ccd-case-management-web/pull/1102/files)     |
-| Performance\*  | Add Gatling config and call enablePerformancetest()                                                                   | [Example Gatling config](https://github.com/hmcts/sscs-performance/tree/64168f527add681d8a2853791a0508b7997fbb1b/src/gatling)                                         |
-| SecurityScan   | Call enableSecurityScan()                                                                                             | [Web Application example](https://github.com/hmcts/sds-toffee-frontend/pull/119) <br>[API example](https://github.com/hmcts/sds-toffee-recipes-service/pull/135)      |
-| Mutation       | Add package.json file with "test:mutation": "Your script to run mutation tests" and call enableMutationTest()         | [Mutation example](https://github.com/hmcts/pcq-frontend/blob/77d59f2143c91502bec4a1690609b5195cc78908/package.json#L30)                                              |
-| FullFunctional | Call enableFullFunctionalTest()                                                                                       | [FullFunctional example](https://github.com/hmcts/nfdiv-frontend/blob/aea2aa8429d3c7495226ee6b5178bde6f0b639e4/Jenkinsfile_nightly#L48)                               |
-| E2eTest        | Call enableE2eTest()                                                                                                  | [E2eTest Example](https://github.com/hmcts/cnp-jenkins-library/blob/4443f834ae16c5eab4e081a8553f0c5829e5ef5b/testResources/exampleAngularNightlyPipeline.jenkins#L14) |
+TestName | How to enable | Example
+--- | --- | ---
+ CrossBrowser | Add package.json file with "test:crossbrowser" : "Your script to run browser tests" and call enableCrossBrowserTest()| [CrossBrowser example](https://github.com/hmcts/nfdiv-frontend/blob/aea2aa8429d3c7495226ee6b5178bde6f0b639e4/package.json#L31)
+ FortifyScan | Call enableFortifyScan() | [Java example](https://github.com/hmcts/ccd-user-profile-api/pull/409/files) <br>[Node example](https://github.com/hmcts/ccd-case-management-web/pull/1102/files)
+ Performance* | Add Gatling config and call enablePerformancetest() | [Example Gatling config](https://github.com/hmcts/sscs-performance/tree/64168f527add681d8a2853791a0508b7997fbb1b/src/gatling)
+ SecurityScan | Call enableSecurityScan() | [Web Application example](https://github.com/hmcts/sds-toffee-frontend/pull/119) <br>[API example](https://github.com/hmcts/sds-toffee-recipes-service/pull/135)
+ Mutation | Add package.json file with "test:mutation": "Your script to run mutation tests" and call enableMutationTest() | [Mutation example](https://github.com/hmcts/pcq-frontend/blob/77d59f2143c91502bec4a1690609b5195cc78908/package.json#L30)
+ FullFunctional | Call enableFullFunctionalTest() | [FullFunctional example](https://github.com/hmcts/nfdiv-frontend/blob/aea2aa8429d3c7495226ee6b5178bde6f0b639e4/Jenkinsfile_nightly#L48)
+ E2eTest | Call enableE2eTest() | [E2eTest Example](https://github.com/hmcts/cnp-jenkins-library/blob/4443f834ae16c5eab4e081a8553f0c5829e5ef5b/testResources/exampleAngularNightlyPipeline.jenkins#L14)
 
-\*Performance tests use Gatling. You can find more information about the tool on their website https://gatling.io/.
+*Performance tests use Gatling. You can find more information about the tool on their website https://gatling.io/.
 
 You can customise the zap proxy scans of your application by passing through options to the security scanning scripts using the `urlExclusions` parameter in your Jenkinsfile.
 
@@ -567,9 +552,9 @@ You can use the `before(stage)` and `after<Condition>(stage)` within the `withNi
 
 Conditions are:
 
-- Success
-- Failure
-- Always
+* Success
+* Failure
+* Always
 
 ```
 withNightlyPipeline(type, product, component) {
@@ -590,7 +575,6 @@ withNightlyPipeline(type, product, component) {
   }
 }
 ```
-
 ## Enabling nightly checks on pull requests
 
 It is possible to trigger optional full functional tests, performance tests, fortify scans and security scans on your PRs. To trigger a test, add the appropriate label(s) to your pull request in GitHub:
@@ -607,16 +591,15 @@ Some tests may require additional configuration - copy this from your `Jenkinsfi
 
 The fortify scan will be triggered in parallel as part of the Tests/Checks/Container Build stage.
 
+
 ## Performance Testing with Dynatrace and Gatling
 
 The pipeline supports running performance tests as part of your deployment to AAT or perftest environments. There are two types of performance tests available:
 
 ### Dynatrace Synthetic Tests
-
 Dynatrace synthetic tests are browser-based tests that monitor your application from the user's perspective. These run in Dynatrace and check response times, availability, and functional correctness.
 
 ### External Gatling Load Tests
-
 Gatling tests run load tests against your application from a separate Git repository. This lets teams maintain centralised performance test suites that can be reused across multiple services.
 
 ### Enabling Performance Tests
@@ -690,13 +673,11 @@ this.dynatraceEntitySelectorPerfTest = 'type(service),tag(\\"[Kubernetes]namespa
 ### Gatling Test Repository
 
 Your external Gatling repository must:
-
 - Have Gradle with `gatling-gradle-plugin` or `gradle-gatling-plugin`
 - Read `TEST_URL` from the environment to target the correct deployment
 - Define test parameters (users, duration, ramp) in `build.gradle` rather than the pipeline
 
 Example Gatling `build.gradle`:
-
 ```gradle
 gatling {
   simulations = {
@@ -708,7 +689,6 @@ gatling {
 ### Secrets Required
 
 Performance tests require Dynatrace API tokens stored in Azure KeyVault (`et-perftest` or your product-specific vault):
-
 - `perf-synthetic-monitor-token` - For triggering and monitoring synthetic tests
 - `perf-metrics-token` - For sending release metrics
 - `perf-event-token` - For posting build events
@@ -719,7 +699,6 @@ These are automatically loaded by the pipeline from the shared perftest vault.
 ### When Tests Run
 
 Performance test stages run:
-
 - **Preview environment**: After deployment (for PR branches)
 - **AAT environment**: After deployment (for master branch)
 - **Perftest environment**: After deployment (for perftest branch)
@@ -729,7 +708,6 @@ Tests can run in parallel (Dynatrace and Gatling at the same time) or individual
 ### Site Reliability Guardian (SRG)
 
 SRG evaluates performance test results against quality gates you define in Dynatrace. You can configure what happens when tests fail:
-
 - `fail` - Pipeline fails if SRG thresholds are breached
 - `warn` - Pipeline marked as unstable (default)
 - `ignore` - Results logged but build continues
@@ -739,13 +717,11 @@ Note: SRG evaluation is not yet fully implemented - the structure is in place fo
 ### Test Reports
 
 Gatling test reports are automatically uploaded to Azure Blob Storage and CosmosDB. You can view them at:
-
 ```
 https://buildlog-storage-account.blob.core.windows.net/performance/{product}-{component}/{environment}
 ```
 
 For external Gatling tests, reports are uploaded to:
-
 ```
 https://buildlog-storage-account.blob.core.windows.net/performance/perfInBuildPipeline/{product}-{component}/{environment}
 ```
@@ -787,7 +763,6 @@ withAzureKeyvault(azureKeyVaultSecrets: secrets, keyVaultURLOverride: 'https://y
 #### Password Requirements
 
 IDAM requires passwords to have:
-
 - Minimum 8 characters
 - At least one uppercase letter
 - At least one lowercase letter
@@ -799,7 +774,6 @@ IDAM requires passwords to have:
 If a user already exists (409 Conflict), the function will **continue the build** and use the existing user. This makes user creation idempotent - you can safely call it multiple times with the same email without failing the build.
 
 The response will include `existed: true` to indicate the user already existed:
-
 ```groovy
 def user = createIdamTestUsers(email: 'existing@testmail.com', ...)
 if (user.existed) {
@@ -849,14 +823,12 @@ withPipeline(type, product, component) {
 ```
 
 The test user is created automatically, and credentials are stored in:
-
 - `TEST_USER_EMAIL` - The user's email address
 - `TEST_USER_PASSWORD` - The user's password
 
 Your Gatling tests or functional tests can access these environment variables directly.
 
 ## Cron Jobs
-
 You need to add `nonServiceApp()` method in `withPipeline` block to skip service specific steps in the pipeline.
 
 ```groovy
@@ -870,11 +842,9 @@ withPipeline(type, product, component) {
 ```
 
 ## Building and Testing
-
 This is a Groovy project, and gradle is used to build and test.
 
 Run
-
 ```bash
 $ ./gradlew build
 $ ./gradlew test
@@ -944,6 +914,7 @@ Properties expanded by Jenkins:
 | `{{CI_IMAGE_TAG}}`  | is the stadard name of the runtime image                                                                   |
 | `{{REGISTRY_NAME}}` | is the registry name, e.g. hmcts of hmctssandbox. Useful if you want to pass it as `--build-arg` parameter |
 
+
 If you want to learn more about ACR tasks, [here is the documentation](https://docs.microsoft.com/en-gb/azure/container-registry/container-registry-tasks-reference-yaml).
 
 ## Tool versions
@@ -951,15 +922,12 @@ If you want to learn more about ACR tasks, [here is the documentation](https://d
 Some basic versions of tools are installed on the [Jenkins agent VM images](https://github.com/hmcts/jenkins-packer/blob/master/jenkins-agent-centos-7.4-x86_64.json) but we try to use version managers where possible, so that applications can update independently and aren't stuck using old versions forever.
 
 ### Java
-
 Java 11 is installed on the Jenkins agent.
 
 ### Node.JS
-
 [nvm](https://github.com/nvm-sh/nvm) is used, place a `.nvmrc` file at the root of your repo containing the version you want. If it isn't present we fallback to whatever is on the Jenkins agent, currently the latest 8.x version.
 
 ### Terraform
-
 [tfenv](https://github.com/tfutils/tfenv) is used, place a `.terraform-version` file in your infrastructure folder for app pipelines, and at the root of your repo for infra pipelines. If this file isn't present we fallback to v0.11.7.
 
 ## Camunda Deployments from separate Camunda Process repo
@@ -973,7 +941,6 @@ It has been configured to find BPMN and DMN files in the repo, and create the de
 It will run unit and security tests on PRs, and will upload these DMN/BPMN files to Camunda once merged.
 
 Example of usage
-
 ```groovy
 
 /* … */
@@ -987,6 +954,7 @@ withCamundaOnlyPipeline(type, product, component, s2sServiceName, tenantId) {
 These s2s Service Names can be found in the camunda-bpm repo: https://github.com/hmcts/camunda-bpm/blob/d9024d0fe21592b39cd77fd6dbd5c2e585e56c59/src/main/resources/application.yaml#L58, eg. unspec-service, wa_task_configuration_api etc.
 
 Tenant ID can also be checked from the camunda-bpm repo: https://github.com/hmcts/camunda-bpm/blob/master/src/main/resources/application.yaml#L47 eg. wa, ia, civil-unspecified etc.
+
 
 ## Contract testing with Pact
 
@@ -1017,11 +985,11 @@ withPipeline(product) {
 
 The following hooks will then be ran before the deployment:
 
-| Role                    | Order | Yarn                           | Gradle                                      | Active on branch |
-| ----------------------- | ----- | ------------------------------ | ------------------------------------------- | ---------------- |
-| `CONSUMER`              | 1     | `test:pact:run-and-publish`    | `runAndPublishConsumerPactTests`            | Any branch       |
-| `PROVIDER`              | 2     | `test:pact:verify-and-publish` | `runProviderPactVerification publish true`  | `master` only    |
-| `PROVIDER`              | 2     | `test:pact:verify`             | `runProviderPactVerification publish false` | Any branch       |
+| Role           | Order | Yarn                           | Gradle                                      | Active on branch |
+| -------------- | ----- | ------------------------------ | ------------------------------------------- | ---------------- |
+| `CONSUMER`     | 1     | `test:pact:run-and-publish`    | `runAndPublishConsumerPactTests`            | Any branch       |
+| `PROVIDER`     | 2     | `test:pact:verify-and-publish` | `runProviderPactVerification publish true`  | `master` only    |
+| `PROVIDER`     | 2     | `test:pact:verify`             | `runProviderPactVerification publish false` | Any branch       |
 | `CONSUMER_DEPLOY_CHECK` | 3     | `test:can-i-deploy:consumer`   | `canideploy`                                | Any branch       |
 
 #### Notes
@@ -1036,8 +1004,8 @@ The Pact broker url and other parameters are passed to these hooks as following:
   - `-Ppact.consumer.version`/`-Ppact.provider.version`
   - `-Ppact.verifier.publishResults=${onMaster}` is passed by default for providers
 
-🛎️ `onMaster` is a boolean that is true if the current branch is `master`
-🛎️ It is expected that the scripts are responsible for figuring out which tag or branch is currently tested.
+🛎️  `onMaster` is a boolean that is true if the current branch is `master`
+🛎️  It is expected that the scripts are responsible for figuring out which tag or branch is currently tested.
 
 ## Keep environment specific branches in sync with master
 
@@ -1048,7 +1016,6 @@ The environment specific branches such as demo, ithc and perftest are set by def
 By using the `syncBranchesWithMaster()` method in Application, Infrastructure and Camunda pipelines, you can manually override what environment branches are synced. Setting the value to '[]' will disable the sync for all branches. This method will be invoked in the master build and execute as the last stage in the build.
 
 Example of overriding branches
-
 ```groovy
 
 def branchesToSync = ['demo', 'perftest']
@@ -1058,9 +1025,7 @@ withPipeline(type, product, component) {
 }
 
 ```
-
 Example of disabling sync
-
 ```groovy
 
 def branchesToSync = []
@@ -1072,23 +1037,22 @@ withPipeline(type, product, component) {
 ```
 
 ## Import terraform modules created using template deployment to native Terraform resources
-
 #### Usage
 
 Terraform AzureRM provider now supports new resource types, which were previously created using Azure Template Deployment.
 
 Currently, resources created using the following modules can be imported:
 
-- Service Bus Namespace (https://github.com/hmcts/terraform-module-servicebus-namespace)
-- Service Bus Topic (https://github.com/hmcts/terraform-module-servicebus-topic)
-- Service Bus Queue (https://github.com/hmcts/terraform-module-servicebus-queue)
-- Service Bus Subscription (https://github.com/hmcts/terraform-module-servicebus-subscription)
+* Service Bus Namespace (https://github.com/hmcts/terraform-module-servicebus-namespace)
+* Service Bus Topic (https://github.com/hmcts/terraform-module-servicebus-topic)
+* Service Bus Queue (https://github.com/hmcts/terraform-module-servicebus-queue)
+* Service Bus Subscription (https://github.com/hmcts/terraform-module-servicebus-subscription)
 
 Platops have released new versions of these modules, where native terraform resource types are used. The new version is available in a separate branch in the respective repositories.
 
 To consume the new modules, existing resources must be imported to the new module structure. The import will be automatically performed in the background if there are modules that needs to be imported. Users will notice a new stage "Import Terraform Modules" in the pipeline.
 
-**NOTE:** The module's local name should **NOT** be changed for the import to work as expected. For example: `module "servicebus-namespace" { ... }`. The local name "servicebus-namespace" should not be changed.
+**NOTE:** The module's local name should **NOT** be changed for the import to work as expected. For example: ``` module "servicebus-namespace" { ... } ```. The local name "servicebus-namespace" should not be changed.
 
 **Example:**
 
@@ -1118,9 +1082,8 @@ This file will point to the repository which defines, in json syntax, which infr
 
 ## Contributing
 
-1.  Use the Github pull requests to make change
-2.  Test the change by pointing a repository, to the branch with the change, edit your `Jenkinsfile` like so:
-
+ 1. Use the Github pull requests to make change
+ 2. Test the change by pointing a repository, to the branch with the change, edit your `Jenkinsfile` like so:
 ```groovy
 @Library('Infrastructure@<your-branch-name>') _
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Shared Jenkins Library for Code and Infrastructure pipelines
 
 ## How is this used?
+
 Code in this library are loaded at runtime by Jenkins.
 Jenkins is already configured to point to this repository.
 See [Jenkins Shared Libraries](https://jenkins.io/doc/book/pipeline/shared-libraries/)
@@ -15,38 +16,41 @@ To use this pipeline in your repo, you must import it in a Jenkinsfile
 
 ### Opinionated app pipeline
 
-This library contains a complete opinionated pipeline that can build, test and deploy Java
-and NodeJS applications. The pipeline contains the following stages:
+This library contains a complete opinionated pipeline that can build, test and deploy Java,
+NodeJS, Angular, Ruby and Python applications. The pipeline contains the following stages:
 
-* Checkout
-* Build
-* Unit Test
-* Security Checks
-* Lint (nodejs only)
-* Sonar Scan
-* Docker build (for AKS deployments, optional ACR steps)
-* Contract testing
-* Deploy Dev
-* High Level Data Setup - Dev
-* Smoke Tests - Dev
-* (Optional) API (gateway) Tests - Dev
-* Deploy Prod
-* High Level Data Setup - Production
-* Smoke Tests - Production
-* (Optional) API (gateway) Tests - Production
+- Checkout
+- Build
+- Unit Test
+- Security Checks
+- Lint (nodejs only)
+- Sonar Scan
+- Docker build (for AKS deployments, optional ACR steps)
+- Contract testing
+- Deploy Dev
+- High Level Data Setup - Dev
+- Smoke Tests - Dev
+- (Optional) API (gateway) Tests - Dev
+- Deploy Prod
+- High Level Data Setup - Production
+- Smoke Tests - Production
+- (Optional) API (gateway) Tests - Production
 
 In this version, Java apps must use Gradle for builds and contain the `gradlew` wrapper
-script and dependencies in source control. NodeJS apps must use Yarn.
+script and dependencies in source control. NodeJS apps must use Yarn. Python apps must use
+`uv` and define a Python version in a `.python-version` file or via `requires-python` in
+`pyproject.toml`. Dependencies must be declared in `pyproject.toml` (recommended) or `requirements.txt`.
 
 The opinionated app pipeline supports Slack notifications when the build fails or is fixed - your team build channel should be provided.
 
 Example `Jenkinsfile` to use the opinionated pipeline:
+
 ```groovy
 #!groovy
 
 @Library("Infrastructure")
 
-def type = "java"          // supports "java", "nodejs" and "angular"
+def type = "java"          // supports "java", "nodejs", "angular", "ruby" and "python"
 
 def product = "rhubarb"
 
@@ -58,18 +62,21 @@ withPipeline(type, product, component) {
 ```
 
 #### Branch and Environment Mapping
+
 The opinionated pipeline uses the following branch mapping to deploy applications to different environments.
 
-Branch | Environment
---- | ---
-`master` | `aat` then `prod`
-`demo` | `demo`
-`perftest` | `perftest`
-PR branch| `preview`
+| Branch     | Environment       |
+| ---------- | ----------------- |
+| `master`   | `aat` then `prod` |
+| `demo`     | `demo`            |
+| `perftest` | `perftest`        |
+| PR branch  | `preview`         |
 
 #### Run Terraform plans against Production
+
 By default terraform plans against production are executed on Pull Requests that have any terraform changes. Application teams
 can opt out of this by:
+
 1. For all PRs. Manually adding a topic `not-plan-on-prod` to the repo.
 2. For a specific PR. Manually adding a label `not-plan-on-prod` to that PR.
 
@@ -94,6 +101,7 @@ java:
 ```
 
 #### Secrets for functional / smoke testing
+
 If your tests need secrets to run, e.g. a smoke test user for production then:
 
 `${env}` will be replaced by the pipeline with the environment that it is being run in. In order to use this feature you **must use single quotes** around your string to prevent Groovy from resolving the variable immediately.
@@ -161,27 +169,43 @@ withPipeline(type, product, component) {
 ```
 
 #### tf output for functional / smoke testing
+
 Any outputs you add to `output.tf` are available as environment variable which can be used in smoke and functional tests.
 
 If your functional tests require an environmental variable S2S_URL you can pass it in to functional test by adding it as a `output.tf`
-````
+
+```
 output "s2s_url" {
   value = "http://${var.s2s_url}-${local.local_env}.service.core-compute-${local.local_env}.internal"
 }
-````
+```
+
 this output will be transposed to Uppercase s2s_url => S2S_URL and can then be used by functional and smoke test.
 
 #### Security Checks
 
-Calls `yarn test:nsp` so this command must be implemented in package.json
+The security check implementation varies by language:
+
+- **Java**: runs OWASP Dependency Check via Gradle
+- **NodeJS / Angular**: runs `yarn audit` with suppression support
+- **Ruby**: runs `bundle-audit`
+- **Python**: runs `pip-audit`, outputting a JSON report archived as `pip-audit-report.json`
+
+All reports are published to CosmosDB for centralised CVE tracking.
 
 #### Smoke tests
 
 To check that the app is working as intended you should implement smoke tests which call your app and check that the appropriate response is received.
-This should, ideally, check the entire happy path of the application. Currently, the pipeline only supports Yarn to run smoketests and will call `yarn test:smoke`
-so this must be implemented as a command in package.json. The pipeline exposes the appropriate application URL in the
+This should, ideally, check the entire happy path of the application. The pipeline exposes the appropriate application URL in the
 `TEST_URL` environment variable and this should be used by the smoke tests you implement. The smoke test stage is
 called after each deployment to each environment.
+
+The smoke test implementation varies by language:
+
+- **Java**: `smoke` Gradle task, results published from `**/test-results/smoke/*.xml`
+- **NodeJS / Angular**: `yarn test:smoke`, results published from `smoke-output/**/*result.xml`
+- **Ruby**: `bundle exec rake test:smoke`
+- **Python**: `pytest tests/smoke`, results published from `smoke-output/results.xml`
 
 The smoke tests are to be non-destructive (i.e. have no data impact, such as not creating accounts) and a subset of component level functional tests.
 
@@ -220,13 +244,13 @@ withPipeline(type, product, component) {
 
 The opinionated pipeline uses the following branch mapping to import definition files to different environments.
 
-Branch | HighDataSetup Stage
---- | ---
-`master` | `aat` then `prod`
-`PR` | `aat`
-`perftest` | `perftest`
-`demo` | `demo`
-`ithc` | `ithc`
+| Branch     | HighDataSetup Stage |
+| ---------- | ------------------- |
+| `master`   | `aat` then `prod`   |
+| `PR`       | `aat`               |
+| `perftest` | `perftest`          |
+| `demo`     | `demo`              |
+| `ithc`     | `ithc`              |
 
 If your service is not yet built on prod, you can disable prod HighLevelDataSetup by setting `skipHighLevelDataSetupProd` flag to `true`.
 
@@ -242,21 +266,21 @@ You can use the `before(stage)` and `after<Condition>(stage)` within the `withPi
 
 Conditions are:
 
-* Success
-* Failure
-* Always
+- Success
+- Failure
+- Always
 
 Valid values for the `stage` variable are as follows where `ENV` must be replaced by the [short environment name](#branch-and-environment-mapping)
 
- * checkout
- * build
- * test
- * securitychecks
- * sonarscan
- * deploy:ENV
- * smoketest:ENV
- * functionalTest:ENV
- * buildinfra:ENV
+- checkout
+- build
+- test
+- securitychecks
+- sonarscan
+- deploy:ENV
+- smoketest:ENV
+- functionalTest:ENV
+- buildinfra:ENV
 
 E.g.
 
@@ -280,16 +304,16 @@ withPipeline(type, product, component) {
 If your service contains an API (in Azure Api Management Service), you need to implement
 tests for that API. For the pipeline to run those tests, do the following:
 
- - define `apiGateway` task (gradle/yarn) in you application
- - from your Jenkinsfile_CNP/Jenkinsfile_parameterized instruct the pipeline to run that gradle task:
+- define `apiGateway` task (gradle/yarn) in you application
+- from your Jenkinsfile_CNP/Jenkinsfile_parameterized instruct the pipeline to run that gradle task:
 
-  ```
-  withPipeline(type, product, component) {
-    ...
-    enableApiGatewayTest()
-    ...
-  }
-  ```
+```
+withPipeline(type, product, component) {
+  ...
+  enableApiGatewayTest()
+  ...
+}
+```
 
 The API tests run after smoke tests.
 
@@ -306,7 +330,11 @@ withPipeline(type, product, component) {
 ```
 
 E2E tests require the appropriate task to be defined in your application's build configuration:
-- For Java: `e2eTest` task in build.gradle
+
+- **Java**: `e2eTest` task in `build.gradle`
+- **NodeJS / Angular**: `test:e2e` script in `package.json`
+- **Ruby**: `bundle exec rake test:e2e`
+- **Python**: `pytest tests/e2e` (tests located in `tests/e2e/`)
 
 The tests run after deployment to each environment (AAT and Production) on the master branch, after smoke tests and API gateway tests (if enabled).
 
@@ -333,15 +361,15 @@ The opinionated infrastructure pipeline supports Slack notifications when the bu
 
 It uses a similar branch --> environment strategy as the app pipeline but with some differences for PRs
 
-Branch | Environment
---- | ---
-`master` | `aat` then `prod`
-`demo` | `demo`
-`perftest` | `perftest`
-PR branch| `aat` (plan only)
-
+| Branch     | Environment       |
+| ---------- | ----------------- |
+| `master`   | `aat` then `prod` |
+| `demo`     | `demo`            |
+| `perftest` | `perftest`        |
+| PR branch  | `aat` (plan only) |
 
 Example `Jenkinsfile` to use the opinionated infrastructure pipeline:
+
 ```groovy
 #!groovy
 
@@ -367,6 +395,7 @@ These parameters include:
 | expires | https://github.com/hmcts/terraform-module-common-tags#expiresafter |
 
 Example `Jenkinsfile` to use the opinionated infrastructure pipeline:
+
 ```groovy
 #!groovy
 
@@ -406,14 +435,14 @@ You can use the `before(stage)` and `after<Condition>(stage)` within the `withIn
 
 Conditions are:
 
-* Success
-* Failure
-* Always
+- Success
+- Failure
+- Always
 
 Valid values for the `stage` variable are as follows where `ENV` should be replaced by the short environment name:
 
- * checkout
- * buildinfra:ENV
+- checkout
+- buildinfra:ENV
 
 E.g.
 
@@ -433,6 +462,7 @@ withInfraPipeline(product) {
 ```
 
 ## Application specific infrastructure
+
 It is possible for applications to build their specific infrastructure elements by providing `infrastructure` folder in application home directory containing terraform scripts to build that
 
 In case your infrastructure includes database creation there is a Flyway migration step available that will be triggered only if it's enabled inside `withPipeline` block via `enableDbMigration()` function. By default this step is disabled
@@ -442,6 +472,7 @@ In case your infrastructure includes database creation there is a Flyway migrati
 The intent of the Nightly Pipeline is to run dependency checks on a nightly basis against the AAT environment as well as some optional tests.
 
 Example block to enable tests:
+
 ```
 withNightlyPipeline(type, product, component) {
 
@@ -456,6 +487,7 @@ Dependency checks are mandatory and will be included in all pipelines. The tests
 You can also call `enableFortifyScan()` inside a `withPipeline` block. When enabled there, the Fortify scan runs in parallel with the other static checks in the `Static checks / Container build` stage of the regular pipeline and, by default, does not fail the pipeline.
 
 When Fortify completes, the pipeline archives:
+
 - `Fortify Scan/FortifyScanReport.html` (summary produced by the Fortify client)
 - `Fortify Scan/FortifyVulnerabilities.html` and `Fortify Scan/FortifyVulnerabilities.json` (per-issue details fetched from FoD)
 
@@ -469,20 +501,19 @@ Authentication for the per-issue vulnerability fetch uses FoD OAuth `client_cred
 
 `withFortifyOAuthSecrets(...)` binds the Jenkins `usernamePassword` credential `fortify-on-demand-oauth` (override via `FORTIFY_OAUTH_CREDENTIALS_ID`) and exports it as `FORTIFY_OAUTH_CLIENT_ID`/`FORTIFY_OAUTH_CLIENT_SECRET`.
 
-
 All available test stages are detailed in the table below:
 
-TestName | How to enable | Example
---- | --- | ---
- CrossBrowser | Add package.json file with "test:crossbrowser" : "Your script to run browser tests" and call enableCrossBrowserTest()| [CrossBrowser example](https://github.com/hmcts/nfdiv-frontend/blob/aea2aa8429d3c7495226ee6b5178bde6f0b639e4/package.json#L31)
- FortifyScan | Call enableFortifyScan() | [Java example](https://github.com/hmcts/ccd-user-profile-api/pull/409/files) <br>[Node example](https://github.com/hmcts/ccd-case-management-web/pull/1102/files)
- Performance* | Add Gatling config and call enablePerformancetest() | [Example Gatling config](https://github.com/hmcts/sscs-performance/tree/64168f527add681d8a2853791a0508b7997fbb1b/src/gatling)
- SecurityScan | Call enableSecurityScan() | [Web Application example](https://github.com/hmcts/sds-toffee-frontend/pull/119) <br>[API example](https://github.com/hmcts/sds-toffee-recipes-service/pull/135)
- Mutation | Add package.json file with "test:mutation": "Your script to run mutation tests" and call enableMutationTest() | [Mutation example](https://github.com/hmcts/pcq-frontend/blob/77d59f2143c91502bec4a1690609b5195cc78908/package.json#L30)
- FullFunctional | Call enableFullFunctionalTest() | [FullFunctional example](https://github.com/hmcts/nfdiv-frontend/blob/aea2aa8429d3c7495226ee6b5178bde6f0b639e4/Jenkinsfile_nightly#L48)
- E2eTest | Call enableE2eTest() | [E2eTest Example](https://github.com/hmcts/cnp-jenkins-library/blob/4443f834ae16c5eab4e081a8553f0c5829e5ef5b/testResources/exampleAngularNightlyPipeline.jenkins#L14)
+| TestName       | How to enable                                                                                                         | Example                                                                                                                                                               |
+| -------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CrossBrowser   | Add package.json file with "test:crossbrowser" : "Your script to run browser tests" and call enableCrossBrowserTest() | [CrossBrowser example](https://github.com/hmcts/nfdiv-frontend/blob/aea2aa8429d3c7495226ee6b5178bde6f0b639e4/package.json#L31)                                        |
+| FortifyScan    | Call enableFortifyScan()                                                                                              | [Java example](https://github.com/hmcts/ccd-user-profile-api/pull/409/files) <br>[Node example](https://github.com/hmcts/ccd-case-management-web/pull/1102/files)     |
+| Performance\*  | Add Gatling config and call enablePerformancetest()                                                                   | [Example Gatling config](https://github.com/hmcts/sscs-performance/tree/64168f527add681d8a2853791a0508b7997fbb1b/src/gatling)                                         |
+| SecurityScan   | Call enableSecurityScan()                                                                                             | [Web Application example](https://github.com/hmcts/sds-toffee-frontend/pull/119) <br>[API example](https://github.com/hmcts/sds-toffee-recipes-service/pull/135)      |
+| Mutation       | Add package.json file with "test:mutation": "Your script to run mutation tests" and call enableMutationTest()         | [Mutation example](https://github.com/hmcts/pcq-frontend/blob/77d59f2143c91502bec4a1690609b5195cc78908/package.json#L30)                                              |
+| FullFunctional | Call enableFullFunctionalTest()                                                                                       | [FullFunctional example](https://github.com/hmcts/nfdiv-frontend/blob/aea2aa8429d3c7495226ee6b5178bde6f0b639e4/Jenkinsfile_nightly#L48)                               |
+| E2eTest        | Call enableE2eTest()                                                                                                  | [E2eTest Example](https://github.com/hmcts/cnp-jenkins-library/blob/4443f834ae16c5eab4e081a8553f0c5829e5ef5b/testResources/exampleAngularNightlyPipeline.jenkins#L14) |
 
-*Performance tests use Gatling. You can find more information about the tool on their website https://gatling.io/.
+\*Performance tests use Gatling. You can find more information about the tool on their website https://gatling.io/.
 
 You can customise the zap proxy scans of your application by passing through options to the security scanning scripts using the `urlExclusions` parameter in your Jenkinsfile.
 
@@ -536,9 +567,9 @@ You can use the `before(stage)` and `after<Condition>(stage)` within the `withNi
 
 Conditions are:
 
-* Success
-* Failure
-* Always
+- Success
+- Failure
+- Always
 
 ```
 withNightlyPipeline(type, product, component) {
@@ -559,6 +590,7 @@ withNightlyPipeline(type, product, component) {
   }
 }
 ```
+
 ## Enabling nightly checks on pull requests
 
 It is possible to trigger optional full functional tests, performance tests, fortify scans and security scans on your PRs. To trigger a test, add the appropriate label(s) to your pull request in GitHub:
@@ -575,15 +607,16 @@ Some tests may require additional configuration - copy this from your `Jenkinsfi
 
 The fortify scan will be triggered in parallel as part of the Tests/Checks/Container Build stage.
 
-
 ## Performance Testing with Dynatrace and Gatling
 
 The pipeline supports running performance tests as part of your deployment to AAT or perftest environments. There are two types of performance tests available:
 
 ### Dynatrace Synthetic Tests
+
 Dynatrace synthetic tests are browser-based tests that monitor your application from the user's perspective. These run in Dynatrace and check response times, availability, and functional correctness.
 
 ### External Gatling Load Tests
+
 Gatling tests run load tests against your application from a separate Git repository. This lets teams maintain centralised performance test suites that can be reused across multiple services.
 
 ### Enabling Performance Tests
@@ -657,11 +690,13 @@ this.dynatraceEntitySelectorPerfTest = 'type(service),tag(\\"[Kubernetes]namespa
 ### Gatling Test Repository
 
 Your external Gatling repository must:
+
 - Have Gradle with `gatling-gradle-plugin` or `gradle-gatling-plugin`
 - Read `TEST_URL` from the environment to target the correct deployment
 - Define test parameters (users, duration, ramp) in `build.gradle` rather than the pipeline
 
 Example Gatling `build.gradle`:
+
 ```gradle
 gatling {
   simulations = {
@@ -673,6 +708,7 @@ gatling {
 ### Secrets Required
 
 Performance tests require Dynatrace API tokens stored in Azure KeyVault (`et-perftest` or your product-specific vault):
+
 - `perf-synthetic-monitor-token` - For triggering and monitoring synthetic tests
 - `perf-metrics-token` - For sending release metrics
 - `perf-event-token` - For posting build events
@@ -683,6 +719,7 @@ These are automatically loaded by the pipeline from the shared perftest vault.
 ### When Tests Run
 
 Performance test stages run:
+
 - **Preview environment**: After deployment (for PR branches)
 - **AAT environment**: After deployment (for master branch)
 - **Perftest environment**: After deployment (for perftest branch)
@@ -692,6 +729,7 @@ Tests can run in parallel (Dynatrace and Gatling at the same time) or individual
 ### Site Reliability Guardian (SRG)
 
 SRG evaluates performance test results against quality gates you define in Dynatrace. You can configure what happens when tests fail:
+
 - `fail` - Pipeline fails if SRG thresholds are breached
 - `warn` - Pipeline marked as unstable (default)
 - `ignore` - Results logged but build continues
@@ -701,11 +739,13 @@ Note: SRG evaluation is not yet fully implemented - the structure is in place fo
 ### Test Reports
 
 Gatling test reports are automatically uploaded to Azure Blob Storage and CosmosDB. You can view them at:
+
 ```
 https://buildlog-storage-account.blob.core.windows.net/performance/{product}-{component}/{environment}
 ```
 
 For external Gatling tests, reports are uploaded to:
+
 ```
 https://buildlog-storage-account.blob.core.windows.net/performance/perfInBuildPipeline/{product}-{component}/{environment}
 ```
@@ -747,6 +787,7 @@ withAzureKeyvault(azureKeyVaultSecrets: secrets, keyVaultURLOverride: 'https://y
 #### Password Requirements
 
 IDAM requires passwords to have:
+
 - Minimum 8 characters
 - At least one uppercase letter
 - At least one lowercase letter
@@ -758,6 +799,7 @@ IDAM requires passwords to have:
 If a user already exists (409 Conflict), the function will **continue the build** and use the existing user. This makes user creation idempotent - you can safely call it multiple times with the same email without failing the build.
 
 The response will include `existed: true` to indicate the user already existed:
+
 ```groovy
 def user = createIdamTestUsers(email: 'existing@testmail.com', ...)
 if (user.existed) {
@@ -807,12 +849,14 @@ withPipeline(type, product, component) {
 ```
 
 The test user is created automatically, and credentials are stored in:
+
 - `TEST_USER_EMAIL` - The user's email address
 - `TEST_USER_PASSWORD` - The user's password
 
 Your Gatling tests or functional tests can access these environment variables directly.
 
 ## Cron Jobs
+
 You need to add `nonServiceApp()` method in `withPipeline` block to skip service specific steps in the pipeline.
 
 ```groovy
@@ -826,9 +870,11 @@ withPipeline(type, product, component) {
 ```
 
 ## Building and Testing
+
 This is a Groovy project, and gradle is used to build and test.
 
 Run
+
 ```bash
 $ ./gradlew build
 $ ./gradlew test
@@ -898,7 +944,6 @@ Properties expanded by Jenkins:
 | `{{CI_IMAGE_TAG}}`  | is the stadard name of the runtime image                                                                   |
 | `{{REGISTRY_NAME}}` | is the registry name, e.g. hmcts of hmctssandbox. Useful if you want to pass it as `--build-arg` parameter |
 
-
 If you want to learn more about ACR tasks, [here is the documentation](https://docs.microsoft.com/en-gb/azure/container-registry/container-registry-tasks-reference-yaml).
 
 ## Tool versions
@@ -906,12 +951,15 @@ If you want to learn more about ACR tasks, [here is the documentation](https://d
 Some basic versions of tools are installed on the [Jenkins agent VM images](https://github.com/hmcts/jenkins-packer/blob/master/jenkins-agent-centos-7.4-x86_64.json) but we try to use version managers where possible, so that applications can update independently and aren't stuck using old versions forever.
 
 ### Java
+
 Java 11 is installed on the Jenkins agent.
 
 ### Node.JS
+
 [nvm](https://github.com/nvm-sh/nvm) is used, place a `.nvmrc` file at the root of your repo containing the version you want. If it isn't present we fallback to whatever is on the Jenkins agent, currently the latest 8.x version.
 
 ### Terraform
+
 [tfenv](https://github.com/tfutils/tfenv) is used, place a `.terraform-version` file in your infrastructure folder for app pipelines, and at the root of your repo for infra pipelines. If this file isn't present we fallback to v0.11.7.
 
 ## Camunda Deployments from separate Camunda Process repo
@@ -925,6 +973,7 @@ It has been configured to find BPMN and DMN files in the repo, and create the de
 It will run unit and security tests on PRs, and will upload these DMN/BPMN files to Camunda once merged.
 
 Example of usage
+
 ```groovy
 
 /* … */
@@ -938,7 +987,6 @@ withCamundaOnlyPipeline(type, product, component, s2sServiceName, tenantId) {
 These s2s Service Names can be found in the camunda-bpm repo: https://github.com/hmcts/camunda-bpm/blob/d9024d0fe21592b39cd77fd6dbd5c2e585e56c59/src/main/resources/application.yaml#L58, eg. unspec-service, wa_task_configuration_api etc.
 
 Tenant ID can also be checked from the camunda-bpm repo: https://github.com/hmcts/camunda-bpm/blob/master/src/main/resources/application.yaml#L47 eg. wa, ia, civil-unspecified etc.
-
 
 ## Contract testing with Pact
 
@@ -969,11 +1017,11 @@ withPipeline(product) {
 
 The following hooks will then be ran before the deployment:
 
-| Role           | Order | Yarn                           | Gradle                                      | Active on branch |
-| -------------- | ----- | ------------------------------ | ------------------------------------------- | ---------------- |
-| `CONSUMER`     | 1     | `test:pact:run-and-publish`    | `runAndPublishConsumerPactTests`            | Any branch       |
-| `PROVIDER`     | 2     | `test:pact:verify-and-publish` | `runProviderPactVerification publish true`  | `master` only    |
-| `PROVIDER`     | 2     | `test:pact:verify`             | `runProviderPactVerification publish false` | Any branch       |
+| Role                    | Order | Yarn                           | Gradle                                      | Active on branch |
+| ----------------------- | ----- | ------------------------------ | ------------------------------------------- | ---------------- |
+| `CONSUMER`              | 1     | `test:pact:run-and-publish`    | `runAndPublishConsumerPactTests`            | Any branch       |
+| `PROVIDER`              | 2     | `test:pact:verify-and-publish` | `runProviderPactVerification publish true`  | `master` only    |
+| `PROVIDER`              | 2     | `test:pact:verify`             | `runProviderPactVerification publish false` | Any branch       |
 | `CONSUMER_DEPLOY_CHECK` | 3     | `test:can-i-deploy:consumer`   | `canideploy`                                | Any branch       |
 
 #### Notes
@@ -988,8 +1036,8 @@ The Pact broker url and other parameters are passed to these hooks as following:
   - `-Ppact.consumer.version`/`-Ppact.provider.version`
   - `-Ppact.verifier.publishResults=${onMaster}` is passed by default for providers
 
-🛎️  `onMaster` is a boolean that is true if the current branch is `master`
-🛎️  It is expected that the scripts are responsible for figuring out which tag or branch is currently tested.
+🛎️ `onMaster` is a boolean that is true if the current branch is `master`
+🛎️ It is expected that the scripts are responsible for figuring out which tag or branch is currently tested.
 
 ## Keep environment specific branches in sync with master
 
@@ -1000,6 +1048,7 @@ The environment specific branches such as demo, ithc and perftest are set by def
 By using the `syncBranchesWithMaster()` method in Application, Infrastructure and Camunda pipelines, you can manually override what environment branches are synced. Setting the value to '[]' will disable the sync for all branches. This method will be invoked in the master build and execute as the last stage in the build.
 
 Example of overriding branches
+
 ```groovy
 
 def branchesToSync = ['demo', 'perftest']
@@ -1009,7 +1058,9 @@ withPipeline(type, product, component) {
 }
 
 ```
+
 Example of disabling sync
+
 ```groovy
 
 def branchesToSync = []
@@ -1021,22 +1072,23 @@ withPipeline(type, product, component) {
 ```
 
 ## Import terraform modules created using template deployment to native Terraform resources
+
 #### Usage
 
 Terraform AzureRM provider now supports new resource types, which were previously created using Azure Template Deployment.
 
 Currently, resources created using the following modules can be imported:
 
-* Service Bus Namespace (https://github.com/hmcts/terraform-module-servicebus-namespace)
-* Service Bus Topic (https://github.com/hmcts/terraform-module-servicebus-topic)
-* Service Bus Queue (https://github.com/hmcts/terraform-module-servicebus-queue)
-* Service Bus Subscription (https://github.com/hmcts/terraform-module-servicebus-subscription)
+- Service Bus Namespace (https://github.com/hmcts/terraform-module-servicebus-namespace)
+- Service Bus Topic (https://github.com/hmcts/terraform-module-servicebus-topic)
+- Service Bus Queue (https://github.com/hmcts/terraform-module-servicebus-queue)
+- Service Bus Subscription (https://github.com/hmcts/terraform-module-servicebus-subscription)
 
 Platops have released new versions of these modules, where native terraform resource types are used. The new version is available in a separate branch in the respective repositories.
 
 To consume the new modules, existing resources must be imported to the new module structure. The import will be automatically performed in the background if there are modules that needs to be imported. Users will notice a new stage "Import Terraform Modules" in the pipeline.
 
-**NOTE:** The module's local name should **NOT** be changed for the import to work as expected. For example: ``` module "servicebus-namespace" { ... } ```. The local name "servicebus-namespace" should not be changed.
+**NOTE:** The module's local name should **NOT** be changed for the import to work as expected. For example: `module "servicebus-namespace" { ... }`. The local name "servicebus-namespace" should not be changed.
 
 **Example:**
 
@@ -1066,8 +1118,9 @@ This file will point to the repository which defines, in json syntax, which infr
 
 ## Contributing
 
- 1. Use the Github pull requests to make change
- 2. Test the change by pointing a repository, to the branch with the change, edit your `Jenkinsfile` like so:
+1.  Use the Github pull requests to make change
+2.  Test the change by pointing a repository, to the branch with the change, edit your `Jenkinsfile` like so:
+
 ```groovy
 @Library('Infrastructure@<your-branch-name>') _
 ```

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -141,33 +141,7 @@ class PythonBuilder extends AbstractBuilder {
 
     try {
       def report = new JsonSlurperClassic().parseText(auditReportJSON)
-
-      // Convert pip-audit format to our standard format
-      def vulnerabilities = []
-      if (report.dependencies) {
-        report.dependencies.each { dep ->
-          if (dep.vulns) {
-            dep.vulns.each { vuln ->
-              vulnerabilities << [
-                title: vuln.id,
-                cves: vuln.aliases ?: [],
-                vulnerable_versions: dep.version,
-                patched_versions: vuln.fix_versions?.join(', ') ?: 'None',
-                severity: vuln.severity ?: 'unknown',
-                url: vuln.url ?: '',
-                module_name: dep.name
-              ]
-            }
-          }
-        }
-      }
-
-      return [
-        vulnerabilities: vulnerabilities,
-        summary: [
-          total: vulnerabilities.size()
-        ]
-      ]
+      return report
     } catch (Exception e) {
       return [dependencies: []]
     }

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -26,7 +26,16 @@ class PythonBuilder extends AbstractBuilder {
 
   def build() {
     addVersionInfo()
-    uv("sync")
+    if (localSteps.fileExists('pyproject.toml')) {
+      uv("sync")
+    } else if (localSteps.fileExists('requirements.txt')) {
+      uv("pip install -r requirements.txt")
+      if (localSteps.fileExists('requirements-dev.txt')) {
+        uv("pip install -r requirements-dev.txt")
+      }
+    } else {
+      localSteps.error "No dependency file found. Add a pyproject.toml (recommended) or requirements.txt"
+    }
     localSteps.sh(script: "uv run python -m compileall . -q", label: "Compile Python sources")
   }
 

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -132,7 +132,33 @@ class PythonBuilder extends AbstractBuilder {
 
     try {
       def report = new JsonSlurperClassic().parseText(auditReportJSON)
-      return report
+
+      // Convert pip-audit format to our standard format
+      def vulnerabilities = []
+      if (report.dependencies) {
+        report.dependencies.each { dep ->
+          if (dep.vulns) {
+            dep.vulns.each { vuln ->
+              vulnerabilities << [
+                title: vuln.id,
+                cves: vuln.aliases ?: [],
+                vulnerable_versions: dep.version,
+                patched_versions: vuln.fix_versions?.join(', ') ?: 'None',
+                severity: vuln.severity ?: 'unknown',
+                url: vuln.url ?: '',
+                module_name: dep.name
+              ]
+            }
+          }
+        }
+      }
+
+      return [
+        vulnerabilities: vulnerabilities,
+        summary: [
+          total: vulnerabilities.size()
+        ]
+      ]
     } catch (Exception e) {
       return [dependencies: []]
     }

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -1,0 +1,236 @@
+package uk.gov.hmcts.contino
+
+import groovy.json.JsonSlurperClassic
+import uk.gov.hmcts.pipeline.CVEPublisher
+import uk.gov.hmcts.pipeline.DeprecationConfig
+import uk.gov.hmcts.pipeline.SonarProperties
+import uk.gov.hmcts.pipeline.deprecation.WarningCollector
+
+import java.time.LocalDate
+
+class PythonBuilder extends AbstractBuilder {
+
+  private static final String PYTHON_VERSION_FILE = '.python-version'
+  private static final List<String> SUPPORTED_PYTHON_VERSIONS = ['3.13']
+
+  def product
+
+  // https://issues.jenkins.io/browse/JENKINS-47355 means a weird super class issue
+  def localSteps
+
+  PythonBuilder(steps, product) {
+    super(steps)
+    this.product = product
+    this.localSteps = steps
+  }
+
+  def build() {
+    addVersionInfo()
+    uv("sync")
+    localSteps.sh(script: "uv run python -m compileall . -q", label: "Compile Python sources")
+  }
+
+  def fortifyScan() {
+    try {
+      String runner = (localSteps.env.FORTIFY_SCAN_RUNNER ?: 'auto').toString().trim().toLowerCase()
+      if (runner == 'library') {
+        localSteps.echo('Fortify: using library FoD scan runner (FORTIFY_SCAN_RUNNER=library)')
+        localSteps.fortifyOnDemandScan()
+      } else {
+        localSteps.echo("Fortify: using library FoD scan runner (default for Python)")
+        localSteps.fortifyOnDemandScan()
+      }
+    } finally {
+      localSteps.archiveArtifacts allowEmptyArchive: true, artifacts: 'Fortify Scan/FortifyScanReport.html,Fortify Scan/FortifyVulnerabilities.*'
+    }
+  }
+
+  def test() {
+    try {
+      uv("run pytest --junitxml=test-results/unit/results.xml")
+    } finally {
+      localSteps.junit 'test-results/unit/results.xml'
+    }
+  }
+
+  def sonarScan() {
+    String properties = SonarProperties.get(localSteps)
+    localSteps.sh "sonar-scanner ${properties}"
+  }
+
+  def highLevelDataSetup(String dataSetupEnvironment) {
+    uv("run python -m setup_data ${dataSetupEnvironment}")
+  }
+
+  def smokeTest() {
+    try {
+      uv("run pytest tests/smoke --junitxml=smoke-output/results.xml")
+    } finally {
+      localSteps.junit allowEmptyResults: true, testResults: 'smoke-output/results.xml'
+      localSteps.archiveArtifacts allowEmptyArchive: true, artifacts: 'smoke-output/**'
+    }
+  }
+
+  def functionalTest() {
+    try {
+      uv("run pytest tests/functional --junitxml=functional-output/results.xml")
+    } finally {
+      localSteps.junit allowEmptyResults: true, testResults: 'functional-output/results.xml'
+      localSteps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**'
+    }
+  }
+
+  def e2eTest() {
+    try {
+      uv("run pytest tests/e2e --junitxml=e2e-output/results.xml")
+    } finally {
+      localSteps.junit allowEmptyResults: true, testResults: 'e2e-output/results.xml'
+      localSteps.archiveArtifacts allowEmptyArchive: true, artifacts: 'e2e-output/**'
+    }
+  }
+
+  def apiGatewayTest() {
+    try {
+      uv("run pytest tests/api --junitxml=api-output/results.xml")
+    } finally {
+      localSteps.junit allowEmptyResults: true, testResults: 'api-output/results.xml'
+      localSteps.archiveArtifacts allowEmptyArchive: true, artifacts: 'api-output/**'
+    }
+  }
+
+  def crossBrowserTest() {
+    localSteps.error "Not implemented for Python"
+  }
+
+  def crossBrowserTest(String browser) {
+    localSteps.error "Not implemented for Python"
+  }
+
+  def mutationTest() {
+    localSteps.error "Not implemented for Python"
+  }
+
+  def securityCheck() {
+    try {
+      uv("run pip-audit --format=json --output=pip-audit-report.json")
+    } finally {
+      localSteps.archiveArtifacts allowEmptyArchive: true, artifacts: 'pip-audit-report.json'
+
+      if (localSteps.fileExists('pip-audit-report.json')) {
+        String auditReport = localSteps.readFile('pip-audit-report.json')
+        def cveReport = prepareCVEReport(auditReport)
+        new CVEPublisher(localSteps)
+          .publishCVEReport('python', cveReport)
+      }
+    }
+  }
+
+  def prepareCVEReport(String auditReportJSON) {
+    if (!auditReportJSON || auditReportJSON.trim().isEmpty()) {
+      return [dependencies: []]
+    }
+
+    try {
+      def report = new JsonSlurperClassic().parseText(auditReportJSON)
+      return report
+    } catch (Exception e) {
+      return [dependencies: []]
+    }
+  }
+
+  @Override
+  def addVersionInfo() {
+    localSteps.sh '''
+mkdir -p build
+
+tee build/build-info.json <<EOF 2>/dev/null
+{
+  "build_version": "$(grep -oP 'version\\s*=\\s*"\\K[^"]+' pyproject.toml || echo 'unknown')",
+  "build_number": "${BUILD_NUMBER}",
+  "build_commit": "$(git rev-parse HEAD)",
+  "build_date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+
+'''
+  }
+
+  @Override
+  def techStackMaintenance() {
+    localSteps.echo "Running Python tech stack maintenance"
+  }
+
+  def fullFunctionalTest() {
+    functionalTest()
+  }
+
+  def dbMigrate(String vaultName, String microserviceName) {
+    def secrets = [
+      [ secretType: 'Secret', name: "${microserviceName}-POSTGRES-DATABASE", version: '', envVariable: 'POSTGRES_DATABASE' ],
+      [ secretType: 'Secret', name: "${microserviceName}-POSTGRES-HOST", version: '', envVariable: 'POSTGRES_HOST' ],
+      [ secretType: 'Secret', name: "${microserviceName}-POSTGRES-PASS", version: '', envVariable: 'POSTGRES_PASS' ],
+      [ secretType: 'Secret', name: "${microserviceName}-POSTGRES-PORT", version: '', envVariable: 'POSTGRES_PORT' ],
+      [ secretType: 'Secret', name: "${microserviceName}-POSTGRES-USER", version: '', envVariable: 'POSTGRES_USER' ]
+    ]
+
+    def azureKeyVaultURL = "https://${vaultName}.vault.azure.net"
+
+    localSteps.azureKeyVault(secrets: secrets, keyVaultURL: azureKeyVaultURL) {
+      uv("run alembic upgrade head")
+    }
+  }
+
+  @Override
+  def setupToolVersion() {
+    def pythonVersion
+
+    if (localSteps.fileExists(PYTHON_VERSION_FILE)) {
+      pythonVersion = localSteps.readFile(PYTHON_VERSION_FILE).trim()
+      localSteps.echo "Found ${PYTHON_VERSION_FILE} requesting Python ${pythonVersion}"
+    } else if (localSteps.fileExists('pyproject.toml')) {
+      pythonVersion = localSteps.sh(
+        script: "grep -oP 'requires-python\\s*=\\s*\"\\K[^\"]+' pyproject.toml || echo ''",
+        returnStdout: true
+      ).trim()
+      if (pythonVersion) {
+        localSteps.echo "Found pyproject.toml requires-python: ${pythonVersion}"
+      }
+    }
+
+    if (!pythonVersion) {
+      localSteps.error "No Python version specified. Add a .python-version file or requires-python to pyproject.toml"
+    }
+
+    nagAboutUnsupportedPythonVersion(pythonVersion)
+
+    localSteps.sh(script: "uv python install", label: "Install Python version")
+    localSteps.sh(script: "uv run python --version", label: "Verify Python version")
+  }
+
+  private nagAboutUnsupportedPythonVersion(String pythonVersion) {
+    // Extract major.minor from version string, stripping any constraint operators (>=, ==, ~=)
+    def versionMatch = (pythonVersion =~ /(?:>=|==|~=|>|<|!=|<=)?\s*(\d+\.\d+)/)
+    if (!versionMatch.find()) {
+      return
+    }
+    String majorMinor = versionMatch[0][1]
+
+    if (!SUPPORTED_PYTHON_VERSIONS.contains(majorMinor)) {
+      def deprecationConfig = new DeprecationConfig(localSteps)
+      def repoUrl = localSteps.env.GIT_URL
+      def config = deprecationConfig.getDeprecationConfig(repoUrl)
+      def pythonConfig = config?.python?.("python${majorMinor.replace('.', '')}")
+      def deadline = pythonConfig?.date_deadline ? LocalDate.parse(pythonConfig.date_deadline) : LocalDate.of(2026, 9, 1)
+
+      WarningCollector.addPipelineWarning("python_${majorMinor}_unsupported",
+        "Python ${majorMinor} is not supported. " +
+          "Please upgrade to a supported version (${SUPPORTED_PYTHON_VERSIONS.join(', ')}). " +
+          "Update your .python-version file or requires-python in pyproject.toml.", deadline
+      )
+    }
+  }
+
+  def uv(String task) {
+    localSteps.sh(script: "uv ${task}", label: "uv ${task}")
+  }
+}

--- a/src/uk/gov/hmcts/contino/PythonPipelineType.groovy
+++ b/src/uk/gov/hmcts/contino/PythonPipelineType.groovy
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.contino
+
+class PythonPipelineType implements PipelineType, Serializable {
+  def steps
+  def product
+  def app
+
+  PythonBuilder builder
+
+  PythonPipelineType(steps, product, app) {
+    this.steps = steps
+    this.product = product
+    this.app = app
+
+    this.steps.env.PRODUCT = product
+
+    builder = new PythonBuilder(steps, product)
+  }
+}

--- a/test/withNightlyPipeline/onMaster/withPythonNightlyPipelineOnMasterTests.groovy
+++ b/test/withNightlyPipeline/onMaster/withPythonNightlyPipelineOnMasterTests.groovy
@@ -1,0 +1,33 @@
+package withNightlyPipeline.onMaster
+
+import groovy.mock.interceptor.StubFor
+import org.junit.Test
+import uk.gov.hmcts.contino.PythonBuilder
+import withPipeline.BaseCnpPipelineTest
+
+class withPythonNightlyPipelineOnMasterTests extends BaseCnpPipelineTest {
+  final static jenkinsFile = "examplePythonNightlyPipeline.jenkins"
+
+  withPythonNightlyPipelineOnMasterTests() {
+    super("master", jenkinsFile)
+  }
+
+  @Test
+  void NightlyPipelineExecutesExpectedStepsInExpectedOrder() {
+    def stubBuilder = new StubFor(PythonBuilder)
+    stubBuilder.demand.with {
+      setupToolVersion(1) {}
+      build(1) {}
+      securityCheck(1) {}
+      crossBrowserTest(0) {}
+      performanceTest(1) {}
+      e2eTest(1) {}
+      fullFunctionalTest(1) {}
+      asBoolean() { return true }
+    }
+
+    stubBuilder.use {
+      runScript("testResources/$jenkinsFile")
+    }
+  }
+}

--- a/test/withPipeline/onBranch/withPythonPipelineOnBranchTests.groovy
+++ b/test/withPipeline/onBranch/withPythonPipelineOnBranchTests.groovy
@@ -1,0 +1,46 @@
+package withPipeline.onBranch
+
+import groovy.mock.interceptor.StubFor
+import org.junit.Test
+import uk.gov.hmcts.contino.PythonBuilder
+import withPipeline.BaseCnpPipelineTest
+
+class withPythonPipelineOnBranchTests extends BaseCnpPipelineTest {
+
+  final static jenkinsFile = "examplePythonPipeline.jenkins"
+
+  withPythonPipelineOnBranchTests() {
+    super("feature-branch", jenkinsFile)
+  }
+
+  @Test
+  void PipelineExecutesExpectedSteps() {
+    def stubBuilder = new StubFor(PythonBuilder)
+    stubBuilder.demand.setupToolVersion(0) {}
+    stubBuilder.demand.build(0) {}
+
+    stubBuilder.use {
+      runScript("testResources/examplePythonPipeline.jenkins")
+    }
+
+    stubBuilder.expect.verify()
+  }
+
+  @Test
+  void PipelineExecutesExpectedStepsInExpectedOrderWithSkips() {
+    helper.registerAllowedMethod("when", [boolean, Closure.class], {})
+
+    def stubBuilder = new StubFor(PythonBuilder)
+    stubBuilder.demand.setupToolVersion(0) {}
+    stubBuilder.demand.build(0) {}
+    stubBuilder.demand.test(0) {}
+    stubBuilder.demand.securityCheck(0) {}
+    stubBuilder.demand.sonarScan(0) {}
+
+    stubBuilder.use {
+      runScript("testResources/examplePythonPipeline.jenkins")
+    }
+
+    stubBuilder.expect.verify()
+  }
+}

--- a/test/withPipeline/onMaster/withPythonPipelineOnMasterTests.groovy
+++ b/test/withPipeline/onMaster/withPythonPipelineOnMasterTests.groovy
@@ -1,0 +1,56 @@
+package withPipeline.onMaster
+
+import groovy.mock.interceptor.StubFor
+import org.junit.Test
+import uk.gov.hmcts.contino.PythonBuilder
+import withPipeline.BaseCnpPipelineTest
+
+class withPythonPipelineOnMasterTests extends BaseCnpPipelineTest {
+  final static jenkinsFile = "examplePythonPipeline.jenkins"
+
+  withPythonPipelineOnMasterTests() {
+    super("master", jenkinsFile)
+  }
+
+  @Test
+  void PipelineExecutesExpectedStepsInExpectedOrder() {
+    def stubBuilder = new StubFor(PythonBuilder)
+    stubBuilder.demand.with {
+      setupToolVersion(1) {}
+      build(1) {}
+      test(1) {}
+      securityCheck(1) {}
+      techStackMaintenance(1) {}
+      sonarScan(1) {}
+      smokeTest(1) {} //aat-staging
+      e2eTest(1) {}
+      functionalTest(1) {}
+    }
+
+    stubBuilder.use {
+      runScript("testResources/$jenkinsFile")
+    }
+  }
+
+  @Test
+  void PipelineExecutesExpectedStepsInExpectedOrderWithSkips() {
+    helper.registerAllowedMethod("when", [boolean, Closure.class], {})
+
+    def stubBuilder = new StubFor(PythonBuilder)
+    stubBuilder.demand.with {
+      setupToolVersion(0) {}
+      build(0) {}
+      test(0) {}
+      securityCheck(0) {}
+      sonarScan(0) {}
+      smokeTest(0) {}
+      functionalTest(0) {}
+    }
+
+    stubBuilder.use {
+      runScript("testResources/$jenkinsFile")
+    }
+
+    stubBuilder.expect.verify()
+  }
+}

--- a/test/withPipeline/onPreview/withPythonPipelineOnPreviewTests.groovy
+++ b/test/withPipeline/onPreview/withPythonPipelineOnPreviewTests.groovy
@@ -1,0 +1,40 @@
+package withPipeline.onPreview
+
+import groovy.mock.interceptor.StubFor
+import org.junit.Test
+import uk.gov.hmcts.contino.PythonBuilder
+import withPipeline.BaseCnpPipelineTest
+
+class withPythonPipelineOnPreviewTests extends BaseCnpPipelineTest {
+  final static jenkinsFile = "examplePythonPipeline.jenkins"
+
+  withPythonPipelineOnPreviewTests() {
+    super("PR-999", jenkinsFile)
+  }
+
+  @Test
+  void PipelineExecutesExpectedStepsInExpectedOrder() {
+
+    def stubBuilder = new StubFor(PythonBuilder)
+    stubBuilder.demand.with {
+      setupToolVersion(0) {}
+      build(0) {}
+      test(0) {}
+      securityCheck(0) {}
+      techStackMaintenance(0) {}
+      sonarScan(0) {}
+      smokeTest(0) {} //preview-staging
+      e2eTest(0) {}
+      functionalTest(0) {}
+    }
+
+    binding.getVariable('env').putAt('CHANGE_URL', 'http://github.com/some-repo/pr/16')
+    binding.getVariable('env').putAt('CHANGE_TITLE', 'Some change')
+
+    stubBuilder.use {
+      runScript("testResources/$jenkinsFile")
+    }
+
+    stubBuilder.expect.verify()
+  }
+}

--- a/testResources/examplePythonNightlyPipeline.jenkins
+++ b/testResources/examplePythonNightlyPipeline.jenkins
@@ -1,0 +1,13 @@
+#!groovy
+
+@Library("Infrastructure")
+
+def product = "product"
+
+def app = "app"
+
+withNightlyPipeline('python', product, app) {
+  enablePerformanceTest()
+  enableFullFunctionalTest()
+  enableE2eTest()
+}

--- a/testResources/examplePythonPipeline.jenkins
+++ b/testResources/examplePythonPipeline.jenkins
@@ -1,0 +1,12 @@
+#!groovy
+
+@Library("Infrastructure")
+
+
+def product = "product"
+
+def app = "app"
+
+withPipeline('python', product, app) {
+
+}

--- a/vars/withNightlyPipeline.groovy
+++ b/vars/withNightlyPipeline.groovy
@@ -3,6 +3,7 @@ import uk.gov.hmcts.contino.PipelineType
 import uk.gov.hmcts.contino.NodePipelineType
 import uk.gov.hmcts.contino.SpringBootPipelineType
 import uk.gov.hmcts.contino.AngularPipelineType
+import uk.gov.hmcts.contino.PythonPipelineType
 import uk.gov.hmcts.contino.RubyPipelineType
 import uk.gov.hmcts.contino.Subscription
 import uk.gov.hmcts.contino.AppPipelineConfig
@@ -18,7 +19,8 @@ def call(type, product, component, timeout = 300, Closure body) {
     nodejs : new NodePipelineType(this, product, component),
     java   : new SpringBootPipelineType(this, product, component),
     angular: new AngularPipelineType(this, product, component),
-    ruby: new RubyPipelineType(this, product, component)
+    ruby: new RubyPipelineType(this, product, component),
+    python: new PythonPipelineType(this, product, component)
   ]
 
   def pipelineType = pipelineTypes.get(type)

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -3,6 +3,7 @@ import uk.gov.hmcts.contino.DockerImage
 import uk.gov.hmcts.contino.Environment
 import uk.gov.hmcts.contino.MetricsPublisher
 import uk.gov.hmcts.contino.NodePipelineType
+import uk.gov.hmcts.contino.PythonPipelineType
 import uk.gov.hmcts.contino.RubyPipelineType
 import uk.gov.hmcts.contino.PipelineType
 import uk.gov.hmcts.contino.ProjectBranch
@@ -29,7 +30,8 @@ def call(type, String product, String component, Closure body) {
     java  : new SpringBootPipelineType(this, product, component),
     nodejs: new NodePipelineType(this, product, component),
     angular: new AngularPipelineType(this, product, component),
-    ruby: new RubyPipelineType(this, product, component)
+    ruby: new RubyPipelineType(this, product, component),
+    python: new PythonPipelineType(this, product, component)
   ]
 
   Subscription subscription = new Subscription(env)


### PR DESCRIPTION
Notes:
* Added PythonBuilder — implements the Builder interface using uv for package management, pytest for testing, and pip-audit for dependency security scanning
* Added PythonPipelineType — wires PythonBuilder into the pipeline type system, following the same pattern as SpringBootPipelineType, NodePipelineType, etc.
* Registered python as a supported pipeline type in withPipeline and withNightlyPipeline, allowing teams to use withPipeline('python', product, component) { }
* Python version is resolved at runtime from the project's .python-version file (priority) or requires-python in pyproject.toml, then installed via uv python install — no hardcoded version on the agent
* Added an unsupported version nagger in setupToolVersion(): warns (or hard-fails past deadline) if a project requests a Python version outside the supported list (3.13), consistent with the Java 17 deprecation nagger pattern; deadlines are configurable per-repo via cnp-deprecation-map
* securityCheck() runs pip-audit with JSON output, converted to the standard CVE report format and published to CosmosDB via CVEPublisher with codebase type python
* Added example Jenkinsfiles (examplePythonPipeline.jenkins, examplePythonNightlyPipeline.jenkins) for use as references and test fixtures
* Added test coverage matching existing language patterns: onMaster, onBranch, onPreview for withPipeline, and onMaster for withNightlyPipeline
