### PR TITLE
Add XUI nightly agent routing

### DIFF
--- a/src/uk/gov/hmcts/pipeline/TeamConfig.groovy
+++ b/src/uk/gov/hmcts/pipeline/TeamConfig.groovy
@@ -45,7 +45,7 @@ class TeamConfig {
       def response = steps.httpRequest(
         consoleLogResponseBody: true,
         timeout: 10,
-        url: "https://raw.githubusercontent.com/hmcts/${repo}/master/team-config.yml",
+        url: "https://raw.githubusercontent.com/hmcts/${repo}/xui-jenkins-8cpu-agent/team-config.yml",
         validResponseCodes: '200'
       )
       teamConfigMap = steps.readYaml (text: response.content)

--- a/test/withPipeline/BaseCnpPipelineTest.groovy
+++ b/test/withPipeline/BaseCnpPipelineTest.groovy
@@ -93,7 +93,8 @@ abstract class BaseCnpPipelineTest extends BasePipelineTest {
     })
 
     helper.registerAllowedMethod("httpRequest", [LinkedHashMap.class], { m ->
-      if (m.get('url') == 'https://raw.githubusercontent.com/hmcts/cnp-jenkins-config/master/team-config.yml') {
+      if (m.get('url') == 'https://raw.githubusercontent.com/hmcts/cnp-jenkins-config/master/team-config.yml'
+        || m.get('url') == 'https://raw.githubusercontent.com/hmcts/cnp-jenkins-config/xui-jenkins-8cpu-agent/team-config.yml') {
         return TeamConfigTest.response
       } else if (m.get('url') == 'https://raw.githubusercontent.com/hmcts/cnp-jenkins-config/master/environment-approvals.yml') {
         return EnvironmentApprovalsTest.response

--- a/vars/withNightlyPipeline.groovy
+++ b/vars/withNightlyPipeline.groovy
@@ -52,6 +52,8 @@ def call(type, product, component, timeout = 300, Closure body) {
     nodeSelector = "daily"
   } else if (agentType == "civil") {
     nodeSelector = agentType
+  } else if (agentType == "xui") {
+    nodeSelector = agentType
   } else {
     nodeSelector = agentType + ' && daily'
   }


### PR DESCRIPTION
Notes:
* Adds temporary XUI 8CPU Jenkins agent routing for pipeline testing.
* Points `TeamConfig` at the matching `cnp-jenkins-config` test branch: `xui-jenkins-8cpu-agent`.
* Treats `xui` like `civil` in nightly pipelines so XUI jobs select the exclusive `xui` label instead of `xui && daily`.

Validation:
* `git diff --check`
* `ASDF_JAVA_VERSION=corretto-17.0.15.6.1 ./gradlew compileGroovy`
* `ASDF_JAVA_VERSION=corretto-17.0.15.6.1 ./gradlew test --tests withNightlyPipeline.onMaster.withNodeJsNightlyPipelineOnMasterTests --rerun-tasks`
