### PR TITLE
Uv audit pretty print

### DIFF
--- a/resources/uk/gov/hmcts/library/allowed-library-branches.yml
+++ b/resources/uk/gov/hmcts/library/allowed-library-branches.yml
@@ -17,3 +17,5 @@ branches:
     allowed: true
   - name: feat/add-python-support
     allowed: true
+  - name: uv-audit-pretty-print
+    allowed: true

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -117,9 +117,9 @@ class PythonBuilder extends AbstractBuilder {
     if (vulns.isEmpty()) {
       steps.error('Security vulnerabilities found in Python dependencies. Review the uv-audit-report.json build artifact for details.')
     }
-    // Print the details as a single block so they appear in the step's log, then fail with a short title.
-    // The failed step's expanded log in Blue Ocean shows everything printed in this script step.
-    steps.error("Security vulnerabilities found in Python dependencies (${vulns.size()})\n${formatCVELines(vulns).join('\n')}\nSee the uv-audit-report.json build artifact for full details.")
+    formatCVELines(vulns).each { steps.echo it }
+    steps.echo 'See the uv-audit-report.json build artifact for full details.'
+    steps.error("Security vulnerabilities found in Python dependencies (${vulns.size()})")
   }
 
   def formatCVELines(vulns) {
@@ -137,7 +137,7 @@ class PythonBuilder extends AbstractBuilder {
       steps.echo 'uv audit: no vulnerabilities found'
       return
     }
-    steps.echo("Security vulnerabilities found in Python dependencies (${vulns.size()})\n${formatCVELines(vulns).join('\n')}")
+    formatCVELines(vulns).each { steps.echo it }
   }
 
   def prepareCVEReport(String uvAuditJSON) {

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -106,15 +106,20 @@ class PythonBuilder extends AbstractBuilder {
         steps.archiveArtifacts(artifacts: 'uv-audit-report.json')
         String jsonReport = steps.readFile('uv-audit-report.json')
         parsedReport = prepareCVEReport(jsonReport)
-        logCVEReport(parsedReport)
         new CVEPublisher(steps).publishCVEReport('python', parsedReport)
       }
     }
-    if (exitCode != 0) {
-      def vulns = parsedReport.vulnerabilities ?: []
-      def summary = vulns ? "Security vulnerabilities found in Python dependencies (${vulns.size()}):\n${formatCVELines(vulns).join('\n')}\nSee the uv-audit-report.json build artifact for full details." : 'Security vulnerabilities found in Python dependencies. Review the uv-audit-report.json build artifact for details.'
-      steps.error(summary)
+    def vulns = parsedReport.vulnerabilities ?: []
+    if (exitCode == 0) {
+      steps.echo 'uv audit: no vulnerabilities found'
+      return
     }
+    if (vulns.isEmpty()) {
+      steps.error('Security vulnerabilities found in Python dependencies. Review the uv-audit-report.json build artifact for details.')
+    }
+    // Print the details as a single block so they appear in the step's log, then fail with a short title.
+    // The failed step's expanded log in Blue Ocean shows everything printed in this script step.
+    steps.error("Security vulnerabilities found in Python dependencies (${vulns.size()})\n${formatCVELines(vulns).join('\n')}\nSee the uv-audit-report.json build artifact for full details.")
   }
 
   def formatCVELines(vulns) {
@@ -132,8 +137,7 @@ class PythonBuilder extends AbstractBuilder {
       steps.echo 'uv audit: no vulnerabilities found'
       return
     }
-    steps.echo "uv audit: found ${vulns.size()} vulnerabilities"
-    steps.echo(formatCVELines(vulns).join('\n'))
+    steps.echo("Security vulnerabilities found in Python dependencies (${vulns.size()})\n${formatCVELines(vulns).join('\n')}")
   }
 
   def prepareCVEReport(String uvAuditJSON) {

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -117,8 +117,9 @@ class PythonBuilder extends AbstractBuilder {
     if (vulns.isEmpty()) {
       steps.error('Security vulnerabilities found in Python dependencies. Review the uv-audit-report.json build artifact for details.')
     }
-    formatCVELines(vulns).each { steps.echo it }
-    steps.echo 'See the uv-audit-report.json build artifact for full details.'
+    def details = formatCVELines(vulns).join('\n')
+    println("${details}\nSee the uv-audit-report.json build artifact for full details.")
+    steps.currentBuild.description = "Security vulnerabilities found in Python dependencies (${vulns.size()}):<br><pre>${details}</pre>"
     steps.error("Security vulnerabilities found in Python dependencies (${vulns.size()})")
   }
 

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -129,20 +129,21 @@ class PythonBuilder extends AbstractBuilder {
 
   def prepareCVEReport(String uvAuditJSON) {
     if (!uvAuditJSON?.trim()) {
+      steps.echo 'uv audit: report is empty'
       return [vulnerabilities: []]
     }
+    def parsed
     try {
-      def parsed = new JsonSlurperClassic().parseText(uvAuditJSON)
-      def vulns = (parsed instanceof Map ? parsed.results : parsed) ?: []
-      def flat = vulns.collectMany { entry ->
-        (entry.vulnerabilities ?: []).collect { v ->
-          v + [package: entry.package?.name, installed: entry.package?.version]
-        }
-      }
-      return [vulnerabilities: flat]
+      parsed = new JsonSlurperClassic().parseText(uvAuditJSON)
     } catch (Exception e) {
+      steps.echo "uv audit: failed to parse report (${e.message}). Raw output:\n${uvAuditJSON}"
       return [vulnerabilities: []]
     }
+    def vulns = (parsed instanceof Map ? parsed.vulnerabilities : parsed) ?: []
+    def flat = vulns.collect { v ->
+      v + [package: v.dependency?.name, installed: v.dependency?.version]
+    }
+    return [vulnerabilities: flat]
   }
 
   @Override

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -120,11 +120,13 @@ class PythonBuilder extends AbstractBuilder {
       steps.echo 'uv audit: no vulnerabilities found'
       return
     }
-    steps.echo "uv audit: found ${vulns.size()} vulnerabilities"
-    vulns.each { v ->
+    def lines = vulns.collect { v ->
       def fixed = (v.fix_versions ?: v.fixed_in ?: v.fixed ?: []) as List
-      steps.echo "  - ${v.id ?: '?'}  ${v.package ?: '?'}@${v.installed ?: '?'}  (fixed in: ${fixed ? fixed.join(', ') : 'n/a'})"
+      def aliases = (v.aliases ?: []) as List
+      def aliasStr = aliases ? " [${aliases.join(', ')}]" : ''
+      "  - ${v.id ?: '?'}${aliasStr} in  ${v.package ?: '?'}@${v.installed ?: '?'}  (fixed in: ${fixed ? fixed.join(', ') : 'n/a'})"
     }
+    steps.echo(["uv audit: found ${vulns.size()} vulnerabilities"] .plus(lines).join('\n'))
   }
 
   def prepareCVEReport(String uvAuditJSON) {

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -119,9 +119,9 @@ class PythonBuilder extends AbstractBuilder {
     }
     def details = ["Security vulnerabilities found in Python dependencies (${vulns.size()})"]
     details.addAll(formatCVELines(vulns))
-    details.add('See the uv-audit-report.json build artifact for full details.')
+    details.add('See the uv-audit-report.json build artifact for full details, or run uv audit --output-format json locally.')
     steps.writeFile(file: 'uv-audit-summary.txt', text: "${details.join('\n')}\n")
-    steps.sh(label: 'Python dependency vulnerabilities', script: 'cat uv-audit-summary.txt && exit 1')
+    steps.sh(label: 'Build Failed: Python dependency vulnerabilities', script: 'cat uv-audit-summary.txt && exit 1')
   }
 
   def formatCVELines(vulns) {

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -117,10 +117,7 @@ class PythonBuilder extends AbstractBuilder {
     if (vulns.isEmpty()) {
       steps.error('Security vulnerabilities found in Python dependencies. Review the uv-audit-report.json build artifact for details.')
     }
-    def details = formatCVELines(vulns).join('\n')
-    println("${details}\nSee the uv-audit-report.json build artifact for full details.")
-    steps.currentBuild.description = "Security vulnerabilities found in Python dependencies (${vulns.size()}):<br><pre>${details}</pre>"
-    steps.error("Security vulnerabilities found in Python dependencies (${vulns.size()})")
+    steps.error("Security vulnerabilities found in Python dependencies (${vulns.size()})\n${formatCVELines(vulns).join('\n')}\nSee the uv-audit-report.json build artifact for full details.")
   }
 
   def formatCVELines(vulns) {

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -117,14 +117,10 @@ class PythonBuilder extends AbstractBuilder {
     if (vulns.isEmpty()) {
       steps.error('Security vulnerabilities found in Python dependencies. Review the uv-audit-report.json build artifact for details.')
     }
-    def details = formatCVELines(vulns).join('\n') + '\nSee the uv-audit-report.json build artifact for full details.'
-    steps.sh(
-      label: "Security vulnerabilities found in Python dependencies (${vulns.size()})",
-      script: """cat <<'EOF'
-${details}
-EOF
-exit 1"""
-    )
+    steps.echo("Security vulnerabilities found in Python dependencies (${vulns.size()})")
+    formatCVELines(vulns).each { steps.echo(it) }
+    steps.echo('See the uv-audit-report.json build artifact for full details.')
+    steps.error('Security vulnerabilities found in Python dependencies. Review the uv-audit-report.json build artifact for details.')
   }
 
   def formatCVELines(vulns) {
@@ -132,7 +128,7 @@ exit 1"""
       def fixed = (v.fix_versions ?: v.fixed_in ?: v.fixed ?: []) as List
       def aliases = (v.aliases ?: []) as List
       def aliasStr = aliases ? " [${aliases.join(', ')}]" : ''
-      "  - ${v.id ?: '?'}${aliasStr} in  ${v.package ?: '?'}@${v.installed ?: '?'}  (fixed in: ${fixed ? fixed.join(', ') : 'n/a'})"
+      "  - ${v.id ?: '?'}${aliasStr} in ${v.package ?: '?'}@${v.installed ?: '?'} (fixed in: ${fixed ? fixed.join(', ') : 'n/a'})"
     }
   }
 

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -105,11 +105,25 @@ class PythonBuilder extends AbstractBuilder {
         steps.archiveArtifacts(artifacts: 'uv-audit-report.json')
         String jsonReport = steps.readFile('uv-audit-report.json')
         def parsedReport = prepareCVEReport(jsonReport)
+        logCVEReport(parsedReport)
         new CVEPublisher(steps).publishCVEReport('python', parsedReport)
       }
     }
     if (exitCode != 0) {
       steps.error('Security vulnerabilities found in Python dependencies. Review the uv-audit-report.json build artifact for details.')
+    }
+  }
+
+  def logCVEReport(parsedReport) {
+    def vulns = parsedReport.vulnerabilities ?: []
+    if (vulns.isEmpty()) {
+      steps.echo 'uv audit: no vulnerabilities found'
+      return
+    }
+    steps.echo "uv audit: found ${vulns.size()} vulnerabilities"
+    vulns.each { v ->
+      def fixed = (v.fix_versions ?: v.fixed_in ?: v.fixed ?: []) as List
+      steps.echo "  - ${v.id ?: '?'}  ${v.package ?: '?'}@${v.installed ?: '?'}  (fixed in: ${fixed ? fixed.join(', ') : 'n/a'})"
     }
   }
 

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -128,13 +128,18 @@ class PythonBuilder extends AbstractBuilder {
   }
 
   def prepareCVEReport(String uvAuditJSON) {
-    if (!uvAuditJSON || uvAuditJSON.trim().isEmpty()) {
+    if (!uvAuditJSON?.trim()) {
       return [vulnerabilities: []]
     }
-
     try {
-      def reportArray = new JsonSlurperClassic().parseText(uvAuditJSON)
-      return [vulnerabilities: reportArray ?: []]
+      def parsed = new JsonSlurperClassic().parseText(uvAuditJSON)
+      def vulns = (parsed instanceof Map ? parsed.results : parsed) ?: []
+      def flat = vulns.collectMany { entry ->
+        (entry.vulnerabilities ?: []).collect { v ->
+          v + [package: entry.package?.name, installed: entry.package?.version]
+        }
+      }
+      return [vulnerabilities: flat]
     } catch (Exception e) {
       return [vulnerabilities: []]
     }

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -98,19 +98,31 @@ class PythonBuilder extends AbstractBuilder {
   @Override
   def securityCheck() {
     int exitCode
+    def parsedReport = [vulnerabilities: []]
     try {
       exitCode = steps.sh(script: 'uv audit --output-format json > uv-audit-report.json', returnStatus: true)
     } finally {
       if (steps.fileExists('uv-audit-report.json')) {
         steps.archiveArtifacts(artifacts: 'uv-audit-report.json')
         String jsonReport = steps.readFile('uv-audit-report.json')
-        def parsedReport = prepareCVEReport(jsonReport)
+        parsedReport = prepareCVEReport(jsonReport)
         logCVEReport(parsedReport)
         new CVEPublisher(steps).publishCVEReport('python', parsedReport)
       }
     }
     if (exitCode != 0) {
-      steps.error('Security vulnerabilities found in Python dependencies. Review the uv-audit-report.json build artifact for details.')
+      def vulns = parsedReport.vulnerabilities ?: []
+      def summary = vulns ? "Security vulnerabilities found in Python dependencies (${vulns.size()}):\n${formatCVELines(vulns).join('\n')}\nSee the uv-audit-report.json build artifact for full details." : 'Security vulnerabilities found in Python dependencies. Review the uv-audit-report.json build artifact for details.'
+      steps.error(summary)
+    }
+  }
+
+  def formatCVELines(vulns) {
+    vulns.collect { v ->
+      def fixed = (v.fix_versions ?: v.fixed_in ?: v.fixed ?: []) as List
+      def aliases = (v.aliases ?: []) as List
+      def aliasStr = aliases ? " [${aliases.join(', ')}]" : ''
+      "  - ${v.id ?: '?'}${aliasStr} in  ${v.package ?: '?'}@${v.installed ?: '?'}  (fixed in: ${fixed ? fixed.join(', ') : 'n/a'})"
     }
   }
 
@@ -120,13 +132,8 @@ class PythonBuilder extends AbstractBuilder {
       steps.echo 'uv audit: no vulnerabilities found'
       return
     }
-    def lines = vulns.collect { v ->
-      def fixed = (v.fix_versions ?: v.fixed_in ?: v.fixed ?: []) as List
-      def aliases = (v.aliases ?: []) as List
-      def aliasStr = aliases ? " [${aliases.join(', ')}]" : ''
-      "  - ${v.id ?: '?'}${aliasStr} in  ${v.package ?: '?'}@${v.installed ?: '?'}  (fixed in: ${fixed ? fixed.join(', ') : 'n/a'})"
-    }
-    steps.echo(["uv audit: found ${vulns.size()} vulnerabilities"] .plus(lines).join('\n'))
+    steps.echo "uv audit: found ${vulns.size()} vulnerabilities"
+    steps.echo(formatCVELines(vulns).join('\n'))
   }
 
   def prepareCVEReport(String uvAuditJSON) {

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -117,7 +117,14 @@ class PythonBuilder extends AbstractBuilder {
     if (vulns.isEmpty()) {
       steps.error('Security vulnerabilities found in Python dependencies. Review the uv-audit-report.json build artifact for details.')
     }
-    steps.error("Security vulnerabilities found in Python dependencies (${vulns.size()})\n${formatCVELines(vulns).join('\n')}\nSee the uv-audit-report.json build artifact for full details.")
+    def details = formatCVELines(vulns).join('\n') + '\nSee the uv-audit-report.json build artifact for full details.'
+    steps.sh(
+      label: "Security vulnerabilities found in Python dependencies (${vulns.size()})",
+      script: """cat <<'EOF'
+${details}
+EOF
+exit 1"""
+    )
   }
 
   def formatCVELines(vulns) {

--- a/src/uk/gov/hmcts/contino/PythonBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/PythonBuilder.groovy
@@ -117,10 +117,11 @@ class PythonBuilder extends AbstractBuilder {
     if (vulns.isEmpty()) {
       steps.error('Security vulnerabilities found in Python dependencies. Review the uv-audit-report.json build artifact for details.')
     }
-    steps.echo("Security vulnerabilities found in Python dependencies (${vulns.size()})")
-    formatCVELines(vulns).each { steps.echo(it) }
-    steps.echo('See the uv-audit-report.json build artifact for full details.')
-    steps.error('Security vulnerabilities found in Python dependencies. Review the uv-audit-report.json build artifact for details.')
+    def details = ["Security vulnerabilities found in Python dependencies (${vulns.size()})"]
+    details.addAll(formatCVELines(vulns))
+    details.add('See the uv-audit-report.json build artifact for full details.')
+    steps.writeFile(file: 'uv-audit-summary.txt', text: "${details.join('\n')}\n")
+    steps.sh(label: 'Python dependency vulnerabilities', script: 'cat uv-audit-summary.txt && exit 1')
   }
 
   def formatCVELines(vulns) {

--- a/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
@@ -163,10 +163,10 @@ class PythonBuilderTest extends Specification {
         it.text.contains('Security vulnerabilities found in Python dependencies (2)') &&
         it.text.contains('GHSA-82w8-qh3p-5jfq [CVE-2026-54283] in starlette@1.2.1 (fixed in: 1.3.1)') &&
         it.text.contains('GHSA-jp82-jpqv-5vv3 [CVE-2026-54282] in starlette@1.2.1 (fixed in: 1.3.0)') &&
-        it.text.contains('See the uv-audit-report.json build artifact for full details.')
+        it.text.contains('See the uv-audit-report.json build artifact for full details')
       })
-      0 * steps.echo(_ as String)
-      1 * steps.sh({ it instanceof Map && it.label == 'Python dependency vulnerabilities' && it.script == 'cat uv-audit-summary.txt && exit 1' })
+      1 * steps.echo('Publishing CVE report')
+      1 * steps.sh({ it instanceof Map && it.label.contains('Python dependency vulnerabilities') && it.script == 'cat uv-audit-summary.txt && exit 1' })
       0 * steps.error(_ as String)
       0 * steps.sh({ it instanceof String && it.contains('jq -r') })
   }

--- a/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
@@ -143,6 +143,27 @@ class PythonBuilderTest extends Specification {
       thrown(Exception)
   }
 
+  def "prepareCVEReport flattens OSV-formatted uv audit output"() {
+    given:
+      def osvJson = '''{
+        "results": [
+          {
+            "package": {"name": "requests", "version": "2.20.0"},
+            "vulnerabilities": [
+              {"id": "GHSA-x84v-xcm2-53pg", "fix_versions": ["2.20.1"]}
+            ]
+          }
+        ]
+      }'''
+    when:
+      def report = builder.prepareCVEReport(osvJson)
+    then:
+      report.vulnerabilities.size() == 1
+      report.vulnerabilities[0].id == 'GHSA-x84v-xcm2-53pg'
+      report.vulnerabilities[0].package == 'requests'
+      report.vulnerabilities[0].installed == '2.20.0'
+  }
+
   def "setupToolVersion adds no warning when .python-version contains supported version 3.13"() {
     given:
       steps.fileExists('.python-version') >> true

--- a/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
@@ -143,20 +143,19 @@ class PythonBuilderTest extends Specification {
       thrown(Exception)
   }
 
-  def "prepareCVEReport flattens OSV-formatted uv audit output"() {
+  def "prepareCVEReport flattens uv audit output"() {
     given:
-      def osvJson = '''{
-        "results": [
+      def uvJson = '''{
+        "vulnerabilities": [
           {
-            "package": {"name": "requests", "version": "2.20.0"},
-            "vulnerabilities": [
-              {"id": "GHSA-x84v-xcm2-53pg", "fix_versions": ["2.20.1"]}
-            ]
+            "id": "GHSA-x84v-xcm2-53pg",
+            "dependency": {"name": "requests", "version": "2.20.0"},
+            "fix_versions": ["2.20.1"]
           }
         ]
       }'''
     when:
-      def report = builder.prepareCVEReport(osvJson)
+      def report = builder.prepareCVEReport(uvJson)
     then:
       report.vulnerabilities.size() == 1
       report.vulnerabilities[0].id == 'GHSA-x84v-xcm2-53pg'

--- a/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/PythonBuilderTest.groovy
@@ -133,6 +133,44 @@ class PythonBuilderTest extends Specification {
       1 * steps.error({ it.contains('uv-audit-report.json') })
   }
 
+  def "securityCheck logs vulnerabilities with clean output and fails pipeline when vulnerabilities found"() {
+    given:
+      steps.sh(_ as Map) >> 1
+      steps.fileExists('uv-audit-report.json') >> true
+      steps.readFile('uv-audit-report.json') >> '''{
+        "summary": {"vulnerabilities": 2},
+        "vulnerabilities": [
+          {
+            "id": "GHSA-82w8-qh3p-5jfq",
+            "aliases": ["CVE-2026-54283"],
+            "dependency": {"name": "starlette", "version": "1.2.1"},
+            "fix_versions": ["1.3.1"]
+          },
+          {
+            "id": "GHSA-jp82-jpqv-5vv3",
+            "aliases": ["CVE-2026-54282"],
+            "dependency": {"name": "starlette", "version": "1.2.1"},
+            "fix_versions": ["1.3.0"]
+          }
+        ]
+      }'''
+    when:
+      builder.securityCheck()
+    then:
+      1 * steps.writeFile({
+        it instanceof Map &&
+        it.file == 'uv-audit-summary.txt' &&
+        it.text.contains('Security vulnerabilities found in Python dependencies (2)') &&
+        it.text.contains('GHSA-82w8-qh3p-5jfq [CVE-2026-54283] in starlette@1.2.1 (fixed in: 1.3.1)') &&
+        it.text.contains('GHSA-jp82-jpqv-5vv3 [CVE-2026-54282] in starlette@1.2.1 (fixed in: 1.3.0)') &&
+        it.text.contains('See the uv-audit-report.json build artifact for full details.')
+      })
+      0 * steps.echo(_ as String)
+      1 * steps.sh({ it instanceof Map && it.label == 'Python dependency vulnerabilities' && it.script == 'cat uv-audit-summary.txt && exit 1' })
+      0 * steps.error(_ as String)
+      0 * steps.sh({ it instanceof String && it.contains('jq -r') })
+  }
+
   def "securityCheck rethrows exception on failure"() {
     given:
       steps.sh(_ as String) >> { throw new Exception('uv audit failed') }


### PR DESCRIPTION
Updates audit in the pipeline to show the flagged issues in a clear format:

<img width="912" height="179" alt="image" src="https://github.com/user-attachments/assets/82480ae1-313e-454c-a2b3-10a8170901a7" />


Unfortunately seems no nice way to clean the title up, this is as close as I could get it


Tested that behaviour is normal once CVE is addressed and pipeline goes green