### PR TITLE
DTSPO-30114 - Add nagger to library version

### DIFF
--- a/resources/uk/gov/hmcts/library/check-old-library-version.sh
+++ b/resources/uk/gov/hmcts/library/check-old-library-version.sh
@@ -10,13 +10,13 @@ echo "Checking for old library version references: ${OLD_LIBRARY_VERSION}"
 
 # Check if this is a nightly pipeline
 if [[ "$JOB_NAME" == *"nightly"* ]]; then
-    echo "Running nightly pipeline"
+    echo "Running nightly pipeline. No need to check for old library version."
     exit 0
 fi
 
 # Check if this pipeline is running on sandbox
 if [[ "$JENKINS_SUBSCRIPTION_NAME" == *"SBOX"* ]]; then
-    echo "Running on Sandbox Jenkins"
+    echo "Running on Sandbox Jenkins. No need to check for old library version."
     exit 0
 fi
 

--- a/resources/uk/gov/hmcts/library/check-old-library-version.sh
+++ b/resources/uk/gov/hmcts/library/check-old-library-version.sh
@@ -32,7 +32,9 @@ fi
 
 # Check Jenkinsfile
 echo "Scanning Jenkinsfile..."
-JENKINSFILES=$(find . -maxdepth 3 -name "Jenkinsfile_CNP" -type f -exec grep -l -E "${OLD_LIBRARY_VERSION}" {} + 2>/dev/null || true)
+# Matches: @Library("Infrastructure"), @Library(Infrastructure), or @Library("Infrastructure@<branch>")
+LIBRARY_PATTERN='@Library\("?Infrastructure(@'"${OLD_LIBRARY_VERSION}"')?"?\)'
+JENKINSFILES=$(find . -maxdepth 1 -name "Jenkinsfile_CNP" -type f -exec grep -l -E "${LIBRARY_PATTERN}" {} + 2>/dev/null || true)
 if [ -n "$JENKINSFILES" ]; then
     FOUND_REFERENCES=1
     while IFS= read -r file; do

--- a/resources/uk/gov/hmcts/library/check-old-library-version.sh
+++ b/resources/uk/gov/hmcts/library/check-old-library-version.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -e
 
+old_library_found () {
+    echo "Old library version references found. Please update your Jenkinsfile to use the new library version."
+    exit 1
+}
+
+no_old_library_found () {
+    echo "No old library version references found. All clear!"
+    exit 0
+}
+
 OLD_LIBRARY_VERSION="${1}"  # Pattern of old library version to detect
 
 FOUND_REFERENCES=0
@@ -46,12 +56,4 @@ if [ $FOUND_REFERENCES -eq 1 ]; then
     old_library_found
 fi
 
-old_library_found() {
-    echo "Old library version references found. Please update your Jenkinsfile to use the new library version."
-    exit 1
-}
-
-no_old_library_found() {
-    echo "No old library version references found. All clear!"
-    exit 0
-}
+no_old_library_found

--- a/resources/uk/gov/hmcts/library/check-old-library-version.sh
+++ b/resources/uk/gov/hmcts/library/check-old-library-version.sh
@@ -43,7 +43,7 @@ fi
 if [ $FOUND_REFERENCES -eq 1 ]; then
     echo ""
     echo "╔════════════════════════════════════════════════════════════════╗"
-    echo "║  WARNING: Deprecated library version in use!      ║"
+    echo "║  WARNING: Deprecated library version in use!                   ║"
     echo "╚════════════════════════════════════════════════════════════════╝"
     echo ""
     echo "Files that need to be updated:"

--- a/resources/uk/gov/hmcts/library/check-old-library-version.sh
+++ b/resources/uk/gov/hmcts/library/check-old-library-version.sh
@@ -21,91 +21,10 @@ if [ -n "$JENKINSFILES" ]; then
     done <<< "$JENKINSFILES"
 fi
 
-# Check Dockerfiles (including variants like Dockerfile.build, Dockerfile.dev, etc.)
-echo "Scanning Dockerfiles..."
-DOCKER_FILES=$(find . -name "Dockerfile*" -type f -exec grep -l -E "${OLD_LIBRARY_VERSION}" {} + 2>/dev/null || true)
-if [ -n "$DOCKER_FILES" ]; then
-    echo "$DOCKER_FILES"
-    echo ""
-    echo "Found old library version references in Dockerfile(s) above"
-    FOUND_REFERENCES=1
-    while IFS= read -r file; do
-        [ -n "$file" ] && FAILED_FILES+=("$file")
-    done <<< "$DOCKER_FILES"
-fi
-
-# Check Helm chart files
-echo "Scanning Helm charts..."
-if [ -d "charts" ]; then
-    # Check Chart.yaml files
-    CHART_FILES=$(find charts -name "Chart.yaml" -type f -exec grep -l -E "${OLD_LIBRARY_VERSION}" {} + 2>/dev/null || true)
-    if [ -n "$CHART_FILES" ]; then
-        echo "$CHART_FILES"
-        echo ""
-        echo "Found old ACR references in Chart.yaml file(s) above"
-        FOUND_REFERENCES=1
-        while IFS= read -r file; do
-            [ -n "$file" ] && FAILED_FILES+=("$file")
-        done <<< "$CHART_FILES"
-    fi
-
-    # Check values files (values.yaml, values-*.yaml, etc.)
-    VALUES_FILES=$(find charts -name "values*.yaml" -type f -exec grep -l -E "${OLD_LIBRARY_VERSION}" {} + 2>/dev/null || true)
-    if [ -n "$VALUES_FILES" ]; then
-        echo "$VALUES_FILES"
-        echo ""
-        echo "Found old ACR references in values file(s) above"
-        FOUND_REFERENCES=1
-        while IFS= read -r file; do
-            [ -n "$file" ] && FAILED_FILES+=("$file")
-        done <<< "$VALUES_FILES"
-    fi
-
-    # Check template files
-    TEMPLATE_FILES=$(find charts -path "*/templates/*" -name "*.yaml" -type f -exec grep -l -E "${OLD_LIBRARY_VERSION}" {} + 2>/dev/null || true)
-    if [ -n "$TEMPLATE_FILES" ]; then
-        echo "$TEMPLATE_FILES"
-        echo ""
-        echo "Found old ACR references in Helm template(s) above"
-        FOUND_REFERENCES=1
-        while IFS= read -r file; do
-            [ -n "$file" ] && FAILED_FILES+=("$file")
-        done <<< "$TEMPLATE_FILES"
-    fi
-fi
-
-# Check additional values files in root or other common locations
-OTHER_VALUES=$(find . -maxdepth 3 -name "values*.yaml" -type f ! -path "*/charts/*" -exec grep -l -E "${OLD_LIBRARY_VERSION}" {} + 2>/dev/null || true)
-if [ -n "$OTHER_VALUES" ]; then
-    echo "$OTHER_VALUES"
-    echo ""
-    echo "Found old ACR references in values file(s) above"
-    FOUND_REFERENCES=1
-    while IFS= read -r file; do
-        [ -n "$file" ] && FAILED_FILES+=("$file")
-    done <<< "$OTHER_VALUES"
-fi
-
-# Check kubernetes/helm directories if they exist outside of standard charts location
-for dir in kubernetes k8s helm; do
-    if [ -d "$dir" ]; then
-        K8S_FILES=$(find "$dir" -name "*.yaml" -type f -exec grep -l -E "${OLD_LIBRARY_VERSION}" {} + 2>/dev/null || true)
-        if [ -n "$K8S_FILES" ]; then
-            echo "$K8S_FILES"
-            echo ""
-            echo "Found old ACR references in $dir directory above"
-            FOUND_REFERENCES=1
-            while IFS= read -r file; do
-                [ -n "$file" ] && FAILED_FILES+=("$file")
-            done <<< "$K8S_FILES"
-        fi
-    fi
-done
-
 if [ $FOUND_REFERENCES -eq 1 ]; then
     echo ""
     echo "╔════════════════════════════════════════════════════════════════╗"
-    echo "║  ERROR: Old Azure Container Registry references detected!      ║"
+    echo "║  WARNING: Deprecated library version in use!      ║"
     echo "╚════════════════════════════════════════════════════════════════╝"
     echo ""
     echo "Files that need to be updated:"
@@ -116,12 +35,10 @@ if [ $FOUND_REFERENCES -eq 1 ]; then
         fi
     done
     echo ""
-    echo "Please update these files to use the new registries:"
-    echo "  • hmctsprod.azurecr.io (for production images)"
-    echo "  • hmctssbox.azurecr.io (for sandbox/non-prod images)"
+    echo "Please update your Jenkinsfile to use the new library version:"
     echo ""
     exit 1
 fi
 
-echo "No old ACR references found. All clear!"
+echo "No old library version references found. All clear!"
 exit 0

--- a/resources/uk/gov/hmcts/library/check-old-library-version.sh
+++ b/resources/uk/gov/hmcts/library/check-old-library-version.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+set -e
+
+OLD_LIBRARY_VERSION="${1}"  # Pattern of old library version to detect
+
+FOUND_REFERENCES=0
+FAILED_FILES=()
+
+echo "Checking for old library version references: ${OLD_LIBRARY_VERSION}"
+
+# Check Jenkinsfile
+echo "Scanning Jenkinsfile..."
+JENKINSFILES=$(find . -maxdepth 3 -name "Jenkinsfile_*" -type f -exec grep -l -E "${OLD_LIBRARY_VERSION}" {} + 2>/dev/null || true)
+if [ -n "$JENKINSFILES" ]; then
+    echo "$JENKINSFILES"
+    echo ""
+    echo "Found old library version references in Jenkinsfile(s) above"
+    FOUND_REFERENCES=1
+    while IFS= read -r file; do
+        [ -n "$file" ] && FAILED_FILES+=("$file")
+    done <<< "$JENKINSFILES"
+fi
+
+# Check Dockerfiles (including variants like Dockerfile.build, Dockerfile.dev, etc.)
+echo "Scanning Dockerfiles..."
+DOCKER_FILES=$(find . -name "Dockerfile*" -type f -exec grep -l -E "${OLD_LIBRARY_VERSION}" {} + 2>/dev/null || true)
+if [ -n "$DOCKER_FILES" ]; then
+    echo "$DOCKER_FILES"
+    echo ""
+    echo "Found old library version references in Dockerfile(s) above"
+    FOUND_REFERENCES=1
+    while IFS= read -r file; do
+        [ -n "$file" ] && FAILED_FILES+=("$file")
+    done <<< "$DOCKER_FILES"
+fi
+
+# Check Helm chart files
+echo "Scanning Helm charts..."
+if [ -d "charts" ]; then
+    # Check Chart.yaml files
+    CHART_FILES=$(find charts -name "Chart.yaml" -type f -exec grep -l -E "${OLD_LIBRARY_VERSION}" {} + 2>/dev/null || true)
+    if [ -n "$CHART_FILES" ]; then
+        echo "$CHART_FILES"
+        echo ""
+        echo "Found old ACR references in Chart.yaml file(s) above"
+        FOUND_REFERENCES=1
+        while IFS= read -r file; do
+            [ -n "$file" ] && FAILED_FILES+=("$file")
+        done <<< "$CHART_FILES"
+    fi
+
+    # Check values files (values.yaml, values-*.yaml, etc.)
+    VALUES_FILES=$(find charts -name "values*.yaml" -type f -exec grep -l -E "${OLD_LIBRARY_VERSION}" {} + 2>/dev/null || true)
+    if [ -n "$VALUES_FILES" ]; then
+        echo "$VALUES_FILES"
+        echo ""
+        echo "Found old ACR references in values file(s) above"
+        FOUND_REFERENCES=1
+        while IFS= read -r file; do
+            [ -n "$file" ] && FAILED_FILES+=("$file")
+        done <<< "$VALUES_FILES"
+    fi
+
+    # Check template files
+    TEMPLATE_FILES=$(find charts -path "*/templates/*" -name "*.yaml" -type f -exec grep -l -E "${OLD_LIBRARY_VERSION}" {} + 2>/dev/null || true)
+    if [ -n "$TEMPLATE_FILES" ]; then
+        echo "$TEMPLATE_FILES"
+        echo ""
+        echo "Found old ACR references in Helm template(s) above"
+        FOUND_REFERENCES=1
+        while IFS= read -r file; do
+            [ -n "$file" ] && FAILED_FILES+=("$file")
+        done <<< "$TEMPLATE_FILES"
+    fi
+fi
+
+# Check additional values files in root or other common locations
+OTHER_VALUES=$(find . -maxdepth 3 -name "values*.yaml" -type f ! -path "*/charts/*" -exec grep -l -E "${OLD_LIBRARY_VERSION}" {} + 2>/dev/null || true)
+if [ -n "$OTHER_VALUES" ]; then
+    echo "$OTHER_VALUES"
+    echo ""
+    echo "Found old ACR references in values file(s) above"
+    FOUND_REFERENCES=1
+    while IFS= read -r file; do
+        [ -n "$file" ] && FAILED_FILES+=("$file")
+    done <<< "$OTHER_VALUES"
+fi
+
+# Check kubernetes/helm directories if they exist outside of standard charts location
+for dir in kubernetes k8s helm; do
+    if [ -d "$dir" ]; then
+        K8S_FILES=$(find "$dir" -name "*.yaml" -type f -exec grep -l -E "${OLD_LIBRARY_VERSION}" {} + 2>/dev/null || true)
+        if [ -n "$K8S_FILES" ]; then
+            echo "$K8S_FILES"
+            echo ""
+            echo "Found old ACR references in $dir directory above"
+            FOUND_REFERENCES=1
+            while IFS= read -r file; do
+                [ -n "$file" ] && FAILED_FILES+=("$file")
+            done <<< "$K8S_FILES"
+        fi
+    fi
+done
+
+if [ $FOUND_REFERENCES -eq 1 ]; then
+    echo ""
+    echo "╔════════════════════════════════════════════════════════════════╗"
+    echo "║  ERROR: Old Azure Container Registry references detected!      ║"
+    echo "╚════════════════════════════════════════════════════════════════╝"
+    echo ""
+    echo "Files that need to be updated:"
+    for file in "${FAILED_FILES[@]}"; do
+        # Only print non-empty file paths
+        if [ -n "$file" ]; then
+            echo "  ❌ $file"
+        fi
+    done
+    echo ""
+    echo "Please update these files to use the new registries:"
+    echo "  • hmctsprod.azurecr.io (for production images)"
+    echo "  • hmctssbox.azurecr.io (for sandbox/non-prod images)"
+    echo ""
+    exit 1
+fi
+
+echo "No old ACR references found. All clear!"
+exit 0

--- a/resources/uk/gov/hmcts/library/check-old-library-version.sh
+++ b/resources/uk/gov/hmcts/library/check-old-library-version.sh
@@ -24,11 +24,11 @@ if [[ "$JOB_NAME" == *"nightly"* ]]; then
     no_old_library_found
 fi
 
-# Check if this pipeline is running on sandbox
-if [[ "$JENKINS_SUBSCRIPTION_NAME" == *"SBOX"* ]]; then
-    echo "Running on Sandbox Jenkins. No need to check for old library version."
-    no_old_library_found
-fi
+# # Check if this pipeline is running on sandbox
+# if [[ "$JENKINS_SUBSCRIPTION_NAME" == *"SBOX"* ]]; then
+#     echo "Running on Sandbox Jenkins. No need to check for old library version."
+#     no_old_library_found
+# fi
 
 # Check Jenkinsfile
 echo "Scanning Jenkinsfile..."

--- a/resources/uk/gov/hmcts/library/check-old-library-version.sh
+++ b/resources/uk/gov/hmcts/library/check-old-library-version.sh
@@ -11,22 +11,19 @@ echo "Checking for old library version references: ${OLD_LIBRARY_VERSION}"
 # Check if this is a nightly pipeline
 if [[ "$JOB_NAME" == *"nightly"* ]]; then
     echo "Running nightly pipeline. No need to check for old library version."
-    exit 0
+    no_old_library_found
 fi
 
 # Check if this pipeline is running on sandbox
 if [[ "$JENKINS_SUBSCRIPTION_NAME" == *"SBOX"* ]]; then
     echo "Running on Sandbox Jenkins. No need to check for old library version."
-    exit 0
+    no_old_library_found
 fi
 
 # Check Jenkinsfile
 echo "Scanning Jenkinsfile..."
 JENKINSFILES=$(find . -maxdepth 3 -name "Jenkinsfile_CNP" -type f -exec grep -l -E "${OLD_LIBRARY_VERSION}" {} + 2>/dev/null || true)
 if [ -n "$JENKINSFILES" ]; then
-    echo "$JENKINSFILES"
-    echo ""
-    echo "Found old library version references in Jenkinsfile(s) above"
     FOUND_REFERENCES=1
     while IFS= read -r file; do
         [ -n "$file" ] && FAILED_FILES+=("$file")
@@ -46,11 +43,15 @@ if [ $FOUND_REFERENCES -eq 1 ]; then
             echo "  ❌ $file"
         fi
     done
-    echo ""
-    echo "Please update your Jenkinsfile to use the new library version:"
-    echo ""
-    exit 1
+    old_library_found
 fi
 
-echo "No old library version references found. All clear!"
-exit 0
+old_library_found() {
+    echo "Old library version references found. Please update your Jenkinsfile to use the new library version."
+    exit 1
+}
+
+no_old_library_found() {
+    echo "No old library version references found. All clear!"
+    exit 0
+}

--- a/resources/uk/gov/hmcts/library/check-old-library-version.sh
+++ b/resources/uk/gov/hmcts/library/check-old-library-version.sh
@@ -24,11 +24,11 @@ if [[ "$JOB_NAME" == *"nightly"* ]]; then
     no_old_library_found
 fi
 
-# # Check if this pipeline is running on sandbox
-# if [[ "$JENKINS_SUBSCRIPTION_NAME" == *"SBOX"* ]]; then
-#     echo "Running on Sandbox Jenkins. No need to check for old library version."
-#     no_old_library_found
-# fi
+# Check if this pipeline is running on sandbox
+if [[ "$JENKINS_SUBSCRIPTION_NAME" == *"SBOX"* ]]; then
+    echo "Running on Sandbox Jenkins. No need to check for old library version."
+    no_old_library_found
+fi
 
 # Check Jenkinsfile
 echo "Scanning Jenkinsfile..."

--- a/resources/uk/gov/hmcts/library/check-old-library-version.sh
+++ b/resources/uk/gov/hmcts/library/check-old-library-version.sh
@@ -2,7 +2,11 @@
 set -e
 
 old_library_found () {
+    echo ""
     echo "Old library version references found. Please update your Jenkinsfile to use the new library version."
+    echo "Required library version: ${NEW_LIBRARY_VERSION}"
+    echo "Deadline for updating: ${DEADLINE}"
+    echo ""
     exit 1
 }
 
@@ -12,6 +16,8 @@ no_old_library_found () {
 }
 
 OLD_LIBRARY_VERSION="${1}"  # Pattern of old library version to detect
+NEW_LIBRARY_VERSION="${2}"  # New library version to suggest in the warning message
+DEADLINE="${3}"             # Deadline for updating the library version
 
 FOUND_REFERENCES=0
 FAILED_FILES=()

--- a/resources/uk/gov/hmcts/library/check-old-library-version.sh
+++ b/resources/uk/gov/hmcts/library/check-old-library-version.sh
@@ -8,9 +8,21 @@ FAILED_FILES=()
 
 echo "Checking for old library version references: ${OLD_LIBRARY_VERSION}"
 
+# Check if this is a nightly pipeline
+if [[ "$JOB_NAME" == *"nightly"* ]]; then
+    echo "Running nightly pipeline"
+    exit 0
+fi
+
+# Check if this pipeline is running on sandbox
+if [[ "$JENKINS_SUBSCRIPTION_NAME" == *"SBOX"* ]]; then
+    echo "Running on Sandbox Jenkins"
+    exit 0
+fi
+
 # Check Jenkinsfile
 echo "Scanning Jenkinsfile..."
-JENKINSFILES=$(find . -maxdepth 3 -name "Jenkinsfile_*" -type f -exec grep -l -E "${OLD_LIBRARY_VERSION}" {} + 2>/dev/null || true)
+JENKINSFILES=$(find . -maxdepth 3 -name "Jenkinsfile_CNP" -type f -exec grep -l -E "${OLD_LIBRARY_VERSION}" {} + 2>/dev/null || true)
 if [ -n "$JENKINSFILES" ]; then
     echo "$JENKINSFILES"
     echo ""

--- a/src/uk/gov/hmcts/pipeline/DeprecationConfig.groovy
+++ b/src/uk/gov/hmcts/pipeline/DeprecationConfig.groovy
@@ -13,7 +13,7 @@ class DeprecationConfig {
             def response = steps.httpRequest(
                 consoleLogResponseBody: true,
                 timeout: 10,
-                url: "https://raw.githubusercontent.com/hmcts/cnp-deprecation-map/refs/heads/DTSPO-30114/nagger-versions.yaml",
+                url: "https://raw.githubusercontent.com/hmcts/cnp-deprecation-map/master/nagger-versions.yaml",
                 validResponseCodes: '200'
             )
             deprecationConfigInternal = steps.readYaml(text: response.content)

--- a/src/uk/gov/hmcts/pipeline/DeprecationConfig.groovy
+++ b/src/uk/gov/hmcts/pipeline/DeprecationConfig.groovy
@@ -13,7 +13,7 @@ class DeprecationConfig {
             def response = steps.httpRequest(
                 consoleLogResponseBody: true,
                 timeout: 10,
-                url: "https://raw.githubusercontent.com/hmcts/cnp-deprecation-map/master/nagger-versions.yaml",
+                url: "https://raw.githubusercontent.com/hmcts/cnp-deprecation-map/DTSPO-30114/nagger-versions.yaml",
                 validResponseCodes: '200'
             )
             deprecationConfigInternal = steps.readYaml(text: response.content)

--- a/src/uk/gov/hmcts/pipeline/DeprecationConfig.groovy
+++ b/src/uk/gov/hmcts/pipeline/DeprecationConfig.groovy
@@ -13,7 +13,7 @@ class DeprecationConfig {
             def response = steps.httpRequest(
                 consoleLogResponseBody: true,
                 timeout: 10,
-                url: "https://raw.githubusercontent.com/hmcts/cnp-deprecation-map/DTSPO-30114/nagger-versions.yaml",
+                url: "https://raw.githubusercontent.com/hmcts/cnp-deprecation-map/refs/heads/DTSPO-30114/nagger-versions.yaml",
                 validResponseCodes: '200'
             )
             deprecationConfigInternal = steps.readYaml(text: response.content)

--- a/vars/checkoutScm.groovy
+++ b/vars/checkoutScm.groovy
@@ -33,5 +33,6 @@ def call(params) {
       echo "Unable to find git email Id for the user' ${err}'"
     }
     warnAboutRenovateConfig()
+    warnAboutOldLibraryVersion()
   }
 }

--- a/vars/warnAboutOldLibraryVersion.groovy
+++ b/vars/warnAboutOldLibraryVersion.groovy
@@ -1,0 +1,28 @@
+import uk.gov.hmcts.pipeline.deprecation.WarningCollector
+import uk.gov.hmcts.pipeline.DeprecationConfig
+import java.time.LocalDate
+
+def call(String repoUrl = null) {
+
+    def acrDeprecationConfig = repoUrl ?
+        new DeprecationConfig(this).getDeprecationConfig(repoUrl).acr :
+        new DeprecationConfig(this).getDeprecationConfig().acr
+
+    writeFile file: 'check-old-acr-references.sh', text: libraryResource('uk/gov/hmcts/acr/check-old-acr-references.sh')
+
+    acrDeprecationConfig.each { configKey, deprecation ->
+        try {
+            sh """
+            chmod +x check-old-acr-references.sh
+            ./check-old-acr-references.sh '${deprecation.pattern}'
+            """
+        } catch(ignored) {
+            WarningCollector.addPipelineWarning(
+                "old_acr_registry",
+                "Your code references the old Azure Container Registry domains (${deprecation.pattern}). Please update Dockerfiles, Helm charts and templates to use the new registries: *${deprecation.new_registries}*",
+                LocalDate.parse(deprecation.date_deadline)
+            )
+        }
+    }
+    sh 'rm -f check-old-acr-references.sh'
+}

--- a/vars/warnAboutOldLibraryVersion.groovy
+++ b/vars/warnAboutOldLibraryVersion.groovy
@@ -5,8 +5,8 @@ import java.time.LocalDate
 def call(String repoUrl = null) {
 
     def jenkinsLibraryDeprecationConfig = repoUrl ?
-        new DeprecationConfig(this).getDeprecationConfig(repoUrl).jenkinsLibrary :
-        new DeprecationConfig(this).getDeprecationConfig().jenkinsLibrary
+        new DeprecationConfig(this).getDeprecationConfig(repoUrl).jenkins :
+        new DeprecationConfig(this).getDeprecationConfig().jenkins
 
     writeFile file: 'check-old-library-version.sh', text: libraryResource('uk/gov/hmcts/library/check-old-library-version.sh')
 

--- a/vars/warnAboutOldLibraryVersion.groovy
+++ b/vars/warnAboutOldLibraryVersion.groovy
@@ -28,7 +28,7 @@ def call(String repoUrl = null) {
             try {
                 sh """
                 chmod +x check-old-library-version.sh
-                ./check-old-library-version.sh '${pattern}'
+                ./check-old-library-version.sh '${pattern}' '${deprecation.version}' '${deprecation.date_deadline}'
                 """
             } catch(ignored) {
                 WarningCollector.addPipelineWarning(

--- a/vars/warnAboutOldLibraryVersion.groovy
+++ b/vars/warnAboutOldLibraryVersion.groovy
@@ -11,17 +11,32 @@ def call(String repoUrl = null) {
     writeFile file: 'check-old-library-version.sh', text: libraryResource('uk/gov/hmcts/library/check-old-library-version.sh')
 
     jenkinsLibraryDeprecationConfig.each { configKey, deprecation ->
-        try {
-            sh """
-            chmod +x check-old-library-version.sh
-            ./check-old-library-version.sh '${deprecation.pattern}'
-            """
-        } catch(ignored) {
-            WarningCollector.addPipelineWarning(
-                "old_library_version",
-                "Your code references the old library version (${deprecation.pattern}). Please update your Jenkinsfile to use the new library version: *${deprecation.version}*", 
-                LocalDate.parse(deprecation.date_deadline)
+        def patterns = []
+        if (deprecation.pattern instanceof Collection) {
+            patterns.addAll(deprecation.pattern)
+        } else {
+            patterns.addAll(
+                deprecation.pattern
+                    .toString()
+                    .split(/\|/)
+                    .collect { it.trim() }
+                    .findAll { it }
             )
+        }
+
+        patterns.each { pattern ->
+            try {
+                sh """
+                chmod +x check-old-library-version.sh
+                ./check-old-library-version.sh '${pattern}'
+                """
+            } catch(ignored) {
+                WarningCollector.addPipelineWarning(
+                    "old_library_version",
+                    "Your code references the old library version (${pattern}). Please update your Jenkinsfile to use the new library version: *${deprecation.version}*", 
+                    LocalDate.parse(deprecation.date_deadline)
+                )
+            }
         }
     }
     sh 'rm -f check-old-library-version.sh'

--- a/vars/warnAboutOldLibraryVersion.groovy
+++ b/vars/warnAboutOldLibraryVersion.groovy
@@ -4,25 +4,25 @@ import java.time.LocalDate
 
 def call(String repoUrl = null) {
 
-    def acrDeprecationConfig = repoUrl ?
-        new DeprecationConfig(this).getDeprecationConfig(repoUrl).acr :
-        new DeprecationConfig(this).getDeprecationConfig().acr
+    def jenkinsLibraryDeprecationConfig = repoUrl ?
+        new DeprecationConfig(this).getDeprecationConfig(repoUrl).jenkinsLibrary :
+        new DeprecationConfig(this).getDeprecationConfig().jenkinsLibrary
 
-    writeFile file: 'check-old-acr-references.sh', text: libraryResource('uk/gov/hmcts/acr/check-old-acr-references.sh')
+    writeFile file: 'check-old-library-version.sh', text: libraryResource('uk/gov/hmcts/library/check-old-library-version.sh')
 
-    acrDeprecationConfig.each { configKey, deprecation ->
+    jenkinsLibraryDeprecationConfig.each { configKey, deprecation ->
         try {
             sh """
-            chmod +x check-old-acr-references.sh
-            ./check-old-acr-references.sh '${deprecation.pattern}'
+            chmod +x check-old-library-version.sh
+            ./check-old-library-version.sh '${deprecation.pattern}'
             """
         } catch(ignored) {
             WarningCollector.addPipelineWarning(
-                "old_acr_registry",
-                "Your code references the old Azure Container Registry domains (${deprecation.pattern}). Please update Dockerfiles, Helm charts and templates to use the new registries: *${deprecation.new_registries}*",
+                "old_library_version",
+                "Your code references the old library version (${deprecation.pattern}). Please update your Jenkinsfile to use the new library version: *${deprecation.version}*", 
                 LocalDate.parse(deprecation.date_deadline)
             )
         }
     }
-    sh 'rm -f check-old-acr-references.sh'
+    sh 'rm -f check-old-library-version.sh'
 }


### PR DESCRIPTION
Adding nagger to the library to check for the library branch/version being used.

This will enable us to transition teams over to a new pipeline structure with minimal disruption to current workloads in a phased manner.

Here is the error message that will be received when the pipeline is not using the desired version after the deadline:

```
Checking for old library version references: DTSPO-30114/library-nagger
Scanning Jenkinsfile...
  
╔════════════════════════════════════════════════════════════════╗
║  WARNING: Deprecated library version in use!                   ║
╚════════════════════════════════════════════════════════════════╝
  
Files that need to be updated:
    ❌ ./Jenkinsfile_CNP
  
Old library version references found. Please update your Jenkinsfile to use the new library version.
Required library version: 2.0.0
Deadline for updating: 2026-05-31
```