### PR TITLE
Route XUI nightly pipelines to XUI agent

### DIFF
--- a/test/uk/gov/hmcts/pipeline/TeamConfigTest.groovy
+++ b/test/uk/gov/hmcts/pipeline/TeamConfigTest.groovy
@@ -16,6 +16,7 @@ class TeamConfigTest extends Specification {
                                      "ccd":["namespace":"ccd", "slack": ["contact_channel":"#ccd-builds", "build_notices_channel":"#ccd-builds" ], "tags": ["application":"ccd"]],
                                      "dm":["team":"CCD","slack": ["contact_channel":"", "build_notices_channel":"" ], "tags": ["application":"ccd"], "tags": ["application":"dm"]],
                                      "product":["namespace":"product", "team":"hmcts","slack": ["contact_channel":"#product-builds", "build_notices_channel":"#product-builds" ], "tags": ["application":"product"]],
+                                     "xui":["namespace":"xui", "team":"Expert UI","agent":"xui","slack": ["contact_channel":"#xui-builds", "build_notices_channel":"#xui-builds" ], "tags": ["application":"xui"]],
                                      "bulk-scan":["team":"Software Engineering","namespace":"rpe","registry":"hmctsprivate","agent":"k8s-agent","slack": ["contact_channel":"#rpe-builds", "build_notices_channel":"#rpe-builds" ], "tags": ["application":"bulk-scan"]]]]
 
   void setup() {

--- a/test/withNightlyPipeline/onMaster/withNodeJsNightlyPipelineXuiAgentTests.groovy
+++ b/test/withNightlyPipeline/onMaster/withNodeJsNightlyPipelineXuiAgentTests.groovy
@@ -1,0 +1,37 @@
+package withNightlyPipeline.onMaster
+
+import org.junit.Test
+import withPipeline.BaseCnpPipelineTest
+
+import static com.lesfurets.jenkins.unit.MethodCall.callArgsToString
+import static org.assertj.core.api.Assertions.assertThat
+
+class withNodeJsNightlyPipelineXuiAgentTests extends BaseCnpPipelineTest {
+  final static jenkinsFile = "exampleNodeJsNightlyPipelineForXuiAgent.jenkins"
+
+  withNodeJsNightlyPipelineXuiAgentTests() {
+    super("master", jenkinsFile)
+  }
+
+  @Test
+  void NightlyPipelineUsesXuiAgentWithoutDailyLabel() {
+    helper.registerAllowedMethod("setupToolVersion", [], {})
+    helper.registerAllowedMethod("build", [], {})
+    helper.registerAllowedMethod("securityCheck", [], {})
+    helper.registerAllowedMethod("e2eTest", [], {})
+    helper.registerAllowedMethod("fullFunctionalTest", [], {})
+
+    runScript("testResources/$jenkinsFile")
+
+    def nodeCalls = helper.callStack.findAll { call ->
+      call.methodName == "node"
+    }
+
+    assertThat(nodeCalls.any { call ->
+      callArgsToString(call).contains("xui")
+    }).isTrue()
+    assertThat(nodeCalls.any { call ->
+      callArgsToString(call).contains("xui && daily")
+    }).isFalse()
+  }
+}

--- a/testResources/exampleNodeJsNightlyPipelineForXuiAgent.jenkins
+++ b/testResources/exampleNodeJsNightlyPipelineForXuiAgent.jenkins
@@ -1,0 +1,12 @@
+#!groovy
+
+@Library("Infrastructure")
+
+
+def product = "xui"
+
+def app = "e2e-tests"
+
+withNightlyPipeline('nodejs', product, app) {
+  enableFullFunctionalTest()
+}

--- a/vars/withNightlyPipeline.groovy
+++ b/vars/withNightlyPipeline.groovy
@@ -52,6 +52,8 @@ def call(type, product, component, timeout = 300, Closure body) {
     nodeSelector = "daily"
   } else if (agentType == "civil") {
     nodeSelector = agentType
+  } else if (agentType == "xui") {
+    nodeSelector = agentType
   } else {
     nodeSelector = agentType + ' && daily'
   }


### PR DESCRIPTION
Notes:
* Routes `withNightlyPipeline` jobs for products with `agent: "xui"` to the exclusive `xui` Jenkins label instead of `xui && daily`.
* Leaves `TeamConfig` loading from `cnp-jenkins-config/master`; this removes the temporary branch override that was present in the draft HMCTS-branch PR.
* Adds Jenkins-unit coverage proving an XUI Node.js nightly pipeline uses `node('xui')` and does not use `node('xui && daily')`.

Validation:
* `git diff --check`
* `ASDF_JAVA_VERSION=corretto-17.0.15.6.1 ./gradlew test --tests withNightlyPipeline.onMaster.withNodeJsNightlyPipelineXuiAgentTests`
* `ASDF_JAVA_VERSION=corretto-17.0.15.6.1 ./gradlew test`
