### PR TITLE
Fix the sandbox artifactory name resolution for SDS where sandbox subscription is called sbox

### DIFF
--- a/resources/uk/gov/hmcts/gradle/init.gradle
+++ b/resources/uk/gov/hmcts/gradle/init.gradle
@@ -1,4 +1,6 @@
-def mirrorUrl = "https://${System.getenv("NONPROD_SUBSCRIPTION_NAME") == "sandbox" ? 'artifactory.sandbox' : 'artifactory'}.platform.hmcts.net/artifactory/maven-remotes"
+// SDS subscription name is set to 'sbox' while CNP one is set to 'sandbox' in sds-flux and cnp-flux respectively
+def isSandboxSubscription = (System.getenv("NONPROD_SUBSCRIPTION_NAME") == "sandbox" || System.getenv("NONPROD_SUBSCRIPTION_NAME") == "sbox")
+def mirrorUrl = "https://${isSandboxSubscription ? 'artifactory.sandbox' : 'artifactory'}.platform.hmcts.net/artifactory/maven-remotes"
 
 settingsEvaluated { settings ->
     settings.pluginManagement {


### PR DESCRIPTION
SDS Sandbox builds fail to resolve the dependencies due to wrong artifactory being used.

Fix the conditional:

[- In CFT sandbox NONPROD_SUBSCRIPTION_NAME = sandbox](https://github.com/hmcts/cnp-flux-config/blob/6a03941bc84c31ece95cf5afecf65f898c37fdcb/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml#L62C30-L62C55)
[- In SDS sandbox NONPROD_SUBSCRIPTION_NAME = sbox](https://github.com/hmcts/sds-flux-config/blob/df63c3f1fb97654fda0b62417efbdf06dc5a34a5/apps/jenkins/jenkins/ptlsbox/jenkins.yaml#L92)

