### PR TITLE
DTSPO-30114 - Silence nagger temporarily

### DIFF
--- a/vars/checkoutScm.groovy
+++ b/vars/checkoutScm.groovy
@@ -33,6 +33,6 @@ def call(params) {
       echo "Unable to find git email Id for the user' ${err}'"
     }
     warnAboutRenovateConfig()
-    warnAboutOldLibraryVersion()
+    // warnAboutOldLibraryVersion()
   }
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-30114

Silence the library version nagger for now as it's sending out messages to slack channels but we've not made the announcement yet

Todo: ensure notifications get sent to our test channels in future so we can detect this.
