### PR TITLE
feat: add Python pipeline support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ bin
 
 # ASDF
 .tool-versions
+
+docs/superpowers/

--- a/README.md
+++ b/README.md
@@ -955,7 +955,7 @@ Java 11 is installed on the Jenkins agent.
 [nvm](https://github.com/nvm-sh/nvm) is used, place a `.nvmrc` file at the root of your repo containing the version you want. If it isn't present we fallback to whatever is on the Jenkins agent, currently the latest 8.x version.
 
 ### Python
-[uv](https://docs.astral.sh/uv/) is used for package management. Place a `.python-version` file at the root of your repo containing the Python version you want (e.g. `3.13`). The pipeline enforces the use of supported Python versions — currently `3.13`. The `.python-version` file is also read by uv and pyenv locally.
+[uv](https://docs.astral.sh/uv/) is used for package management. Place a `.python-version` file at the root of your repo containing the Python version you want (e.g. `3.13`). The pipeline enforces the use of supported Python versions — currently `3.13`. The `.python-version` file is also read by uv locally.
 
 ### Terraform
 [tfenv](https://github.com/tfutils/tfenv) is used, place a `.terraform-version` file in your infrastructure folder for app pipelines, and at the root of your repo for infra pipelines. If this file isn't present we fallback to v0.11.7.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ To use this pipeline in your repo, you must import it in a Jenkinsfile
 
 ### Opinionated app pipeline
 
-This library contains a complete opinionated pipeline that can build, test and deploy Java
-and NodeJS applications. The pipeline contains the following stages:
+This library contains a complete opinionated pipeline that can build, test and deploy Java,
+NodeJS and Python applications. The pipeline contains the following stages:
 
 * Checkout
 * Build
@@ -36,7 +36,9 @@ and NodeJS applications. The pipeline contains the following stages:
 * (Optional) API (gateway) Tests - Production
 
 In this version, Java apps must use Gradle for builds and contain the `gradlew` wrapper
-script and dependencies in source control. NodeJS apps must use Yarn.
+script and dependencies in source control. NodeJS apps must use Yarn. Python apps must use
+[uv](https://docs.astral.sh/uv/) for package management and include a `.python-version` file
+at the root of the repository.
 
 The opinionated app pipeline supports Slack notifications when the build fails or is fixed - your team build channel should be provided.
 
@@ -46,7 +48,7 @@ Example `Jenkinsfile` to use the opinionated pipeline:
 
 @Library("Infrastructure")
 
-def type = "java"          // supports "java", "nodejs" and "angular"
+def type = "java"          // supports "java", "nodejs", "angular" and "python"
 
 def product = "rhubarb"
 
@@ -951,6 +953,9 @@ Java 11 is installed on the Jenkins agent.
 
 ### Node.JS
 [nvm](https://github.com/nvm-sh/nvm) is used, place a `.nvmrc` file at the root of your repo containing the version you want. If it isn't present we fallback to whatever is on the Jenkins agent, currently the latest 8.x version.
+
+### Python
+[uv](https://docs.astral.sh/uv/) is used for package management. Place a `.python-version` file at the root of your repo containing the Python version you want (e.g. `3.13`). The pipeline enforces the use of supported Python versions — currently `3.13`. The `.python-version` file is also read by uv and pyenv locally.
 
 ### Terraform
 [tfenv](https://github.com/tfutils/tfenv) is used, place a `.terraform-version` file in your infrastructure folder for app pipelines, and at the root of your repo for infra pipelines. If this file isn't present we fallback to v0.11.7.

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -99,12 +99,10 @@ class PythonBuilder extends AbstractBuilder {
   def securityCheck() {
     try {
       steps.sh('uv run pip-audit --format json -o pip-audit-report.json')
+    } finally {
       String jsonReport = steps.readFile('pip-audit-report.json')
       def parsedReport = prepareCVEReport(jsonReport)
       new CVEPublisher(steps).publishCVEReport('python', parsedReport)
-    } catch (Exception e) {
-      steps.echo("Security check failed: ${e.message}")
-      throw e
     }
   }
 

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -73,7 +73,7 @@ class PythonBuilder extends AbstractBuilder {
   @Override
   def addVersionInfo() {
     steps.sh('''tee version <<EOF
-version: $(grep '^version' pyproject.toml | sed 's/.*= *"//' | sed 's/".*//')
+version: $(grep -m 1 '^version' pyproject.toml | sed "s/.*= *//" | tr -d '"' | tr -d "'")
 number: ${BUILD_NUMBER}
 commit: $(git rev-parse HEAD)
 date: $(date)

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -1,0 +1,75 @@
+package uk.gov.hmcts.contino
+
+import uk.gov.hmcts.pipeline.CVEPublisher
+import uk.gov.hmcts.pipeline.SonarProperties
+import uk.gov.hmcts.pipeline.deprecation.WarningCollector
+import java.time.LocalDate
+
+class PythonBuilder extends AbstractBuilder {
+
+  private static final String PYTHON_VERSION_FILE = '.python-version'
+  private static final List<String> SUPPORTED_PYTHON_VERSIONS = ['3.13']
+  private static final LocalDate PYTHON_VERSION_DEADLINE = LocalDate.of(2027, 1, 1)
+
+  def localSteps
+
+  PythonBuilder(steps) {
+    super(steps)
+    this.localSteps = steps
+  }
+
+  @Override
+  def build() {}
+
+  @Override
+  def fortifyScan() {}
+
+  @Override
+  def test() {}
+
+  @Override
+  def sonarScan() {}
+
+  @Override
+  def highLevelDataSetup(String dataSetupEnvironment) {}
+
+  @Override
+  def smokeTest() {}
+
+  @Override
+  def functionalTest() {}
+
+  @Override
+  def e2eTest() {
+    steps.error('Not implemented')
+  }
+
+  @Override
+  def apiGatewayTest() {
+    steps.error('Not implemented')
+  }
+
+  @Override
+  def crossBrowserTest() {
+    steps.error('Not implemented')
+  }
+
+  @Override
+  def mutationTest() {
+    steps.error('Not implemented')
+  }
+
+  @Override
+  def fullFunctionalTest() {
+    functionalTest()
+  }
+
+  @Override
+  def securityCheck() {}
+
+  @Override
+  def addVersionInfo() {}
+
+  @Override
+  def setupToolVersion() {}
+}

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.contino
 
+import groovy.json.JsonSlurperClassic
 import uk.gov.hmcts.pipeline.CVEPublisher
 import uk.gov.hmcts.pipeline.SonarProperties
 import uk.gov.hmcts.pipeline.deprecation.WarningCollector
@@ -92,11 +93,25 @@ class PythonBuilder extends AbstractBuilder {
   def securityCheck() {
     try {
       steps.sh('uv run pip-audit --format json -o pip-audit-report.json')
-      def report = [dependencies: steps.readFile('pip-audit-report.json')]
-      new CVEPublisher(steps).publishCVEReport('python', report)
+      String jsonReport = steps.readFile('pip-audit-report.json')
+      def parsedReport = prepareCVEReport(jsonReport)
+      new CVEPublisher(steps).publishCVEReport('python', parsedReport)
     } catch (Exception e) {
       steps.echo("Security check failed: ${e.message}")
       throw e
+    }
+  }
+
+  def prepareCVEReport(String pipAuditJSON) {
+    if (!pipAuditJSON || pipAuditJSON.trim().isEmpty()) {
+      return [vulnerabilities: []]
+    }
+
+    try {
+      def reportArray = new JsonSlurperClassic().parseText(pipAuditJSON)
+      return [vulnerabilities: reportArray ?: []]
+    } catch (Exception e) {
+      return [vulnerabilities: []]
     }
   }
 

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -147,7 +147,7 @@ EOF
     if (!SUPPORTED_PYTHON_VERSIONS.contains(majorMinor)) {
       WarningCollector.addPipelineWarning(
         'unsupported_python_version',
-        "Python version '${majorMinor}' is not supported. Currently supported versions: ${SUPPORTED_PYTHON_VERSIONS.join(', ')}. Update your ${PYTHON_VERSION_FILE} file. See https://github.com/hmcts/fastapi-template for reference.",
+        "Python version '${majorMinor}' is not supported. Currently supported versions: ${SUPPORTED_PYTHON_VERSIONS.join(', ')}. Update your ${PYTHON_VERSION_FILE} file. ",
         PYTHON_VERSION_DEADLINE
       )
     }

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -47,7 +47,7 @@ class PythonBuilder extends AbstractBuilder {
     try {
       steps.sh('uv run pytest tests/smoke --junit-xml=test-results/smoke/results.xml -v')
     } finally {
-      steps.junit(allowEmptyResults: true, testResults: 'test-results/smoke/*.xml')
+      steps.junit(allowEmptyResults: false, testResults: 'test-results/smoke/*.xml')
     }
   }
 

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -19,7 +19,10 @@ class PythonBuilder extends AbstractBuilder {
   }
 
   @Override
-  def build() {}
+  def build() {
+    addVersionInfo()
+    steps.sh('uv sync --locked --no-dev')
+  }
 
   @Override
   def fortifyScan() {}
@@ -68,7 +71,15 @@ class PythonBuilder extends AbstractBuilder {
   def securityCheck() {}
 
   @Override
-  def addVersionInfo() {}
+  def addVersionInfo() {
+    steps.sh('''tee version <<EOF
+version: $(grep '^version' pyproject.toml | sed 's/.*= *"//' | sed 's/".*//')
+number: ${BUILD_NUMBER}
+commit: $(git rev-parse HEAD)
+date: $(date)
+EOF
+''')
+  }
 
   @Override
   def setupToolVersion() {}

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -139,12 +139,7 @@ EOF
     def deadline = pythonConfig?.date_deadline ? LocalDate.parse(pythonConfig.date_deadline) : null
 
     if (!steps.fileExists(PYTHON_VERSION_FILE)) {
-      def message = "A ${PYTHON_VERSION_FILE} file is missing. Add a ${PYTHON_VERSION_FILE} file specifying your Python version, e.g. '3.13'. See https://github.com/hmcts/fastapi-template for reference."
-      if (deadline) {
-        WarningCollector.addPipelineWarning('missing_python_version_file', message, deadline)
-      } else {
-        steps.echo("[Warning] ${message}")
-      }
+      steps.echo("[Warning] A ${PYTHON_VERSION_FILE} file is missing. Add a ${PYTHON_VERSION_FILE} file specifying your Python version, e.g. '3.13'.")
       return
     }
 
@@ -152,7 +147,7 @@ EOF
     String majorMinor = rawVersion.tokenize('.').take(2).join('.')
 
     if (!SUPPORTED_PYTHON_VERSIONS.contains(majorMinor)) {
-      def message = "Python version '${majorMinor}' is not supported. Currently supported versions: ${SUPPORTED_PYTHON_VERSIONS.join(', ')}. Update your ${PYTHON_VERSION_FILE} file. See https://github.com/hmcts/fastapi-template for reference."
+      def message = "Python version '${majorMinor}' is not supported. Currently supported versions: ${SUPPORTED_PYTHON_VERSIONS.join(', ')}. Update your ${PYTHON_VERSION_FILE} file."
       if (deadline) {
         WarningCollector.addPipelineWarning('unsupported_python_version', message, deadline)
       } else {

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -26,7 +26,13 @@ class PythonBuilder extends AbstractBuilder {
   }
 
   @Override
-  def fortifyScan() {}
+  def fortifyScan() {
+    try {
+      steps.fortifyOnDemandScan()
+    } finally {
+      steps.archiveArtifacts(allowEmptyArchive: true, artifacts: 'Fortify Scan/FortifyScanReport.html,Fortify Scan/FortifyVulnerabilities.*')
+    }
+  }
 
   @Override
   def test() {

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -99,8 +99,7 @@ class PythonBuilder extends AbstractBuilder {
   def securityCheck() {
     int exitCode
     try {
-      exitCode = steps.sh(script: 'uv audit', returnStatus: true)
-      steps.sh('uv audit --output-format json > uv-audit-report.json || true')
+      exitCode = steps.sh(script: 'uv audit --output-format json > uv-audit-report.json', returnStatus: true)
     } finally {
       if (steps.fileExists('uv-audit-report.json')) {
         steps.archiveArtifacts(artifacts: 'uv-audit-report.json')
@@ -110,7 +109,7 @@ class PythonBuilder extends AbstractBuilder {
       }
     }
     if (exitCode != 0) {
-      steps.error('Security vulnerabilities found in Python dependencies. See uv-audit-report.json for details.')
+      steps.error('Security vulnerabilities found in Python dependencies. Review the uv-audit-report.json build artifact for details.')
     }
   }
 

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -2,6 +2,7 @@ package uk.gov.hmcts.contino
 
 import groovy.json.JsonSlurperClassic
 import uk.gov.hmcts.pipeline.CVEPublisher
+import uk.gov.hmcts.pipeline.DeprecationConfig
 import uk.gov.hmcts.pipeline.SonarProperties
 import uk.gov.hmcts.pipeline.deprecation.WarningCollector
 import java.time.LocalDate
@@ -132,11 +133,17 @@ EOF
 
   @Override
   def setupToolVersion() {
+    def deprecationConfig = new DeprecationConfig(steps)
+    def repoUrl = steps.env.GIT_URL
+    def config = deprecationConfig.getDeprecationConfig(repoUrl)
+    def pythonConfig = config?.python?.python_version
+    def deadline = pythonConfig?.date_deadline ? LocalDate.parse(pythonConfig.date_deadline) : PYTHON_VERSION_DEADLINE
+
     if (!steps.fileExists(PYTHON_VERSION_FILE)) {
       WarningCollector.addPipelineWarning(
         'missing_python_version_file',
         "A ${PYTHON_VERSION_FILE} file is missing. Add a ${PYTHON_VERSION_FILE} file specifying your Python version, e.g. '3.13'. See https://github.com/hmcts/fastapi-template for reference.",
-        PYTHON_VERSION_DEADLINE
+        deadline
       )
       return
     }
@@ -147,8 +154,8 @@ EOF
     if (!SUPPORTED_PYTHON_VERSIONS.contains(majorMinor)) {
       WarningCollector.addPipelineWarning(
         'unsupported_python_version',
-        "Python version '${majorMinor}' is not supported. Currently supported versions: ${SUPPORTED_PYTHON_VERSIONS.join(', ')}. Update your ${PYTHON_VERSION_FILE} file. ",
-        PYTHON_VERSION_DEADLINE
+        "Python version '${majorMinor}' is not supported. Currently supported versions: ${SUPPORTED_PYTHON_VERSIONS.join(', ')}. Update your ${PYTHON_VERSION_FILE} file. See https://github.com/hmcts/fastapi-template for reference.",
+        deadline
       )
     }
   }

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -22,7 +22,7 @@ class PythonBuilder extends AbstractBuilder {
   @Override
   def build() {
     addVersionInfo()
-    steps.sh('uv sync --locked --no-dev')
+    steps.sh('uv sync --locked --no-dev --link-mode=copy')
   }
 
   @Override

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -28,7 +28,13 @@ class PythonBuilder extends AbstractBuilder {
   def fortifyScan() {}
 
   @Override
-  def test() {}
+  def test() {
+    try {
+      steps.sh('uv run pytest tests/unit --junit-xml=test-results/unit/results.xml -v')
+    } finally {
+      steps.junit(allowEmptyResults: true, testResults: 'test-results/unit/*.xml')
+    }
+  }
 
   @Override
   def sonarScan() {}
@@ -37,10 +43,22 @@ class PythonBuilder extends AbstractBuilder {
   def highLevelDataSetup(String dataSetupEnvironment) {}
 
   @Override
-  def smokeTest() {}
+  def smokeTest() {
+    try {
+      steps.sh('uv run pytest tests/smoke --junit-xml=test-results/smoke/results.xml -v')
+    } finally {
+      steps.junit(allowEmptyResults: true, testResults: 'test-results/smoke/*.xml')
+    }
+  }
 
   @Override
-  def functionalTest() {}
+  def functionalTest() {
+    try {
+      steps.sh('uv run pytest tests/functional --junit-xml=test-results/functional/results.xml -v')
+    } finally {
+      steps.junit(allowEmptyResults: true, testResults: 'test-results/functional/*.xml')
+    }
+  }
 
   @Override
   def e2eTest() {

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -22,7 +22,7 @@ class PythonBuilder extends AbstractBuilder {
   @Override
   def build() {
     addVersionInfo()
-    steps.sh('uv sync --locked --no-dev --link-mode=copy')
+    steps.sh('uv sync --locked --link-mode=copy')
   }
 
   @Override
@@ -98,9 +98,9 @@ class PythonBuilder extends AbstractBuilder {
   @Override
   def securityCheck() {
     try {
-      steps.sh('uv audit --output-format json > uv-audit-report.json')
+      steps.sh('uv audit --output-format json > uv-audit-report.json || true')
     } finally {
-      String jsonReport = steps.readFile('uv-audit-report.json')
+      String jsonReport = steps.fileExists('uv-audit-report.json') ? steps.readFile('uv-audit-report.json') : ''
       def parsedReport = prepareCVEReport(jsonReport)
       new CVEPublisher(steps).publishCVEReport('python', parsedReport)
     }

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -106,13 +106,13 @@ class PythonBuilder extends AbstractBuilder {
     }
   }
 
-  def prepareCVEReport(String pipAuditJSON) {
-    if (!pipAuditJSON || pipAuditJSON.trim().isEmpty()) {
+  def prepareCVEReport(String uvAuditJSON) {
+    if (!uvAuditJSON || uvAuditJSON.trim().isEmpty()) {
       return [vulnerabilities: []]
     }
 
     try {
-      def reportArray = new JsonSlurperClassic().parseText(pipAuditJSON)
+      def reportArray = new JsonSlurperClassic().parseText(uvAuditJSON)
       return [vulnerabilities: reportArray ?: []]
     } catch (Exception e) {
       return [vulnerabilities: []]

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -37,7 +37,7 @@ class PythonBuilder extends AbstractBuilder {
   @Override
   def test() {
     try {
-      steps.sh('uv run pytest tests/unit --junit-xml=test-results/unit/results.xml -v')
+      steps.sh('uv run pytest tests/unit --junit-xml=test-results/unit/results.xml --cov=app --cov-report=xml -v')
     } finally {
       steps.junit(allowEmptyResults: true, testResults: 'test-results/unit/*.xml')
     }

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -127,5 +127,25 @@ EOF
   }
 
   @Override
-  def setupToolVersion() {}
+  def setupToolVersion() {
+    if (!steps.fileExists(PYTHON_VERSION_FILE)) {
+      WarningCollector.addPipelineWarning(
+        'missing_python_version_file',
+        "A ${PYTHON_VERSION_FILE} file is missing. Add a ${PYTHON_VERSION_FILE} file specifying your Python version, e.g. '3.13'. See https://github.com/hmcts/fastapi-template for reference.",
+        PYTHON_VERSION_DEADLINE
+      )
+      return
+    }
+
+    String rawVersion = steps.readFile(PYTHON_VERSION_FILE).trim()
+    String majorMinor = rawVersion.tokenize('.').take(2).join('.')
+
+    if (!SUPPORTED_PYTHON_VERSIONS.contains(majorMinor)) {
+      WarningCollector.addPipelineWarning(
+        'unsupported_python_version',
+        "Python version '${majorMinor}' is not supported. Currently supported versions: ${SUPPORTED_PYTHON_VERSIONS.join(', ')}. Update your ${PYTHON_VERSION_FILE} file. See https://github.com/hmcts/fastapi-template for reference.",
+        PYTHON_VERSION_DEADLINE
+      )
+    }
+  }
 }

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -37,7 +37,10 @@ class PythonBuilder extends AbstractBuilder {
   }
 
   @Override
-  def sonarScan() {}
+  def sonarScan() {
+    String properties = SonarProperties.get(steps)
+    steps.sh("sonar-scanner ${properties}")
+  }
 
   @Override
   def highLevelDataSetup(String dataSetupEnvironment) {}
@@ -86,7 +89,16 @@ class PythonBuilder extends AbstractBuilder {
   }
 
   @Override
-  def securityCheck() {}
+  def securityCheck() {
+    try {
+      steps.sh('uv run pip-audit --format json -o pip-audit-report.json')
+      def report = [dependencies: steps.readFile('pip-audit-report.json')]
+      new CVEPublisher(steps).publishCVEReport('python', report)
+    } catch (Exception e) {
+      steps.echo("Security check failed: ${e.message}")
+      throw e
+    }
+  }
 
   @Override
   def addVersionInfo() {

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -98,9 +98,9 @@ class PythonBuilder extends AbstractBuilder {
   @Override
   def securityCheck() {
     try {
-      steps.sh('uv run pip-audit --format json -o pip-audit-report.json')
+      steps.sh('uv audit --output-format json > uv-audit-report.json')
     } finally {
-      String jsonReport = steps.readFile('pip-audit-report.json')
+      String jsonReport = steps.readFile('uv-audit-report.json')
       def parsedReport = prepareCVEReport(jsonReport)
       new CVEPublisher(steps).publishCVEReport('python', parsedReport)
     }

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -97,12 +97,20 @@ class PythonBuilder extends AbstractBuilder {
 
   @Override
   def securityCheck() {
+    int exitCode
     try {
+      exitCode = steps.sh(script: 'uv audit', returnStatus: true)
       steps.sh('uv audit --output-format json > uv-audit-report.json || true')
     } finally {
-      String jsonReport = steps.fileExists('uv-audit-report.json') ? steps.readFile('uv-audit-report.json') : ''
-      def parsedReport = prepareCVEReport(jsonReport)
-      new CVEPublisher(steps).publishCVEReport('python', parsedReport)
+      if (steps.fileExists('uv-audit-report.json')) {
+        steps.archiveArtifacts(artifacts: 'uv-audit-report.json')
+        String jsonReport = steps.readFile('uv-audit-report.json')
+        def parsedReport = prepareCVEReport(jsonReport)
+        new CVEPublisher(steps).publishCVEReport('python', parsedReport)
+      }
+    }
+    if (exitCode != 0) {
+      steps.error('Security vulnerabilities found in Python dependencies. See uv-audit-report.json for details.')
     }
   }
 

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -11,7 +11,6 @@ class PythonBuilder extends AbstractBuilder {
 
   private static final String PYTHON_VERSION_FILE = '.python-version'
   private static final List<String> SUPPORTED_PYTHON_VERSIONS = ['3.13']
-  private static final LocalDate PYTHON_VERSION_DEADLINE = LocalDate.of(2027, 1, 1)
 
   def localSteps
 
@@ -137,14 +136,15 @@ EOF
     def repoUrl = steps.env.GIT_URL
     def config = deprecationConfig.getDeprecationConfig(repoUrl)
     def pythonConfig = config?.python?.python_version
-    def deadline = pythonConfig?.date_deadline ? LocalDate.parse(pythonConfig.date_deadline) : PYTHON_VERSION_DEADLINE
+    def deadline = pythonConfig?.date_deadline ? LocalDate.parse(pythonConfig.date_deadline) : null
 
     if (!steps.fileExists(PYTHON_VERSION_FILE)) {
-      WarningCollector.addPipelineWarning(
-        'missing_python_version_file',
-        "A ${PYTHON_VERSION_FILE} file is missing. Add a ${PYTHON_VERSION_FILE} file specifying your Python version, e.g. '3.13'. See https://github.com/hmcts/fastapi-template for reference.",
-        deadline
-      )
+      def message = "A ${PYTHON_VERSION_FILE} file is missing. Add a ${PYTHON_VERSION_FILE} file specifying your Python version, e.g. '3.13'. See https://github.com/hmcts/fastapi-template for reference."
+      if (deadline) {
+        WarningCollector.addPipelineWarning('missing_python_version_file', message, deadline)
+      } else {
+        steps.echo("[Warning] ${message}")
+      }
       return
     }
 
@@ -152,11 +152,12 @@ EOF
     String majorMinor = rawVersion.tokenize('.').take(2).join('.')
 
     if (!SUPPORTED_PYTHON_VERSIONS.contains(majorMinor)) {
-      WarningCollector.addPipelineWarning(
-        'unsupported_python_version',
-        "Python version '${majorMinor}' is not supported. Currently supported versions: ${SUPPORTED_PYTHON_VERSIONS.join(', ')}. Update your ${PYTHON_VERSION_FILE} file. See https://github.com/hmcts/fastapi-template for reference.",
-        deadline
-      )
+      def message = "Python version '${majorMinor}' is not supported. Currently supported versions: ${SUPPORTED_PYTHON_VERSIONS.join(', ')}. Update your ${PYTHON_VERSION_FILE} file. See https://github.com/hmcts/fastapi-template for reference."
+      if (deadline) {
+        WarningCollector.addPipelineWarning('unsupported_python_version', message, deadline)
+      } else {
+        steps.echo("[Warning] ${message}")
+      }
     }
   }
 }

--- a/src/uk/gov/hmcts/contino/PythonPipelineType.groovy
+++ b/src/uk/gov/hmcts/contino/PythonPipelineType.groovy
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.contino
+
+class PythonPipelineType implements PipelineType, Serializable {
+  def steps
+  def product
+  def app
+
+  PythonBuilder builder
+
+  PythonPipelineType(steps, product, app) {
+    this.steps = steps
+    this.product = product
+    this.app = app
+
+    this.steps.env.PRODUCT = product
+
+    builder = new PythonBuilder(steps)
+  }
+}

--- a/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
@@ -98,4 +98,20 @@ class PythonBuilderTest extends Specification {
       1 * steps.sh({ it.contains('uv run pytest tests/functional') })
       1 * steps.junit({ it instanceof Map && it.allowEmptyResults == true && it.testResults.contains('test-results/functional') })
   }
+
+  def "sonarScan calls sonar-scanner"() {
+    when:
+      builder.sonarScan()
+    then:
+      1 * steps.sh({ it.contains('sonar-scanner') })
+  }
+
+  def "securityCheck calls pip-audit"() {
+    given:
+      steps.readFile('pip-audit-report.json') >> '[]'
+    when:
+      builder.securityCheck()
+    then:
+      1 * steps.sh({ it.contains('pip-audit') })
+  }
 }

--- a/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
@@ -39,6 +39,11 @@ class PythonBuilderTest extends Specification {
     when:
       builder.addVersionInfo()
     then:
-      1 * steps.sh({ it.contains('tee version') && it.contains('pyproject.toml') })
+      1 * steps.sh({
+        it.contains('tee version') &&
+        it.contains('pyproject.toml') &&
+        it.contains('BUILD_NUMBER') &&
+        it.contains('git rev-parse HEAD')
+      })
   }
 }

--- a/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
@@ -106,30 +106,30 @@ class PythonBuilderTest extends Specification {
       1 * steps.sh({ it.contains('sonar-scanner') })
   }
 
-  def "securityCheck calls pip-audit"() {
+  def "securityCheck calls uv audit"() {
     given:
-      steps.readFile('pip-audit-report.json') >> '[]'
+      steps.readFile('uv-audit-report.json') >> '[]'
     when:
       builder.securityCheck()
     then:
-      1 * steps.sh({ it.contains('pip-audit') })
+      1 * steps.sh({ it.contains('uv audit') })
   }
 
-  def "securityCheck publishes CVE report even when pip-audit finds vulnerabilities"() {
+  def "securityCheck publishes CVE report even when uv audit finds vulnerabilities"() {
     given:
-      steps.sh(_ as String) >> { throw new Exception('pip-audit exit 1') }
-      steps.readFile('pip-audit-report.json') >> '[]'
+      steps.sh(_ as String) >> { throw new Exception('uv audit exit 1') }
+      steps.readFile('uv-audit-report.json') >> '[]'
     when:
       builder.securityCheck()
     then:
       thrown(Exception)
-      1 * steps.readFile('pip-audit-report.json')
+      1 * steps.readFile('uv-audit-report.json')
   }
 
   def "securityCheck rethrows exception on failure"() {
     given:
-      steps.sh(_ as String) >> { throw new Exception('pip-audit failed') }
-      steps.readFile('pip-audit-report.json') >> '[]'
+      steps.sh(_ as String) >> { throw new Exception('uv audit failed') }
+      steps.readFile('uv-audit-report.json') >> '[]'
     when:
       builder.securityCheck()
     then:

--- a/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.contino
 
 import spock.lang.Specification
+import uk.gov.hmcts.pipeline.DeprecationConfig
 import uk.gov.hmcts.pipeline.deprecation.WarningCollector
 
 class PythonBuilderTest extends Specification {
@@ -11,14 +12,18 @@ class PythonBuilderTest extends Specification {
 
   def setup() {
     steps = Mock(JenkinsStepMock.class)
-    envVars = [BRANCH_NAME: 'master']
+    envVars = [BRANCH_NAME: 'master', GIT_URL: 'https://github.com/hmcts/test-repo']
     steps.getEnv() >> envVars
+    steps.httpRequest(_) >> [content: 'dummy']
+    steps.readYaml(_) >> [python: [python_version: [date_deadline: '2027-01-01']]]
     builder = new PythonBuilder(steps)
     WarningCollector.pipelineWarnings.clear()
+    DeprecationConfig.deprecationConfigInternal = null
   }
 
   def cleanup() {
     WarningCollector.pipelineWarnings.clear()
+    DeprecationConfig.deprecationConfigInternal = null
   }
 
   def "build calls 'uv sync --locked --no-dev'"() {

--- a/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
@@ -164,4 +164,40 @@ class PythonBuilderTest extends Specification {
       WarningCollector.pipelineWarnings.size() == 1
       WarningCollector.pipelineWarnings[0].warningKey == 'missing_python_version_file'
   }
+
+  def "fortifyScan delegates to library FoD runner"() {
+    when:
+      builder.fortifyScan()
+    then:
+      1 * steps.fortifyOnDemandScan()
+      1 * steps.archiveArtifacts({ it instanceof Map && it.allowEmptyArchive == true && it.artifacts.contains('FortifyScanReport.html') })
+  }
+
+  def "e2eTest calls error with not implemented message"() {
+    when:
+      builder.e2eTest()
+    then:
+      1 * steps.error('Not implemented')
+  }
+
+  def "crossBrowserTest calls error with not implemented message"() {
+    when:
+      builder.crossBrowserTest()
+    then:
+      1 * steps.error('Not implemented')
+  }
+
+  def "mutationTest calls error with not implemented message"() {
+    when:
+      builder.mutationTest()
+    then:
+      1 * steps.error('Not implemented')
+  }
+
+  def "apiGatewayTest calls error with not implemented message"() {
+    when:
+      builder.apiGatewayTest()
+    then:
+      1 * steps.error('Not implemented')
+  }
 }

--- a/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
@@ -115,9 +115,21 @@ class PythonBuilderTest extends Specification {
       1 * steps.sh({ it.contains('pip-audit') })
   }
 
+  def "securityCheck publishes CVE report even when pip-audit finds vulnerabilities"() {
+    given:
+      steps.sh(_ as String) >> { throw new Exception('pip-audit exit 1') }
+      steps.readFile('pip-audit-report.json') >> '[]'
+    when:
+      builder.securityCheck()
+    then:
+      thrown(Exception)
+      1 * steps.readFile('pip-audit-report.json')
+  }
+
   def "securityCheck rethrows exception on failure"() {
     given:
       steps.sh(_ as String) >> { throw new Exception('pip-audit failed') }
+      steps.readFile('pip-audit-report.json') >> '[]'
     when:
       builder.securityCheck()
     then:

--- a/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
@@ -46,4 +46,35 @@ class PythonBuilderTest extends Specification {
         it.contains('git rev-parse HEAD')
       })
   }
+
+  def "test calls 'uv run pytest tests/unit' and publishes JUnit XML"() {
+    when:
+      builder.test()
+    then:
+      1 * steps.sh({ it.contains('uv run pytest tests/unit') })
+      1 * steps.junit({ it instanceof Map && it.allowEmptyResults == true && it.testResults.contains('test-results/unit') })
+  }
+
+  def "smokeTest calls 'uv run pytest tests/smoke' and publishes JUnit XML"() {
+    when:
+      builder.smokeTest()
+    then:
+      1 * steps.sh({ it.contains('uv run pytest tests/smoke') })
+      1 * steps.junit({ it instanceof Map && it.allowEmptyResults == true && it.testResults.contains('test-results/smoke') })
+  }
+
+  def "functionalTest calls 'uv run pytest tests/functional' and publishes JUnit XML"() {
+    when:
+      builder.functionalTest()
+    then:
+      1 * steps.sh({ it.contains('uv run pytest tests/functional') })
+      1 * steps.junit({ it instanceof Map && it.allowEmptyResults == true && it.testResults.contains('test-results/functional') })
+  }
+
+  def "fullFunctionalTest delegates to functionalTest"() {
+    when:
+      builder.fullFunctionalTest()
+    then:
+      1 * steps.sh({ it.contains('uv run pytest tests/functional') })
+  }
 }

--- a/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
@@ -114,4 +114,13 @@ class PythonBuilderTest extends Specification {
     then:
       1 * steps.sh({ it.contains('pip-audit') })
   }
+
+  def "securityCheck rethrows exception on failure"() {
+    given:
+      steps.sh(_ as String) >> { throw new Exception('pip-audit failed') }
+    when:
+      builder.securityCheck()
+    then:
+      thrown(Exception)
+  }
 }

--- a/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
@@ -123,4 +123,45 @@ class PythonBuilderTest extends Specification {
     then:
       thrown(Exception)
   }
+
+  def "setupToolVersion adds no warning when .python-version contains supported version 3.13"() {
+    given:
+      steps.fileExists('.python-version') >> true
+      steps.readFile('.python-version') >> '3.13'
+    when:
+      builder.setupToolVersion()
+    then:
+      WarningCollector.pipelineWarnings.isEmpty()
+  }
+
+  def "setupToolVersion extracts major.minor from full patch version string 3.13.2"() {
+    given:
+      steps.fileExists('.python-version') >> true
+      steps.readFile('.python-version') >> '3.13.2'
+    when:
+      builder.setupToolVersion()
+    then:
+      WarningCollector.pipelineWarnings.isEmpty()
+  }
+
+  def "setupToolVersion adds warning when .python-version contains unsupported version"() {
+    given:
+      steps.fileExists('.python-version') >> true
+      steps.readFile('.python-version') >> '3.11'
+    when:
+      builder.setupToolVersion()
+    then:
+      WarningCollector.pipelineWarnings.size() == 1
+      WarningCollector.pipelineWarnings[0].warningKey == 'unsupported_python_version'
+  }
+
+  def "setupToolVersion adds warning when .python-version file is missing"() {
+    given:
+      steps.fileExists('.python-version') >> false
+    when:
+      builder.setupToolVersion()
+    then:
+      WarningCollector.pipelineWarnings.size() == 1
+      WarningCollector.pipelineWarnings[0].warningKey == 'missing_python_version_file'
+  }
 }

--- a/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
@@ -182,6 +182,29 @@ class PythonBuilderTest extends Specification {
       WarningCollector.pipelineWarnings[0].warningKey == 'missing_python_version_file'
   }
 
+  def "setupToolVersion echoes warning (no WarningCollector) when no deprecation config and version unsupported"() {
+    given:
+      DeprecationConfig.deprecationConfigInternal = [:]
+      steps.fileExists('.python-version') >> true
+      steps.readFile('.python-version') >> '3.11'
+    when:
+      builder.setupToolVersion()
+    then:
+      WarningCollector.pipelineWarnings.isEmpty()
+      1 * steps.echo({ it.contains('3.11') && it.contains('[Warning]') })
+  }
+
+  def "setupToolVersion echoes warning (no WarningCollector) when no deprecation config and file missing"() {
+    given:
+      DeprecationConfig.deprecationConfigInternal = [:]
+      steps.fileExists('.python-version') >> false
+    when:
+      builder.setupToolVersion()
+    then:
+      WarningCollector.pipelineWarnings.isEmpty()
+      1 * steps.echo({ it.contains('.python-version') && it.contains('[Warning]') })
+  }
+
   def "fortifyScan delegates to library FoD runner"() {
     when:
       builder.fortifyScan()

--- a/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
@@ -55,12 +55,22 @@ class PythonBuilderTest extends Specification {
       1 * steps.junit({ it instanceof Map && it.allowEmptyResults == true && it.testResults.contains('test-results/unit') })
   }
 
+  def "test publishes JUnit XML even when pytest fails"() {
+    given:
+      steps.sh(_ as String) >> { throw new Exception('pytest failed') }
+    when:
+      builder.test()
+    then:
+      thrown(Exception)
+      1 * steps.junit({ it instanceof Map && it.allowEmptyResults == true && it.testResults.contains('test-results/unit') })
+  }
+
   def "smokeTest calls 'uv run pytest tests/smoke' and publishes JUnit XML"() {
     when:
       builder.smokeTest()
     then:
       1 * steps.sh({ it.contains('uv run pytest tests/smoke') })
-      1 * steps.junit({ it instanceof Map && it.allowEmptyResults == true && it.testResults.contains('test-results/smoke') })
+      1 * steps.junit({ it instanceof Map && it.allowEmptyResults == false && it.testResults.contains('test-results/smoke') })
   }
 
   def "functionalTest calls 'uv run pytest tests/functional' and publishes JUnit XML"() {
@@ -76,5 +86,6 @@ class PythonBuilderTest extends Specification {
       builder.fullFunctionalTest()
     then:
       1 * steps.sh({ it.contains('uv run pytest tests/functional') })
+      1 * steps.junit({ it instanceof Map && it.allowEmptyResults == true && it.testResults.contains('test-results/functional') })
   }
 }

--- a/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
@@ -172,14 +172,14 @@ class PythonBuilderTest extends Specification {
       WarningCollector.pipelineWarnings[0].warningKey == 'unsupported_python_version'
   }
 
-  def "setupToolVersion adds warning when .python-version file is missing"() {
+  def "setupToolVersion echoes warning when .python-version file is missing"() {
     given:
       steps.fileExists('.python-version') >> false
     when:
       builder.setupToolVersion()
     then:
-      WarningCollector.pipelineWarnings.size() == 1
-      WarningCollector.pipelineWarnings[0].warningKey == 'missing_python_version_file'
+      WarningCollector.pipelineWarnings.isEmpty()
+      1 * steps.echo({ it.contains('.python-version') && it.contains('[Warning]') })
   }
 
   def "setupToolVersion echoes warning (no WarningCollector) when no deprecation config and version unsupported"() {

--- a/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
@@ -65,6 +65,16 @@ class PythonBuilderTest extends Specification {
       1 * steps.junit({ it instanceof Map && it.allowEmptyResults == true && it.testResults.contains('test-results/unit') })
   }
 
+  def "smokeTest publishes JUnit XML even when pytest fails"() {
+    given:
+      steps.sh(_ as String) >> { throw new Exception('pytest failed') }
+    when:
+      builder.smokeTest()
+    then:
+      thrown(Exception)
+      1 * steps.junit({ it instanceof Map && it.allowEmptyResults == false && it.testResults.contains('test-results/smoke') })
+  }
+
   def "smokeTest calls 'uv run pytest tests/smoke' and publishes JUnit XML"() {
     when:
       builder.smokeTest()

--- a/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
@@ -26,11 +26,11 @@ class PythonBuilderTest extends Specification {
     DeprecationConfig.deprecationConfigInternal = null
   }
 
-  def "build calls 'uv sync --locked --no-dev'"() {
+  def "build calls 'uv sync --locked --link-mode=copy'"() {
     when:
       builder.build()
     then:
-      1 * steps.sh({ it.contains('uv sync --locked --no-dev') })
+      1 * steps.sh({ it.contains('uv sync --locked --link-mode=copy') })
   }
 
   def "build calls addVersionInfo"() {
@@ -113,22 +113,24 @@ class PythonBuilderTest extends Specification {
 
   def "securityCheck calls uv audit"() {
     given:
+      steps.fileExists('uv-audit-report.json') >> true
       steps.readFile('uv-audit-report.json') >> '[]'
     when:
       builder.securityCheck()
     then:
-      1 * steps.sh({ it.contains('uv audit') })
+      1 * steps.sh({ it instanceof Map && it.script.contains('uv audit') }) >> 0
   }
 
-  def "securityCheck publishes CVE report even when uv audit finds vulnerabilities"() {
+  def "securityCheck publishes CVE report and fails pipeline when vulnerabilities found"() {
     given:
-      steps.sh(_ as String) >> { throw new Exception('uv audit exit 1') }
+      steps.sh(_ as Map) >> 1
+      steps.fileExists('uv-audit-report.json') >> true
       steps.readFile('uv-audit-report.json') >> '[]'
     when:
       builder.securityCheck()
     then:
-      thrown(Exception)
       1 * steps.readFile('uv-audit-report.json')
+      1 * steps.error({ it.contains('uv-audit-report.json') })
   }
 
   def "securityCheck rethrows exception on failure"() {

--- a/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.contino
+
+import spock.lang.Specification
+import uk.gov.hmcts.pipeline.deprecation.WarningCollector
+
+class PythonBuilderTest extends Specification {
+
+  def steps
+  def builder
+  def envVars
+
+  def setup() {
+    steps = Mock(JenkinsStepMock.class)
+    envVars = [BRANCH_NAME: 'master']
+    steps.getEnv() >> envVars
+    builder = new PythonBuilder(steps)
+    WarningCollector.pipelineWarnings.clear()
+  }
+
+  def cleanup() {
+    WarningCollector.pipelineWarnings.clear()
+  }
+
+  def "build calls 'uv sync --locked --no-dev'"() {
+    when:
+      builder.build()
+    then:
+      1 * steps.sh({ it.contains('uv sync --locked --no-dev') })
+  }
+
+  def "build calls addVersionInfo"() {
+    when:
+      builder.build()
+    then:
+      1 * steps.sh({ it.contains('tee version') })
+  }
+
+  def "addVersionInfo writes a version file reading from pyproject.toml"() {
+    when:
+      builder.addVersionInfo()
+    then:
+      1 * steps.sh({ it.contains('tee version') && it.contains('pyproject.toml') })
+  }
+}

--- a/test/uk/gov/hmcts/pipeline/DeprecationConfigTest.groovy
+++ b/test/uk/gov/hmcts/pipeline/DeprecationConfigTest.groovy
@@ -12,7 +12,8 @@ class DeprecationConfigTest {
           ],
         "helm"     : ["java": ["version": "5.2.0", "date_deadline": "2024-06-30"]],
         "gradle"   : ["java-logging": ["version": "6.0.1", "date_deadline": "2023-10-28"]],
-        "npm"      : ["angular/core": ["version": "15", "date_deadline": "2024-03-25"]]
+        "npm"      : ["angular/core": ["version": "15", "date_deadline": "2024-03-25"]],
+        "python"   : ["python_version": ["date_deadline": "2027-01-01"]]
       ]
   ]
 }

--- a/test/withPipeline/onMaster/withPythonPipelineOnMasterTests.groovy
+++ b/test/withPipeline/onMaster/withPythonPipelineOnMasterTests.groovy
@@ -1,0 +1,34 @@
+package withPipeline.onMaster
+
+import groovy.mock.interceptor.StubFor
+import org.junit.Test
+import uk.gov.hmcts.contino.PythonBuilder
+import withPipeline.BaseCnpPipelineTest
+
+class withPythonPipelineOnMasterTests extends BaseCnpPipelineTest {
+  final static jenkinsFile = "examplePythonPipeline.jenkins"
+
+  withPythonPipelineOnMasterTests() {
+    super("master", jenkinsFile)
+  }
+
+  @Test
+  void PipelineExecutesExpectedStepsInExpectedOrder() {
+    def stubBuilder = new StubFor(PythonBuilder)
+    stubBuilder.demand.with {
+      setupToolVersion(1) {}
+      build(1) {}
+      test(1) {}
+      securityCheck(1) {}
+      techStackMaintenance(1) {}
+      sonarScan(1) {}
+      smokeTest(1) {}
+      functionalTest(1) {}
+      e2eTest(1) {}
+    }
+
+    stubBuilder.use {
+      runScript("testResources/$jenkinsFile")
+    }
+  }
+}

--- a/testResources/examplePythonPipeline.jenkins
+++ b/testResources/examplePythonPipeline.jenkins
@@ -1,0 +1,10 @@
+#!groovy
+
+@Library("Infrastructure")
+
+def product = "product"
+def app = "app"
+
+withPipeline('python', product, app) {
+
+}

--- a/vars/withNightlyPipeline.groovy
+++ b/vars/withNightlyPipeline.groovy
@@ -3,6 +3,7 @@ import uk.gov.hmcts.contino.PipelineType
 import uk.gov.hmcts.contino.NodePipelineType
 import uk.gov.hmcts.contino.SpringBootPipelineType
 import uk.gov.hmcts.contino.AngularPipelineType
+import uk.gov.hmcts.contino.PythonPipelineType
 import uk.gov.hmcts.contino.RubyPipelineType
 import uk.gov.hmcts.contino.Subscription
 import uk.gov.hmcts.contino.AppPipelineConfig
@@ -19,7 +20,8 @@ def call(type, product, component, timeout = 300, Closure body) {
     nodejs : new NodePipelineType(this, product, component),
     java   : new SpringBootPipelineType(this, product, component),
     angular: new AngularPipelineType(this, product, component),
-    ruby: new RubyPipelineType(this, product, component)
+    ruby: new RubyPipelineType(this, product, component),
+    python: new PythonPipelineType(this, product, component)
   ]
 
   def pipelineType = pipelineTypes.get(type)

--- a/vars/withParameterizedPipeline.groovy
+++ b/vars/withParameterizedPipeline.groovy
@@ -4,6 +4,7 @@ import uk.gov.hmcts.contino.Environment
 import uk.gov.hmcts.contino.MetricsPublisher
 import uk.gov.hmcts.contino.NodePipelineType
 import uk.gov.hmcts.contino.PipelineType
+import uk.gov.hmcts.contino.PythonPipelineType
 import uk.gov.hmcts.contino.RubyPipelineType
 import uk.gov.hmcts.contino.SpringBootPipelineType
 import uk.gov.hmcts.contino.AppPipelineConfig
@@ -24,7 +25,8 @@ def call(type, String product, String component, String environment, String subs
     java  : new SpringBootPipelineType(this, product, component),
     nodejs: new NodePipelineType(this, product, component),
     angular: new AngularPipelineType(this, product, component),
-    ruby: new RubyPipelineType(this, product, component)
+    ruby: new RubyPipelineType(this, product, component),
+    python: new PythonPipelineType(this, product, component)
   ]
 
   PipelineType pipelineType

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -1,5 +1,4 @@
 import uk.gov.hmcts.contino.AngularPipelineType
-import uk.gov.hmcts.contino.PythonPipelineType
 import uk.gov.hmcts.contino.DockerImage
 import uk.gov.hmcts.contino.Environment
 import uk.gov.hmcts.contino.MetricsPublisher
@@ -7,6 +6,7 @@ import uk.gov.hmcts.contino.NodePipelineType
 import uk.gov.hmcts.contino.RubyPipelineType
 import uk.gov.hmcts.contino.PipelineType
 import uk.gov.hmcts.contino.ProjectBranch
+import uk.gov.hmcts.contino.PythonPipelineType
 import uk.gov.hmcts.contino.SpringBootPipelineType
 import uk.gov.hmcts.contino.Subscription
 import uk.gov.hmcts.contino.AppPipelineConfig

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -1,4 +1,5 @@
 import uk.gov.hmcts.contino.AngularPipelineType
+import uk.gov.hmcts.contino.PythonPipelineType
 import uk.gov.hmcts.contino.DockerImage
 import uk.gov.hmcts.contino.Environment
 import uk.gov.hmcts.contino.MetricsPublisher
@@ -30,7 +31,8 @@ def call(type, String product, String component, Closure body) {
     java  : new SpringBootPipelineType(this, product, component),
     nodejs: new NodePipelineType(this, product, component),
     angular: new AngularPipelineType(this, product, component),
-    ruby: new RubyPipelineType(this, product, component)
+    ruby: new RubyPipelineType(this, product, component),
+    python: new PythonPipelineType(this, product, component)
   ]
 
   Subscription subscription = new Subscription(env)


### PR DESCRIPTION
## Summary

Adds Python as a first-class pipeline type to the CNP Jenkins shared library, giving Python services the same opinionated CI/CD pipeline as Java and Node.

- Introduces `PythonPipelineType` and `PythonBuilder` following the `NodePipelineType`/`YarnBuilder` pattern
- Registers `python:` as a new pipeline type in `withPipeline.groovy`
- Uses `uv` for package management and `pytest` for testing throughout
- Includes a version nagger via `setupToolVersion()` — reads `.python-version`, enforces supported versions (`3.13`), warns via `WarningCollector`

## Builder methods

| Method | Implementation |
|---|---|
| `build()` | `uv sync --locked` + `addVersionInfo()` |
| `test()` | `uv run pytest tests/unit` + JUnit XML |
| `smokeTest()` | `uv run pytest tests/smoke` + JUnit XML |
| `functionalTest()` | `uv run pytest tests/functional` + JUnit XML |
| `sonarScan()` | `sonar-scanner` via `SonarProperties` |
| `securityCheck()` | `uv audit --output-format json` + `CVEPublisher` |
| `fortifyScan()` | `fortifyOnDemandScan()` + artifact archive |
| `setupToolVersion()` | `.python-version` nagger |
| `addVersionInfo()` | Writes `version` file from `pyproject.toml` |

## Test plan

- 22 new unit tests in `PythonBuilderTest` (Spock)
- 1 new integration test in `withPythonPipelineOnMasterTests`
- Full suite: 308 tests, 0 failures
