### PR TITLE
EXUI-4541: preserve Ardoq payload JSON for ACR builds

### DIFF
--- a/src/uk/gov/hmcts/ardoq/ArdoqClient.groovy
+++ b/src/uk/gov/hmcts/ardoq/ArdoqClient.groovy
@@ -73,8 +73,9 @@ class ArdoqClient {
       String jsonPayload = getJson(applicationId, repositoryName, b64Dependencies, parser, language, languageVersion)
 
       this.steps.writeFile(file: 'payload.json', text: jsonPayload);
-      // gzip the payload
-      this.steps.sh "gzip payload.json"
+      // Keep the original payload file in place so parallel docker/acr context collection
+      // cannot race a disappearing workspace file.
+      this.steps.sh "gzip -c payload.json > payload.json.gz"
 
       this.steps.sh """curl -w "%{http_code}" --location --request POST '${this.apiUrl}/api/dependencies' \
                   --header 'Authorization: Bearer ${this.apiKey}' \

--- a/test/uk/gov/hmcts/contino/ArdoqClientTest.groovy
+++ b/test/uk/gov/hmcts/contino/ArdoqClientTest.groovy
@@ -57,6 +57,26 @@ class ArdoqClientTest extends Specification {
     1 * steps.echo('Missing required parameters for tech stack maintenance')
   }
 
+  def "UpdateDependencies keeps payload.json while creating the gzipped upload"() {
+    given:
+    steps.fileExists('Dockerfile') >> true
+    steps.readFile('languageProc') >> 'node'
+    steps.readFile('languageVersionProc') >> '20-alpine'
+
+    when:
+    ardoqClient.updateDependencies("deps", "yarn")
+
+    then:
+    1 * steps.sh("grep -E '^FROM' Dockerfile | awk '{print \\$2}' | awk -F ':' '{printf(\"%s\", \\$1)}' | tr '/' '\\n' | tail -1 > languageProc")
+    1 * steps.sh("grep -E '^FROM' Dockerfile | awk '{print \\$2}' | awk -F ':' '{printf(\"%s\", \\$2)}' > languageVersionProc")
+    1 * steps.writeFile([file: 'payload.json', text: _])
+    1 * steps.sh('gzip -c payload.json > payload.json.gz')
+    1 * steps.sh({ String script ->
+      script.contains("--data-binary '@payload.json.gz'")
+    })
+    0 * steps.echo('Missing required parameters for tech stack maintenance')
+  }
+
   def "json"() {
     when:
     String json = ArdoqClient.getJson("appId", "repoName", "deps", "yarn", "java", "1.8")
@@ -75,5 +95,4 @@ class ArdoqClientTest extends Specification {
               """.stripIndent())
   }
 }
-
 


### PR DESCRIPTION
Notes:
* Jira: https://tools.hmcts.net/jira/browse/EXUI-4541
* This preserves `payload.json` while still producing `payload.json.gz` during Ardoq payload packaging.
* This is needed because `az acr build` in rpx-xui-webapp failed when the shared Jenkins-library packaging removed `payload.json` before the Docker build context was uploaded.
* Adds direct test coverage for the packaging behaviour so the original JSON payload and compressed payload are both available.
* Value: restores ACR build compatibility for consumers that still expect `payload.json` in the build context, without removing the compressed payload used by the Jenkins-library flow.
* Validation: `git diff --check` passed for the split branch. Full Jenkins-library test suite was not run after the split.
