### PR TITLE
Added new nonDeployableApp to only run validation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,6 +825,19 @@ withPipeline(type, product, component) {
 }
 ```
 
+## Java Library
+You need to add `isJavaLibrary()` method in `withPipeline` block to skip docker and service specific steps in the pipeline.
+
+```groovy
+#!groovy
+
+@Library("Infrastructure")
+
+withPipeline(type, product, component) {
+  isJavaLibrary()
+}
+```
+
 ## Building and Testing
 This is a Groovy project, and gradle is used to build and test.
 

--- a/README.md
+++ b/README.md
@@ -826,7 +826,7 @@ withPipeline(type, product, component) {
 ```
 
 ## Java Library
-You need to add `isJavaLibrary()` method in `withPipeline` block to skip deployments.
+You need to add `nonDeployableApp()` method in `withPipeline` block to skip deployments.
 
 ```groovy
 #!groovy
@@ -834,7 +834,7 @@ You need to add `isJavaLibrary()` method in `withPipeline` block to skip deploym
 @Library("Infrastructure")
 
 withPipeline(type, product, component) {
-  isJavaLibrary()
+  nonDeployableApp()
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -826,7 +826,7 @@ withPipeline(type, product, component) {
 ```
 
 ## Java Library
-You need to add `isJavaLibrary()` method in `withPipeline` block to skip docker and service specific steps in the pipeline.
+You need to add `isJavaLibrary()` method in `withPipeline` block to skip deployments.
 
 ```groovy
 #!groovy

--- a/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
@@ -20,6 +20,7 @@ class AppPipelineConfig extends CommonPipelineConfig implements Serializable {
   boolean e2eTest = false
   boolean securityScan = false
   boolean serviceApp = true
+  boolean isJavaLibrary = false
   boolean aksStagingDeployment = false
   boolean legacyDeployment = true
   Set<String> legacyDeploymentExemptions = []

--- a/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
@@ -20,7 +20,7 @@ class AppPipelineConfig extends CommonPipelineConfig implements Serializable {
   boolean e2eTest = false
   boolean securityScan = false
   boolean serviceApp = true
-  boolean isJavaLibrary = false
+  boolean deployableApp = true
   boolean aksStagingDeployment = false
   boolean legacyDeployment = true
   Set<String> legacyDeploymentExemptions = []

--- a/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
@@ -88,6 +88,11 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
     config.serviceApp = false
   }
 
+  void isJavaLibrary() {
+    config.isJavaLibrary = true
+    nonServiceApp()
+  }
+
   void overrideVaultEnvironments(Map<String, String> vaultOverrides) {
     config.vaultEnvironmentOverrides = vaultOverrides
   }

--- a/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
@@ -88,8 +88,8 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
     config.serviceApp = false
   }
 
-  void isJavaLibrary() {
-    config.isJavaLibrary = true
+  void nonDeployableApp() {
+    config.deployableApp = false
     nonServiceApp()
   }
 

--- a/src/uk/gov/hmcts/pipeline/DeploymentControls.groovy
+++ b/src/uk/gov/hmcts/pipeline/DeploymentControls.groovy
@@ -32,9 +32,9 @@ class DeploymentControls {
   }
 
   boolean isDeployEnabled(String repository, def pipelineConfig = null) {
-    boolean isJavaLibrary = pipelineConfig?.isJavaLibrary == true
+    boolean isDeployableApp = pipelineConfig?.deployableApp == true
 
-    if (isJavaLibrary) {
+    if (!isDeployableApp) {
       return false
     }
     def deploymentControls = getDeploymentControls()

--- a/src/uk/gov/hmcts/pipeline/DeploymentControls.groovy
+++ b/src/uk/gov/hmcts/pipeline/DeploymentControls.groovy
@@ -31,8 +31,10 @@ class DeploymentControls {
     return deploymentControls
   }
 
-  boolean isDeployEnabled(String repository) {
-    if (steps.config.isJavaLibrary) {
+  boolean isDeployEnabled(String repository, def pipelineConfig = null) {
+    boolean isJavaLibrary = pipelineConfig?.isJavaLibrary == true
+
+    if (isJavaLibrary) {
       return false
     }
     def deploymentControls = getDeploymentControls()

--- a/src/uk/gov/hmcts/pipeline/DeploymentControls.groovy
+++ b/src/uk/gov/hmcts/pipeline/DeploymentControls.groovy
@@ -32,7 +32,7 @@ class DeploymentControls {
   }
 
   boolean isDeployEnabled(String repository, def pipelineConfig = null) {
-    boolean isDeployableApp = pipelineConfig?.deployableApp == true
+    boolean isDeployableApp = pipelineConfig == null || pipelineConfig?.deployableApp == true
 
     if (!isDeployableApp) {
       return false

--- a/src/uk/gov/hmcts/pipeline/DeploymentControls.groovy
+++ b/src/uk/gov/hmcts/pipeline/DeploymentControls.groovy
@@ -32,6 +32,9 @@ class DeploymentControls {
   }
 
   boolean isDeployEnabled(String repository) {
+    if (steps.config.isJavaLibrary) {
+      return false
+    }
     def deploymentControls = getDeploymentControls()
     if (!deploymentControls.containsKey('repositories')) {
 

--- a/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
+++ b/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
@@ -33,7 +33,7 @@ class AppPipelineConfigTest extends Specification {
       assertThat(pipelineConfig.securityScan).isFalse()
       assertThat(pipelineConfig.legacyDeployment).isTrue()
       assertThat(pipelineConfig.serviceApp).isTrue()
-      assertThat(pipelineConfig.isJavaLibrary).isFalse()
+      assertThat(pipelineConfig.deployableApp).isTrue()
       assertThat(pipelineConfig.pactBrokerEnabled).isFalse()
       assertThat(pipelineConfig.pactProviderVerificationsEnabled).isFalse()
       assertThat(pipelineConfig.pactConsumerTestsEnabled).isFalse()
@@ -154,11 +154,11 @@ class AppPipelineConfigTest extends Specification {
     assertThat(pipelineConfig.serviceApp).isFalse()
   }
 
-  def "ensure is java library"() {
+  def "ensure is non deployable app"() {
     when:
-    dsl.isJavaLibrary()
+    dsl.nonDeployableApp()
     then:
-    assertThat(pipelineConfig.isJavaLibrary).isTrue()
+    assertThat(pipelineConfig.deployableApp).isFalse()
     assertThat(pipelineConfig.serviceApp).isFalse()
   }
 

--- a/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
+++ b/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
@@ -33,6 +33,7 @@ class AppPipelineConfigTest extends Specification {
       assertThat(pipelineConfig.securityScan).isFalse()
       assertThat(pipelineConfig.legacyDeployment).isTrue()
       assertThat(pipelineConfig.serviceApp).isTrue()
+      assertThat(pipelineConfig.isJavaLibrary).isFalse()
       assertThat(pipelineConfig.pactBrokerEnabled).isFalse()
       assertThat(pipelineConfig.pactProviderVerificationsEnabled).isFalse()
       assertThat(pipelineConfig.pactConsumerTestsEnabled).isFalse()
@@ -150,6 +151,14 @@ class AppPipelineConfigTest extends Specification {
     when:
     dsl.nonServiceApp()
     then:
+    assertThat(pipelineConfig.serviceApp).isFalse()
+  }
+
+  def "ensure is java library"() {
+    when:
+    dsl.isJavaLibrary()
+    then:
+    assertThat(pipelineConfig.isJavaLibrary).isTrue()
     assertThat(pipelineConfig.serviceApp).isFalse()
   }
 

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -28,7 +28,7 @@ def call(params) {
     checkoutScm(pipelineCallbacksRunner: pcr)
 
     // This needs to be initialised after the checkoutScm as it relies on env.GIT_URL which is not populated until after checkout
-    deploymentEnabled = new DeploymentControls(this).isDeployEnabled(env.GIT_URL)
+    deploymentEnabled = new DeploymentControls(this).isDeployEnabled(env.GIT_URL, config)
     withAcrClient(subscription) {
       projectBranch = new ProjectBranch(env.BRANCH_NAME)
       imageRegistry = env.TEAM_CONTAINER_REGISTRY ?: env.REGISTRY_NAME

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -215,7 +215,7 @@ def call(params) {
       }
     }
 
-    if (noSkipImgBuild && deploymentEnabled) {
+    if (!config.isJavaLibrary && noSkipImgBuild && deploymentEnabled) {
       stageWithAgent("Promote Docker Image", product) {
         if (dockerFileExists) {
           def deploymentStage = DockerImage.DeploymentStage.STAGING

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -28,7 +28,7 @@ def call(params) {
     checkoutScm(pipelineCallbacksRunner: pcr)
 
     // This needs to be initialised after the checkoutScm as it relies on env.GIT_URL which is not populated until after checkout
-    deploymentEnabled = new DeploymentControls(this).isDeployEnabled(env.GIT_URL) && !config.isJavaLibrary
+    deploymentEnabled = new DeploymentControls(this).isDeployEnabled(env.GIT_URL)
     withAcrClient(subscription) {
       projectBranch = new ProjectBranch(env.BRANCH_NAME)
       imageRegistry = env.TEAM_CONTAINER_REGISTRY ?: env.REGISTRY_NAME

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -51,7 +51,7 @@ def call(params) {
   onPathToLive {
     stageWithAgent("Build", product) {
       onPR {
-        if (deploymentEnabled) {
+        if (config.deployableApp) {
           enforceChartVersionBumped product: product, component: component
           warnAboutAADIdentityPreviewHack product: product, component: component
         }

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -51,8 +51,10 @@ def call(params) {
   onPathToLive {
     stageWithAgent("Build", product) {
       onPR {
-        enforceChartVersionBumped product: product, component: component
-        warnAboutAADIdentityPreviewHack product: product, component: component
+        if (deploymentEnabled) {
+          enforceChartVersionBumped product: product, component: component
+          warnAboutAADIdentityPreviewHack product: product, component: component
+        }
       }
 
       // always build master and demo as we currently do not deploy an image there

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -28,7 +28,7 @@ def call(params) {
     checkoutScm(pipelineCallbacksRunner: pcr)
 
     // This needs to be initialised after the checkoutScm as it relies on env.GIT_URL which is not populated until after checkout
-    deploymentEnabled = new DeploymentControls(this).isDeployEnabled(env.GIT_URL)
+    deploymentEnabled = new DeploymentControls(this).isDeployEnabled(env.GIT_URL) && !config.isJavaLibrary
     withAcrClient(subscription) {
       projectBranch = new ProjectBranch(env.BRANCH_NAME)
       imageRegistry = env.TEAM_CONTAINER_REGISTRY ?: env.REGISTRY_NAME
@@ -215,7 +215,7 @@ def call(params) {
       }
     }
 
-    if (!config.isJavaLibrary && noSkipImgBuild && deploymentEnabled) {
+    if (noSkipImgBuild && deploymentEnabled) {
       stageWithAgent("Promote Docker Image", product) {
         if (dockerFileExists) {
           def deploymentStage = DockerImage.DeploymentStage.STAGING

--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -43,7 +43,9 @@ def call(params) {
   def nonProdEnv = new Environment(env).nonProdName
 
   def builder = pipelineType.builder
-
+  if (config.isJavaLibrary) {
+    return
+  }
   withAcrClient(subscription) {
     imageRegistry = env.TEAM_CONTAINER_REGISTRY ?: env.REGISTRY_NAME
     acr = new Acr(this, subscription, imageRegistry, env.REGISTRY_RESOURCE_GROUP, env.REGISTRY_SUBSCRIPTION)
@@ -130,7 +132,7 @@ def call(params) {
               }
             }
           }
-        
+
           onFunctionalTestEnvironment(environment) {
             if (testLabels.contains('enable_full_functional_tests')) {
               stageWithAgent('Functional test (Full)', product) {
@@ -191,7 +193,7 @@ def call(params) {
           }
           // Performance Test Pipeline: Setup -> Parallel Testing
           if ((config.performanceTestStages || config.gatlingLoadTests) && environment in config.performanceTestEnvironments) {
-            
+
             // Load performance test secrets once for all stages - Secrets are stored only within the
             // rpe-shared-perftest KV for all environments (they are DT API keys and not env specific)
             def perfKeyVaultUrl = "https://rpe-shared-perftest.vault.azure.net"   //https://et-perftest.vault.azure.net/
@@ -211,7 +213,7 @@ def call(params) {
               azureKeyVaultSecrets: perfSecrets,
               keyVaultURLOverride: perfKeyVaultUrl
             ) {
-            
+
               // Stage 1: Dynatrace Setup - Post build info, events, and metrics first
               // Run setup for any performance testing (synthetic or gatling) to ensure DT events/metrics are sent
               stageWithAgent("Dynatrace Performance Setup - ${environment}", product) {
@@ -243,10 +245,10 @@ def call(params) {
                   }
                 }
               }
-            
+
             // Stage 2: Run performance tests in parallel (if both enabled) or sequential (if only one enabled)
             def testStages = [:]
-            
+
             if (config.performanceTestStages) {
               testStages['Dynatrace Synthetic Tests'] = {
                 stageWithAgent("Dynatrace Synthetic Tests - ${environment}", product) {
@@ -277,7 +279,7 @@ def call(params) {
                 }
               }
             }
-            
+
             if (config.gatlingLoadTests) {
               testStages['Gatling Load Tests'] = {
                 stageWithAgent("Gatling Load Tests - ${environment}", product) {
@@ -310,7 +312,7 @@ def call(params) {
                 }
               }
             }
-            
+
               // Execute test stages
               if (testStages.size() > 1) {
                 echo "Running Dynatrace Synthetic Tests and Gatling Load Tests in parallel..."

--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -43,9 +43,6 @@ def call(params) {
   def nonProdEnv = new Environment(env).nonProdName
 
   def builder = pipelineType.builder
-  if (config.isJavaLibrary) {
-    return
-  }
   withAcrClient(subscription) {
     imageRegistry = env.TEAM_CONTAINER_REGISTRY ?: env.REGISTRY_NAME
     acr = new Acr(this, subscription, imageRegistry, env.REGISTRY_RESOURCE_GROUP, env.REGISTRY_SUBSCRIPTION)

--- a/vars/withParameterizedPipeline.groovy
+++ b/vars/withParameterizedPipeline.groovy
@@ -72,7 +72,7 @@ def call(type, String product, String component, String environment, String subs
         checkoutScm(pipelineCallbacksRunner: callbacksRunner)
 
         // This needs to run after checkoutScm because env.GIT_URL is populated post-checkout.
-        deploymentEnabled = new DeploymentControls(this).isDeployEnabled(env.GIT_URL)
+        deploymentEnabled = new DeploymentControls(this).isDeployEnabled(env.GIT_URL, pipelineConfig)
         echo "Deployment Enabled status: '${deploymentEnabled}' for repository ${env.GIT_URL}"
       }
 


### PR DESCRIPTION
Added new nonDeployableApp flag.

When this toggle is enabled the deployment steps are skipped.
This means only the verification steps (Tests, Sonar, Dependency checks) are executed

The intention of this new flag is to enable Jenkins to run on common libraries (which have no ability to be deployed)

Once this is verified and working the aim is to extend upon this to support automatic releases in which once a PR gets merged into master (and a flag is added in Jenkins) that a new version of the lib gets deployed and added to our  maven repository