### PR TITLE
Add metrics for tracking jenkins library branches

### DIFF
--- a/src/uk/gov/hmcts/contino/MetricsPublisher.groovy
+++ b/src/uk/gov/hmcts/contino/MetricsPublisher.groovy
@@ -41,6 +41,8 @@ class MetricsPublisher implements Serializable {
       job_url                      : env.JOB_URL,
       git_url                      : env.GIT_URL,
       git_commit                   : env.GIT_COMMIT,
+      shared_library_name          : 'Infrastructure',
+      shared_library_version       : resolveSharedLibraryVersion('Infrastructure'),
       current_build_number         : currentBuild.number,
       current_step_name            : currentStepName,
       current_build_result         : currentBuild.result,
@@ -56,6 +58,23 @@ class MetricsPublisher implements Serializable {
     ]
   }
 
+  private String resolveSharedLibraryVersion(String libraryName) {
+    // Optional override for local/unit testing
+    if (env?.SHARED_LIBRARY_VERSION) {
+      return env.SHARED_LIBRARY_VERSION
+    }
+
+    // Jenkins does not expose a standard env var for shared library version.
+    // Try reading loaded library metadata from the build at runtime.
+    try {
+      def actionClass = this.class.classLoader.loadClass('org.jenkinsci.plugins.workflow.libs.LibrariesAction')
+      def action = currentBuild?.rawBuild?.getAction(actionClass)
+      def record = action?.libraries?.find { it.name == libraryName }
+      return record?.version
+    } catch (ignored) {
+      return null
+    }
+  }
 
   def publish(eventName) {
     try {

--- a/src/uk/gov/hmcts/contino/MetricsPublisher.groovy
+++ b/src/uk/gov/hmcts/contino/MetricsPublisher.groovy
@@ -22,6 +22,7 @@ class MetricsPublisher implements Serializable {
 
   private def collectMetrics(currentStepName) {
     def dateBuildScheduled = new Date(currentBuild.timeInMillis as long)
+    def (libName, libVersion) = resolveSharedLibrary()
 
     return [
       id                           : UUID.randomUUID().toString(),
@@ -41,8 +42,8 @@ class MetricsPublisher implements Serializable {
       job_url                      : env.JOB_URL,
       git_url                      : env.GIT_URL,
       git_commit                   : env.GIT_COMMIT,
-      shared_library_name          : 'Infrastructure',
-      shared_library_version       : resolveSharedLibraryVersion('Infrastructure'),
+      shared_library_name          : libName,
+      shared_library_version       : libVersion,
       current_build_number         : currentBuild.number,
       current_step_name            : currentStepName,
       current_build_result         : currentBuild.result,
@@ -58,14 +59,9 @@ class MetricsPublisher implements Serializable {
     ]
   }
 
-  private String resolveSharedLibraryVersion(String libraryName) {
-    // Optional override for local/unit testing
-    if (env?.SHARED_LIBRARY_VERSION) {
-      return env.SHARED_LIBRARY_VERSION
-    }
-    
+  private List<String> resolveSharedLibrary() {    
     // try different library names as it is possible for these to vary. Default is Infrastructure
-    def namesToTry = env?.SHARED_LIBRARY_NAME ? [env.SHARED_LIBRARY_NAME] : libraryNames.split(',').collect { it.trim() }
+    def namesToTry = env?.SHARED_LIBRARY_NAME ? [env.SHARED_LIBRARY_NAME] :  ['Infrastructure', 'Pipeline', 'Tagged']
 
     // Jenkins does not expose a standard env var for shared library version.
     // Try reading loaded library metadata from the build at runtime.
@@ -74,20 +70,25 @@ class MetricsPublisher implements Serializable {
       def action = currentBuild?.rawBuild?.getAction(actionClass)
       def record = action?.libraries?.find { it.name == libraryName }
       return record?.version
-      
+
       // Try each name in order, return first match
       for (name in namesToTry) {
         def record = action?.libraries?.find { it.name == name }
         if (record?.version) {
-          return record.version
+          return [record.name, record.version]
         }
       }
       
       // If no match found, return first loaded library as fallback
-      return action?.libraries?.first()?.version
+      def firstLib = action?.libraries?.first()
+      if (firstLib) {
+        return [firstLib.name, firstLib.version]
+      }
     } catch (ignored) {
-      return null
+      // silence errors
     }
+
+      return [null, null]
   }
 
   def publish(eventName) {

--- a/src/uk/gov/hmcts/contino/MetricsPublisher.groovy
+++ b/src/uk/gov/hmcts/contino/MetricsPublisher.groovy
@@ -68,8 +68,6 @@ class MetricsPublisher implements Serializable {
     try {
       def actionClass = this.class.classLoader.loadClass('org.jenkinsci.plugins.workflow.libs.LibrariesAction')
       def action = currentBuild?.rawBuild?.getAction(actionClass)
-      def record = action?.libraries?.find { it.name == libraryName }
-      return record?.version
 
       // Try each name in order, return first match
       for (name in namesToTry) {

--- a/src/uk/gov/hmcts/contino/MetricsPublisher.groovy
+++ b/src/uk/gov/hmcts/contino/MetricsPublisher.groovy
@@ -86,6 +86,11 @@ class MetricsPublisher implements Serializable {
       // silence errors
     }
 
+    // Fallback for pipeline tests
+    if (env?.SHARED_LIBRARY_VERSION) {
+      return [env?.SHARED_LIBRARY_NAME ?: namesToTry[0], env.SHARED_LIBRARY_VERSION]
+    }
+
       return [null, null]
   }
 

--- a/src/uk/gov/hmcts/contino/MetricsPublisher.groovy
+++ b/src/uk/gov/hmcts/contino/MetricsPublisher.groovy
@@ -63,6 +63,9 @@ class MetricsPublisher implements Serializable {
     if (env?.SHARED_LIBRARY_VERSION) {
       return env.SHARED_LIBRARY_VERSION
     }
+    
+    // try different library names as it is possible for these to vary. Default is Infrastructure
+    def namesToTry = env?.SHARED_LIBRARY_NAME ? [env.SHARED_LIBRARY_NAME] : libraryNames.split(',').collect { it.trim() }
 
     // Jenkins does not expose a standard env var for shared library version.
     // Try reading loaded library metadata from the build at runtime.
@@ -71,6 +74,17 @@ class MetricsPublisher implements Serializable {
       def action = currentBuild?.rawBuild?.getAction(actionClass)
       def record = action?.libraries?.find { it.name == libraryName }
       return record?.version
+      
+      // Try each name in order, return first match
+      for (name in namesToTry) {
+        def record = action?.libraries?.find { it.name == name }
+        if (record?.version) {
+          return record.version
+        }
+      }
+      
+      // If no match found, return first loaded library as fallback
+      return action?.libraries?.first()?.version
     } catch (ignored) {
       return null
     }

--- a/test/uk/gov/hmcts/contino/MetricsPublisherTests.groovy
+++ b/test/uk/gov/hmcts/contino/MetricsPublisherTests.groovy
@@ -14,7 +14,18 @@ class MetricsPublisherTests extends Specification {
   def setup() {
     stubSteps = Mock(JenkinsStepMock.class)
     stubSteps.currentBuild >>  ["timeInMillis" : 1513613748925]
-    stubSteps.env >> [BRANCH_NAME: "master"]
+    stubSteps.env >> [BRANCH_NAME: "master", SHARED_LIBRARY_VERSION: "feature/test-lib-branch"]
+
+   def "collects build metrics"() {
+
+     assertThat(metricsMap).contains(entry("component", "testComponent"))
+     assertThat(metricsMap).contains(entry("product", "testProduct"))
+     assertThat(metricsMap).contains(entry("branch_name", "master"))
+     assertThat(metricsMap).contains(entry("shared_library_name", "Infrastructure"))
+     assertThat(metricsMap).contains(entry("shared_library_version", "feature/test-lib-branch"))
+     assertThat(metricsMap).contains(entry("current_build_scheduled_time", "2017-12-18T16:15:48Z"))
+   }
+   
     stubSteps.azureCosmosDBCreateDocument(_) >> {}
 
     stubSteps.echo(_) >> { System.out.println(it) }

--- a/test/uk/gov/hmcts/contino/MetricsPublisherTests.groovy
+++ b/test/uk/gov/hmcts/contino/MetricsPublisherTests.groovy
@@ -15,16 +15,6 @@ class MetricsPublisherTests extends Specification {
     stubSteps = Mock(JenkinsStepMock.class)
     stubSteps.currentBuild >>  ["timeInMillis" : 1513613748925]
     stubSteps.env >> [BRANCH_NAME: "master", SHARED_LIBRARY_VERSION: "feature/test-lib-branch"]
-
-   def "collects build metrics"() {
-
-     assertThat(metricsMap).contains(entry("component", "testComponent"))
-     assertThat(metricsMap).contains(entry("product", "testProduct"))
-     assertThat(metricsMap).contains(entry("branch_name", "master"))
-     assertThat(metricsMap).contains(entry("shared_library_name", "Infrastructure"))
-     assertThat(metricsMap).contains(entry("shared_library_version", "feature/test-lib-branch"))
-     assertThat(metricsMap).contains(entry("current_build_scheduled_time", "2017-12-18T16:15:48Z"))
-   }
    
     stubSteps.azureCosmosDBCreateDocument(_) >> {}
 
@@ -54,6 +44,8 @@ class MetricsPublisherTests extends Specification {
     assertThat(metricsMap).contains(entry("product", "testProduct"))
     assertThat(metricsMap).contains(entry("branch_name", "master"))
     assertThat(metricsMap).contains(entry("current_build_scheduled_time", "2017-12-18T16:15:48Z"))
+    assertThat(metricsMap).contains(entry("shared_library_name", "Infrastructure"))
+    assertThat(metricsMap).contains(entry("shared_library_version", "feature/test-lib-branch"))
   }
 
   def "publishes to database returned by resolver"() {


### PR DESCRIPTION
Adds metrics to the `metricsPublisher` method that will extract information about the branches being used in the jenkins library to cosmos db.

We will be able to use this data to track the adoption of new features.

Tested in https://build.hmcts.net/job/HMCTS_a_to_c/job/cnp-plum-recipes-service/view/change-requests/job/PR-1330/5/