### PR TITLE
Move initialising Github credentials to top of the pipeline initisali…

### DIFF
--- a/src/uk/gov/hmcts/contino/GithubAPI.groovy
+++ b/src/uk/gov/hmcts/contino/GithubAPI.groovy
@@ -2,6 +2,7 @@ package uk.gov.hmcts.contino
 
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurperClassic
+import jenkins.scm.api.SCMSource
 
 class GithubAPI {
 
@@ -11,6 +12,37 @@ class GithubAPI {
 
   GithubAPI(steps) {
     this.steps = steps
+  }
+
+  def initializeGitCredentials() {
+    def credentialsId = this.steps.env.GIT_CREDENTIALS_ID
+
+    if (!credentialsId) {
+      try {
+        def source = SCMSource.SourceByItem.findSource(this.steps.currentBuild.rawBuild.parent)
+        credentialsId = source?.credentialsId
+      } catch (err) {
+        this.steps.echo "Unable to resolve GIT_CREDENTIALS_ID from SCM source: ${err}"
+        return null
+      }
+
+      if (credentialsId) {
+        this.steps.env.GIT_CREDENTIALS_ID = credentialsId
+        this.steps.echo "Initialized GIT_CREDENTIALS_ID from SCM source."
+        def response = this.steps.httpRequest(
+          url: "https://api.github.com/users/$credentialsId%5Bbot%5D",
+          httpMode: 'GET',
+          acceptType: 'APPLICATION_JSON',
+          authentication: credentialsId
+        )
+        def gitUserId = this.steps.readYaml(text: response.content).id
+        this.steps.env.GIT_APP_EMAIL_ID = gitUserId + "+" + credentialsId + "[bot]@users.noreply.github.com"
+      } else {
+        this.steps.echo "Unable to resolve GIT_CREDENTIALS_ID from SCM source."
+        return null
+      }
+    }
+    return credentialsId
   }
 
   private static cachedLabelList = [

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -281,4 +281,31 @@ class GithubAPITest extends Specification {
       assertThat(masterLabelExists).isFalse()
       assertThat(prLabelExists).isTrue()
   }
+
+  def "initializeGitCredentials populates app email when credentials are already present"() {
+    given:
+      steps.httpRequest(_) >> [content: '{"id":12345}']
+      steps.readYaml(_) >> [id: 12345]
+
+    when:
+      def credentialsId = githubApi.initializeGitCredentials()
+
+    then:
+      assertThat(credentialsId).isEqualTo('test-app-id')
+      assertThat(steps.env.GIT_APP_EMAIL_ID).isEqualTo('12345+test-app-id[bot]@users.noreply.github.com')
+  }
+
+  def "initializeGitCredentials returns null when credentials are absent and scm lookup is unavailable"() {
+    given:
+      def env = [CHANGE_URL: "https://github.com/hmcts/some-project/pull/68", CHANGE_ID: "68"]
+      steps.env >> env
+      steps.currentBuild >> [:]
+
+    when:
+      def credentialsId = githubApi.initializeGitCredentials()
+
+    then:
+      assertThat(credentialsId).isNull()
+      assertThat(env.containsKey('GIT_APP_EMAIL_ID')).isFalse()
+  }
 }

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -282,30 +282,43 @@ class GithubAPITest extends Specification {
       assertThat(prLabelExists).isTrue()
   }
 
-  def "initializeGitCredentials populates app email when credentials are already present"() {
+  def "initializeGitCredentials returns existing credential id without scm lookup when already present"() {
     given:
-      steps.httpRequest(_) >> [content: '{"id":12345}']
-      steps.readYaml(_) >> [id: 12345]
+      def env = [CHANGE_URL: "https://github.com/hmcts/some-project/pull/68",
+                 CHANGE_ID: "68",
+                 GIT_CREDENTIALS_ID:"test-app-id",
+                 GIT_APP_EMAIL_ID: "12345+test-app-id[bot]@users.noreply.github.com"]
+      def localSteps = Mock(JenkinsStepMock.class)
+      localSteps.env >> env
+      def localGithubApi = new GithubAPI(localSteps)
 
     when:
-      def credentialsId = githubApi.initializeGitCredentials()
+      def credentialsId = localGithubApi.initializeGitCredentials()
 
     then:
       assertThat(credentialsId).isEqualTo('test-app-id')
-      assertThat(steps.env.GIT_APP_EMAIL_ID).isEqualTo('12345+test-app-id[bot]@users.noreply.github.com')
+      0 * localSteps.httpRequest(_)
+      0 * localSteps.readYaml(_)
   }
 
   def "initializeGitCredentials returns null when credentials are absent and scm lookup is unavailable"() {
     given:
-      def env = [CHANGE_URL: "https://github.com/hmcts/some-project/pull/68", CHANGE_ID: "68"]
-      steps.env >> env
-      steps.currentBuild >> [:]
+      def env = new Expando(
+        CHANGE_URL: "https://github.com/hmcts/some-project/pull/68",
+        CHANGE_ID: "68"
+      )
+      def localSteps = new Expando(
+        env: env,
+        currentBuild: [:],
+        echo: { String ignored -> null }
+      )
+      def localGithubApi = new GithubAPI(localSteps)
 
     when:
-      def credentialsId = githubApi.initializeGitCredentials()
+      def credentialsId = localGithubApi.initializeGitCredentials()
 
     then:
       assertThat(credentialsId).isNull()
-      assertThat(env.containsKey('GIT_APP_EMAIL_ID')).isFalse()
+      assertThat(env.properties.containsKey('GIT_APP_EMAIL_ID')).isFalse()
   }
 }

--- a/vars/checkoutScm.groovy
+++ b/vars/checkoutScm.groovy
@@ -1,6 +1,6 @@
-import jenkins.scm.api.SCMSource;
 import uk.gov.hmcts.contino.PipelineCallbacksConfig;
 import uk.gov.hmcts.contino.PipelineCallbacksRunner;
+import uk.gov.hmcts.contino.GithubAPI;
 
 /**
 * Compatibility for external consumers that were using this (mostly IDAM)
@@ -20,17 +20,6 @@ def call(params) {
       env.GIT_URL = scmVars.GIT_URL
       env.LAST_COMMIT_TIMESTAMP = steps.sh(script: "git log -1 --pretty='%cd' --date=iso | TZ=UTC date '+%Y%m%d%H%M%S' -f -", returnStdout: true)
       env.ORIGINAL_REMOTE_URL = steps.sh(script: "git config remote.origin.url", returnStdout: true).trim()
-    }
-    try {
-      def credentialsId = SCMSource.SourceByItem.findSource(currentBuild.rawBuild.parent).credentialsId
-      env.GIT_CREDENTIALS_ID = credentialsId
-      //This code assumes it uses GitHub App Authentication
-      def response = steps.httpRequest url: "https://api.github.com/users/$credentialsId%5Bbot%5D", httpMode: 'GET', acceptType: 'APPLICATION_JSON',
-        authentication: credentialsId
-      def gitUserId = steps.readYaml(text: response.content).id
-      env.GIT_APP_EMAIL_ID = gitUserId + "+" + credentialsId + "[bot]@users.noreply.github.com"
-    } catch (err) {
-      echo "Unable to find git email Id for the user' ${err}'"
     }
     warnAboutRenovateConfig()
   }

--- a/vars/withCamundaOnlyPipeline.groovy
+++ b/vars/withCamundaOnlyPipeline.groovy
@@ -1,5 +1,6 @@
 import uk.gov.hmcts.contino.AppPipelineConfig
 import uk.gov.hmcts.contino.AppPipelineDsl
+import uk.gov.hmcts.contino.GithubAPI
 import uk.gov.hmcts.contino.PipelineCallbacksConfig
 import uk.gov.hmcts.contino.PipelineCallbacksRunner
 import uk.gov.hmcts.contino.MetricsPublisher
@@ -39,6 +40,8 @@ def call(type, String product, String component, String s2sServiceName, String t
   callbacks.registerAfterAll { stage ->
     metricsPublisher.publish(stage)
   }
+
+  new GithubAPI(this).initializeGitCredentials()
 
   def dsl = new AppPipelineDsl(this, callbacks, pipelineConfig)
   body.delegate = dsl

--- a/vars/withInfraPipeline.groovy
+++ b/vars/withInfraPipeline.groovy
@@ -24,6 +24,8 @@ def call(String product, String component = null, Closure body) {
     metricsPublisher.publish(stage)
   }
 
+  new GithubAPI(this).initializeGitCredentials()
+
   def dsl = new InfraPipelineDsl(this, callbacks, pipelineConfig)
   body.delegate = dsl
   body.call() // register pipeline config

--- a/vars/withNightlyPipeline.groovy
+++ b/vars/withNightlyPipeline.groovy
@@ -3,6 +3,7 @@ import uk.gov.hmcts.contino.PipelineType
 import uk.gov.hmcts.contino.NodePipelineType
 import uk.gov.hmcts.contino.SpringBootPipelineType
 import uk.gov.hmcts.contino.AngularPipelineType
+import uk.gov.hmcts.contino.GithubAPI
 import uk.gov.hmcts.contino.RubyPipelineType
 import uk.gov.hmcts.contino.Subscription
 import uk.gov.hmcts.contino.AppPipelineConfig
@@ -35,6 +36,8 @@ def call(type, product, component, timeout = 300, Closure body) {
   callbacks.registerAfterAll { stage ->
     metricsPublisher.publish(stage)
   }
+
+  new GithubAPI(this).initializeGitCredentials()
 
   def dsl = new AppPipelineDsl(this, callbacks, pipelineConfig)
   body.delegate = dsl

--- a/vars/withPactTestOnlyPipeline.groovy
+++ b/vars/withPactTestOnlyPipeline.groovy
@@ -9,6 +9,7 @@ import uk.gov.hmcts.contino.RubyPipelineType
 import uk.gov.hmcts.contino.SpringBootPipelineType
 import uk.gov.hmcts.contino.AppPipelineConfig
 import uk.gov.hmcts.contino.AppPipelineDsl
+import uk.gov.hmcts.contino.GithubAPI
 import uk.gov.hmcts.contino.PipelineCallbacksConfig
 import uk.gov.hmcts.contino.PipelineCallbacksRunner
 import uk.gov.hmcts.pipeline.TeamConfig
@@ -40,6 +41,8 @@ def call(type, String product, String component, Closure body) {
   callbacks.registerAfterAll { stage ->
     metricsPublisher.publish(stage)
   }
+
+  new GithubAPI(this).initializeGitCredentials()
 
   def dsl = new AppPipelineDsl(this, callbacks, pipelineConfig)
   body.delegate = dsl

--- a/vars/withParameterizedInfraPipeline.groovy
+++ b/vars/withParameterizedInfraPipeline.groovy
@@ -1,5 +1,6 @@
 import uk.gov.hmcts.contino.InfraPipelineConfig
 import uk.gov.hmcts.contino.InfraPipelineDsl
+import uk.gov.hmcts.contino.GithubAPI
 import uk.gov.hmcts.contino.PipelineCallbacksConfig
 import uk.gov.hmcts.contino.PipelineCallbacksRunner
 import uk.gov.hmcts.contino.MetricsPublisher
@@ -26,6 +27,8 @@ def call(String product, String environment, String subscription, Boolean planOn
   callbacks.registerAfterAll { stage ->
     metricsPublisher.publish(stage)
   }
+
+  new GithubAPI(this).initializeGitCredentials()
 
   def dsl = new InfraPipelineDsl(this, callbacks, pipelineConfig)
   body.delegate = dsl

--- a/vars/withParameterizedPipeline.groovy
+++ b/vars/withParameterizedPipeline.groovy
@@ -8,6 +8,7 @@ import uk.gov.hmcts.contino.RubyPipelineType
 import uk.gov.hmcts.contino.SpringBootPipelineType
 import uk.gov.hmcts.contino.AppPipelineConfig
 import uk.gov.hmcts.contino.AppPipelineDsl
+import uk.gov.hmcts.contino.GithubAPI
 import uk.gov.hmcts.contino.PipelineCallbacksConfig
 import uk.gov.hmcts.contino.PipelineCallbacksRunner
 import uk.gov.hmcts.pipeline.AKSSubscriptions
@@ -44,6 +45,8 @@ def call(type, String product, String component, String environment, String subs
   callbacks.registerAfterAll { stage ->
     metricsPublisher.publish(stage)
   }
+
+  new GithubAPI(this).initializeGitCredentials()
 
   def dsl = new AppPipelineDsl(this, callbacks, pipelineConfig)
 

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -54,6 +54,8 @@ def call(type, String product, String component, Closure body) {
     metricsPublisher.publish(stage)
   }
 
+  new GithubAPI(this).initializeGitCredentials()
+
   def dsl = new AppPipelineDsl(this, callbacks, pipelineConfig)
   body.delegate = dsl
   body.call() // register pipeline config


### PR DESCRIPTION
Currently teams use GithubAPI in Jenkinsfile_CNP during evaluation like https://github.com/hmcts/pcs-api/blob/master/Jenkinsfile_CNP#L41 to do things based on the labels. Pipeline runs these even before code is checked out during registering pipeline. This makes calls unauth from Jenkins in turn it will fail subsequent calls for everyone based of the egress IP.

