### PR TITLE
Added ability to create GitHub releases on merge into master

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,7 +825,7 @@ withPipeline(type, product, component) {
 }
 ```
 
-## Java Library
+## Non-Deployable App
 You need to add `nonDeployableApp()` method in `withPipeline` block to skip deployments.
 
 ```groovy
@@ -835,6 +835,19 @@ You need to add `nonDeployableApp()` method in `withPipeline` block to skip depl
 
 withPipeline(type, product, component) {
   nonDeployableApp()
+}
+```
+
+## Release on merge
+You need to add `releaseOnMerge()` method in `withPipeline` to automatically trigger a release pipeline when changes are merged to master if the gradle version number has been updated.
+
+```groovy
+#!groovy
+
+@Library("Infrastructure")
+
+withPipeline(type, product, component) {
+  releaseOnMerge()
 }
 ```
 

--- a/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
@@ -21,6 +21,7 @@ class AppPipelineConfig extends CommonPipelineConfig implements Serializable {
   boolean securityScan = false
   boolean serviceApp = true
   boolean deployableApp = true
+  boolean releaseOnMerge = false
   boolean aksStagingDeployment = false
   boolean legacyDeployment = true
   Set<String> legacyDeploymentExemptions = []

--- a/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
@@ -93,6 +93,10 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
     nonServiceApp()
   }
 
+  void releaseOnMerge() {
+    config.releaseOnMerge = true
+  }
+
   void overrideVaultEnvironments(Map<String, String> vaultOverrides) {
     config.vaultEnvironmentOverrides = vaultOverrides
   }

--- a/src/uk/gov/hmcts/contino/GithubAPI.groovy
+++ b/src/uk/gov/hmcts/contino/GithubAPI.groovy
@@ -342,6 +342,73 @@ class GithubAPI {
     return checkForLabel(branchName, "dependencies")
   }
 
+  def getLatestReleaseVersion(String project) {
+    def credentialsId = resolveCredentialsId()
+    if (!credentialsId) {
+      this.steps.echo('Skipping latest release lookup: no GitHub credentials could be resolved')
+      return null
+    }
+
+    def response = this.steps.httpRequest(
+      httpMode: 'GET',
+      authentication: credentialsId,
+      acceptType: 'APPLICATION_JSON',
+      contentType: 'APPLICATION_JSON',
+      url: API_URL + "/${project}/releases/latest",
+      consoleLogResponseBody: false,
+      validResponseCodes: '200,404'
+    )
+
+    if (response.status == 404) {
+      return null
+    }
+
+    def latestRelease = new JsonSlurperClassic().parseText(response.content)
+    String tagName = (latestRelease?.tag_name ?: '').toString().trim()
+    return normalizeVersion(tagName)
+  }
+
+  def createGitHubRelease(String project, String version, String targetCommitish = null) {
+    def credentialsId = resolveCredentialsId()
+    if (!credentialsId) {
+      this.steps.echo('Skipping release creation: no GitHub credentials could be resolved')
+      return null
+    }
+
+    String tagName = "v${version}"
+    String requestBody = JsonOutput.toJson([
+      tag_name: tagName,
+      target_commitish: targetCommitish ?: this.steps.env.GIT_COMMIT,
+      name: tagName,
+      body: "Automated release for ${version}",
+      draft: false,
+      prerelease: false,
+      generate_release_notes: true
+    ])
+
+    return this.steps.httpRequest(
+      httpMode: 'POST',
+      authentication: credentialsId,
+      acceptType: 'APPLICATION_JSON',
+      contentType: 'APPLICATION_JSON',
+      url: API_URL + "/${project}/releases",
+      requestBody: requestBody,
+      consoleLogResponseBody: true,
+      validResponseCodes: '201'
+    )
+  }
+
+  private String normalizeVersion(String version) {
+    String cleaned = (version ?: '').trim()
+    if (!cleaned) {
+      return ''
+    }
+
+    cleaned = cleaned.replaceFirst('^[vV]', '')
+    cleaned = cleaned.replaceFirst('[-+].*$', '')
+    return cleaned
+  }
+
   /**
    * Calls workflow to manually startup environment
    * @param workflowName

--- a/src/uk/gov/hmcts/contino/GradleAPI.groovy
+++ b/src/uk/gov/hmcts/contino/GradleAPI.groovy
@@ -1,0 +1,61 @@
+package uk.gov.hmcts.contino
+
+class GradleAPI {
+
+  def steps
+
+  GradleAPI(steps) {
+    this.steps = steps
+  }
+
+  String resolveGradleVersion() {
+    try {
+      return this.steps.sh(
+        script: "./gradlew --no-daemon -q properties | grep '^version:' | cut -d ':' -f 2- | head -n 1",
+        returnStdout: true
+      ).trim()
+    } catch (Exception ignored) {
+      return null
+    }
+  }
+
+  int compareReleaseVersions(String left, String right) {
+    List<Integer> leftParts = versionNumericParts(left)
+    List<Integer> rightParts = versionNumericParts(right)
+    int maxParts = Math.max(leftParts.size(), rightParts.size())
+
+    for (int i = 0; i < maxParts; i++) {
+      int leftPart = i < leftParts.size() ? leftParts[i] : 0
+      int rightPart = i < rightParts.size() ? rightParts[i] : 0
+      if (leftPart != rightPart) {
+        return leftPart <=> rightPart
+      }
+    }
+
+    return 0
+  }
+
+  private List<Integer> versionNumericParts(String version) {
+    String normalized = normalizeVersion(version)
+    if (!normalized) {
+      return [0]
+    }
+
+    return normalized
+      .split('\\.')
+      .findAll { it ==~ /\d+/ }
+      .collect { it as Integer }
+  }
+
+  private String normalizeVersion(String version) {
+    String cleaned = (version ?: '').trim()
+    if (!cleaned) {
+      return ''
+    }
+
+    cleaned = cleaned.replaceFirst('^[vV]', '')
+    cleaned = cleaned.replaceFirst('[-+].*$', '')
+    return cleaned
+  }
+}
+

--- a/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
+++ b/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
@@ -34,6 +34,7 @@ class AppPipelineConfigTest extends Specification {
       assertThat(pipelineConfig.legacyDeployment).isTrue()
       assertThat(pipelineConfig.serviceApp).isTrue()
       assertThat(pipelineConfig.deployableApp).isTrue()
+      assertThat(pipelineConfig.releaseOnMerge).isFalse()
       assertThat(pipelineConfig.pactBrokerEnabled).isFalse()
       assertThat(pipelineConfig.pactProviderVerificationsEnabled).isFalse()
       assertThat(pipelineConfig.pactConsumerTestsEnabled).isFalse()
@@ -160,6 +161,12 @@ class AppPipelineConfigTest extends Specification {
     then:
     assertThat(pipelineConfig.deployableApp).isFalse()
     assertThat(pipelineConfig.serviceApp).isFalse()
+  }
+  def "ensure release on merge"() {
+    when:
+    dsl.releaseOnMerge()
+    then:
+    assertThat(pipelineConfig.releaseOnMerge).isTrue()
   }
 
   def "ensure enable deploy to AKS Staging"() {

--- a/test/uk/gov/hmcts/contino/GithubAPITest.groovy
+++ b/test/uk/gov/hmcts/contino/GithubAPITest.groovy
@@ -79,6 +79,16 @@ class GithubAPITest extends Specification {
 
   static def invalidResponse = ["status": 500]
 
+  static def latestReleaseResponse = ["status": 200, "content": '''{
+      "tag_name": "v1.2.3"
+    }''']
+
+  static def latestReleaseNotFoundResponse = ["status": 404, "content": '']
+
+  static def releaseCreatedResponse = ["status": 201, "content": '''{
+      "id": 1
+    }''']
+
   void setup() {
     steps = Mock(JenkinsStepMock.class)
     steps.env >> [CHANGE_URL: "https://github.com/hmcts/some-project/pull/68",
@@ -280,5 +290,44 @@ class GithubAPITest extends Specification {
     then:
       assertThat(masterLabelExists).isFalse()
       assertThat(prLabelExists).isTrue()
+  }
+
+  def "getLatestReleaseVersion normalizes release tag"() {
+    given:
+      steps.httpRequest(_) >> latestReleaseResponse
+
+    when:
+      def version = githubApi.getLatestReleaseVersion('hmcts/some-project')
+
+    then:
+      assertThat(version).isEqualTo('1.2.3')
+  }
+
+  def "getLatestReleaseVersion returns null on 404"() {
+    given:
+      steps.httpRequest(_) >> latestReleaseNotFoundResponse
+
+    when:
+      def version = githubApi.getLatestReleaseVersion('hmcts/some-project')
+
+    then:
+      assertThat(version).isNull()
+  }
+
+  def "createGitHubRelease calls GitHub releases endpoint with expected payload"() {
+    given:
+      steps.httpRequest({ Map request ->
+        request.httpMode == 'POST' &&
+          request.url == 'https://api.github.com/repos/hmcts/some-project/releases' &&
+          request.requestBody.contains('"tag_name":"v1.2.4"') &&
+          request.requestBody.contains('"target_commitish":"abcdef1"') &&
+          request.requestBody.contains('"generate_release_notes":true')
+      }) >> releaseCreatedResponse
+
+    when:
+      def response = githubApi.createGitHubRelease('hmcts/some-project', '1.2.4', 'abcdef1')
+
+    then:
+      assertThat(response.status).isEqualTo(201)
   }
 }

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -220,8 +220,8 @@ def call(params) {
     }
 
     if (config.releaseOnMerge) {
-      stageWithAgent("Create release", product) {
-        onMaster {
+      onMaster {
+        stageWithAgent("Create release", product) {
           if (fileExists('build.gradle')) {
             String gradleVersion = gradleAPI.resolveGradleVersion()
             if (!gradleVersion) {

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -6,6 +6,7 @@ import uk.gov.hmcts.contino.DockerImage
 import uk.gov.hmcts.contino.ProjectBranch
 import uk.gov.hmcts.contino.azure.Acr
 import uk.gov.hmcts.contino.GithubAPI
+import uk.gov.hmcts.contino.GradleAPI
 import uk.gov.hmcts.pipeline.DeploymentControls
 
 def call(params) {
@@ -21,6 +22,7 @@ def call(params) {
   def dockerImage
   def projectBranch
   def imageRegistry
+  def gradleAPI = new GradleAPI(this)
   boolean noSkipImgBuild = true
   boolean deploymentEnabled = false
 
@@ -43,11 +45,11 @@ def call(params) {
   }
   boolean dockerFileExists = fileExists('Dockerfile')
   warnAboutJitpackRemoval(product: product, component: component)
-  
+
   stage('ACR Migration Check') {
     warnAboutOldAcrReferences(env.GIT_URL ?: 'unknown')
   }
-  
+
   onPathToLive {
     stageWithAgent("Build", product) {
       onPR {
@@ -217,6 +219,32 @@ def call(params) {
       }
     }
 
+    if (config.releaseOnMerge) {
+      stageWithAgent("Create release", product) {
+        onMaster {
+          if (fileExists('build.gradle')) {
+            String gradleVersion = gradleAPI.resolveGradleVersion()
+            if (!gradleVersion) {
+              echo('Skipping GitHub release creation: unable to resolve Gradle version')
+              return
+            }
+
+            GithubAPI githubAPI = new GithubAPI(this)
+            String project = githubAPI.currentProject()
+            String latestReleaseVersion = githubAPI.getLatestReleaseVersion(project)
+
+            if (latestReleaseVersion && gradleAPI.compareReleaseVersions(gradleVersion, latestReleaseVersion) <= 0) {
+              echo("Skipping GitHub release creation: ${gradleVersion} is not greater than latest release ${latestReleaseVersion}")
+              return
+            }
+
+            githubAPI.createGitHubRelease(project, gradleVersion, env.GIT_COMMIT)
+          }
+        }
+      }
+    }
+
+
     if (noSkipImgBuild && deploymentEnabled) {
       stageWithAgent("Promote Docker Image", product) {
         if (dockerFileExists) {
@@ -259,3 +287,4 @@ def call(params) {
   }
   return deploymentEnabled
 }
+


### PR DESCRIPTION
Added new releaseOnMerge flag.

When this flag is enabled a new step is added when the pipeline runs on master which will compare the Gradle version with the latest release version in GitHub and if different a new GitHub release is created.

The intention of this is to allow for automated releases of common-lib's.
This new GitHub release will then trigger a GitHub workflow which will build and deploy the lib into the maven repository, such that other applications can use it.

This removes a manual step from the process (But only triggers when the build.gradle version is updated)

