### PR TITLE
Allow closures on publish helm chart stage

### DIFF
--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -216,13 +216,15 @@ def call(type, String product, String component, Closure body) {
             )
 
             stageWithAgent('Publish Helm chart', product) {
-              helmPublish(
-                appPipelineConfig: pipelineConfig,
-                subscription: subscription.nonProdName,
-                environment: environment.nonProdName,
-                product: product,
-                component: component
-              )
+              callbacksRunner.callAround('Publish Helm chart') {
+                helmPublish(
+                  appPipelineConfig: pipelineConfig,
+                  subscription: subscription.nonProdName,
+                  environment: environment.nonProdName,
+                  product: product,
+                  component: component
+                )
+              }
             }
 
             sectionDeployToEnvironment(


### PR DESCRIPTION
Notes:
* Allow using `afterSuccess()` and other closures on the `Publish Helm Chart` stage of the pipeline
* Used by the PRE team to only deploy to Production when parameter set in pipeline

e.g.
```groovy
properties([
  parameters([
    booleanParam(name: 'DEPLOY_TO_PROD', defaultValue: false, description: 'Deploy to production?')
  ])
])

afterSuccess('Publish Helm chart') {
    if (!params.DEPLOY_TO_PROD) {
      echo "DEPLOY_TO_PROD not set - skipping production deployment"
      error("AUTO_ABORT: Production deployment skipped")
    }
}
```

Tested on pre-api pipeline and confirmed working as expected.