### PR TITLE
Re-enable library nagger

### DIFF
--- a/vars/checkoutScm.groovy
+++ b/vars/checkoutScm.groovy
@@ -33,6 +33,6 @@ def call(params) {
       echo "Unable to find git email Id for the user' ${err}'"
     }
     warnAboutRenovateConfig()
-    // warnAboutOldLibraryVersion()
+    warnAboutOldLibraryVersion()
   }
 }


### PR DESCRIPTION
This was supposed to be re-enabled but I forgot about it.

I had disabled it after it was sending out premature notifications but we've announced the changes so this can be re-enabled.