### PR TITLE
Poll for pod instead of waiting 30s

### DIFF
--- a/resources/uk/gov/hmcts/library/allowed-library-branches.yml
+++ b/resources/uk/gov/hmcts/library/allowed-library-branches.yml
@@ -21,5 +21,3 @@ branches:
     allowed: true
   - name: DTSPO-30107-jenkins-agents-2
     allowed: true
-  - name: poll_for_pods
-    allowed: true

--- a/resources/uk/gov/hmcts/library/allowed-library-branches.yml
+++ b/resources/uk/gov/hmcts/library/allowed-library-branches.yml
@@ -21,3 +21,5 @@ branches:
     allowed: true
   - name: DTSPO-30107-jenkins-agents-2
     allowed: true
+  - name: poll_for_pods
+    allowed: true

--- a/src/uk/gov/hmcts/contino/Helm.groovy
+++ b/src/uk/gov/hmcts/contino/Helm.groovy
@@ -279,7 +279,7 @@ class Helm {
         """
         echo 'Waiting for initial pod creation...'
 
-        if timeout 60 kubectl get pods -n ${this.namespace} -l app.kubernetes.io/instance=${releaseName},'!job-name' -w 2>/dev/null | grep -m1 "Running\|Pending" > /dev/null; then
+        if timeout 60 kubectl get pods -n ${this.namespace} -l app.kubernetes.io/instance=${releaseName},'!job-name' -w 2>/dev/null | grep -m1 "Running\\|Pending" > /dev/null; then
           echo "Pods detected"
         else
           echo "No pods found matching selector - this chart may only contain jobs/cronjobs"

--- a/src/uk/gov/hmcts/contino/Helm.groovy
+++ b/src/uk/gov/hmcts/contino/Helm.groovy
@@ -6,7 +6,7 @@ import groovy.json.JsonSlurperClassic
 
 /**
  * Helm chart management class.
- * 
+ *
  * Supports dual ACR publish mode for transitioning between registries.
  * When DUAL_ACR_PUBLISH_ENABLED is set to 'true', Helm charts will be
  * published to both primary and secondary ACR registries.
@@ -30,7 +30,7 @@ class Helm {
   def notFoundMessage = 'Not found'
   String registrySubscription
   def namespace
-  
+
   // Secondary ACR for dual publish mode
   def secondaryRegistryName
   def secondaryResourceGroup
@@ -50,7 +50,7 @@ class Helm {
     this.chartLocation = "${HELM_RESOURCES_DIR}/${chartName}"
     this.chartName = chartName
     this.namespace = this.steps.env.TEAM_NAMESPACE
-    // NOTE: Do NOT initialize dual publish mode here - Jenkins CPS cannot call 
+    // NOTE: Do NOT initialize dual publish mode here - Jenkins CPS cannot call
     // CPS-transformed methods (steps.env, steps.echo) from constructors.
     // Dual publish mode is checked lazily via isDualPublishModeEnabled().
   }
@@ -58,12 +58,12 @@ class Helm {
   /**
    * Check if dual ACR publish mode is enabled.
    * Reads directly from environment variables each time to avoid CPS issues.
-   * 
+   *
    * @return true if dual publish is enabled and properly configured
    */
   private boolean isDualPublishModeEnabled() {
     def enabled = steps.env.DUAL_ACR_PUBLISH_ENABLED?.toLowerCase() == 'true'
-    
+
     if (enabled) {
       // Load secondary registry details from environment if not already set
       if (!this.secondaryRegistryName) {
@@ -71,7 +71,7 @@ class Helm {
         this.secondaryResourceGroup = steps.env.SECONDARY_REGISTRY_RESOURCE_GROUP
         this.secondaryRegistrySubscription = steps.env.SECONDARY_REGISTRY_SUBSCRIPTION
       }
-      
+
       // Validate configuration
       if (!this.secondaryRegistryName || !this.secondaryResourceGroup || !this.secondaryRegistrySubscription) {
         return false
@@ -80,7 +80,7 @@ class Helm {
     }
     return false
   }
-  
+
   /**
    * Check if dual publish mode is enabled (public accessor for tests).
    */
@@ -112,17 +112,17 @@ class Helm {
    */
   private List<String> detectCrossRegistryDependencies() {
     def chartYamlPath = "${this.chartLocation}/Chart.yaml"
-    
+
     if (!steps.fileExists(chartYamlPath)) {
       return []
     }
-    
+
     try {
       def chartYaml = steps.readFile(chartYamlPath)
       def externalRegistries = [] as Set
-      
+
       steps.echo "Scanning Chart.yaml for OCI-based cross-registry dependencies..."
-      
+
       // Look for OCI repository references in dependencies
       // Example: repository: oci://hmctsprod.azurecr.io/helm
       // Handles: repository: 'oci://...' or repository: "oci://..." or repository: oci://...
@@ -138,7 +138,7 @@ class Helm {
           steps.echo('skipped - same as current registry')
         }
       }
-      
+
       return externalRegistries.toList()
     } catch (Exception e) {
       steps.echo "Warning: Could not parse Chart.yaml for cross-registry dependencies: ${e.message}"
@@ -149,12 +149,12 @@ class Helm {
   def authenticateAcr() {
     // Authenticate to current registry
     this.acr.az "acr login --name ${registryName}"
-    
+
     // Check if chart has dependencies from other ACR registries
     def externalRegistries = detectCrossRegistryDependencies()
-    
+
     steps.echo "Detected external registries: ${externalRegistries.size() > 0 ? externalRegistries.join(', ') : 'none'}"
-    
+
     if (externalRegistries) {
       steps.echo "Chart has dependencies from: ${externalRegistries.join(', ')}"
       externalRegistries.each { externalRegistry ->
@@ -162,7 +162,7 @@ class Helm {
         this.acr.az "acr login --name ${externalRegistry}"
       }
     }
-    
+
     // Also authenticate to secondary registry if dual publish is enabled
     if (isDualPublishModeEnabled()) {
       steps.echo "Authenticating to secondary ACR for dual publish: ${secondaryRegistryName}"
@@ -184,10 +184,10 @@ class Helm {
 
     def version = this.steps.sh(script: "helm inspect chart ${this.chartLocation} | grep ^version | cut -d ':' -f 2", returnStdout: true).trim()
     this.steps.echo "Version of chart locally is: ${version}"
-    
+
     // Check and publish to primary registry
     def primaryResult = checkAndPublishToRegistry(registryName, version)
-    
+
     // Also publish to secondary registry if dual publish is enabled
     if (isDualPublishModeEnabled()) {
       this.steps.echo "Checking secondary ACR for chart: ${secondaryRegistryName}"
@@ -268,7 +268,7 @@ class Helm {
     this.steps.writeFile file: 'aks-debug-info.sh', text: this.steps.libraryResource('uk/gov/hmcts/helm/aks-debug-info.sh')
 
     this.steps.sh('chmod +x aks-debug-info.sh')
-    
+
     boolean onPR = new ProjectBranch(this.steps.env.BRANCH_NAME).isPR()
     def optionsStr = (options + (onPR ? ['--install', '--timeout 1250s'] : ['--install', '--wait', '--timeout 1250s'])).join(' ')
     def valuesStr =  "${' -f ' + values.flatten().join(' -f ')}"
@@ -277,13 +277,12 @@ class Helm {
       this.steps.sh(label: 'helm upgrade', script: "helm upgrade ${releaseName}  ${this.chartLocation} ${valuesStr} ${optionsStr}")
       this.steps.sh(label: 'wait for install', script:
         """
-        echo 'Waiting 30s for initial pod creation...'
-        sleep 30
+        echo 'Waiting for initial pod creation...'
 
-        POD_COUNT=\$(kubectl get pods -n ${this.namespace} -l app.kubernetes.io/instance=${releaseName},'!job-name' --no-headers 2>/dev/null | wc -l)
-
-        if [ "\$POD_COUNT" -eq 0 ]; then
-          echo "ℹ️  No pods found matching selector - this chart may only contain jobs/cronjobs"
+        if timeout 60 kubectl get pods -n ${this.namespace} -l app.kubernetes.io/instance=${releaseName},'!job-name' -w 2>/dev/null | grep -m1 "Running\|Pending" > /dev/null; then
+          echo "Pods detected"
+        else
+          echo "No pods found matching selector - this chart may only contain jobs/cronjobs"
           exit 0
         fi
 

--- a/test/uk/gov/hmcts/contino/HelmTest.groovy
+++ b/test/uk/gov/hmcts/contino/HelmTest.groovy
@@ -62,12 +62,12 @@ class HelmTest extends Specification {
     1 * steps.libraryResource('uk/gov/hmcts/helm/aks-debug-info.sh')
     1 * steps.writeFile(_)
     1 * steps.sh('chmod +x aks-debug-info.sh')
-    1 * steps.sh({it.containsKey('label') && 
+    1 * steps.sh({it.containsKey('label') &&
       it.get('label') == 'helm upgrade' &&
       it.get('script').contains("helm upgrade ${CHART}-pr-1  ${CHART_PATH}  -f val1 -f val2 --namespace cnp --install --timeout 1250s") &&
       !it.get('script').contains("--wait")
     })
-    1 * steps.sh({it.containsKey('label') && 
+    1 * steps.sh({it.containsKey('label') &&
       it.get('label') == 'wait for install' &&
       it.get('script').contains("Waiting for initial pod creation...") &&
       it.get('script').contains('timeout 60 kubectl get pods -n cnp -l app.kubernetes.io/instance=my-chart-pr-1,' + "'!job-name'" + ' -w 2>/dev/null | grep -m1 "Running\\|Pending" > /dev/null') &&
@@ -107,7 +107,7 @@ class HelmTest extends Specification {
     1 * nonPrSteps.libraryResource('uk/gov/hmcts/helm/aks-debug-info.sh')
     1 * nonPrSteps.writeFile(_)
     1 * nonPrSteps.sh('chmod +x aks-debug-info.sh')
-    1 * nonPrSteps.sh({it.containsKey('label') && 
+    1 * nonPrSteps.sh({it.containsKey('label') &&
       it.get('label') == 'helm upgrade' &&
       it.get('script').contains("helm upgrade ${CHART}-staging  ${CHART_PATH}  -f val1 -f val2 --namespace cnp --install --wait --timeout 1250s") &&
       it.get('script').contains("|| ./aks-debug-info.sh ${CHART}-staging cnp")
@@ -150,10 +150,10 @@ class HelmTest extends Specification {
                       REGISTRY_SUBSCRIPTION: "test-sub",
                       SUBSCRIPTION_NAME: "${SUBSCRIPTION}",
                       BRANCH_NAME: "PR-123"]
-    
+
     when:
     def testHelm = new Helm(testSteps, CHART)
-    
+
     then:
     testHelm.isDualPublishEnabled() == false
   }
@@ -169,10 +169,10 @@ class HelmTest extends Specification {
                       DUAL_ACR_PUBLISH_ENABLED: "true",
                       SECONDARY_REGISTRY_NAME: null]
     testSteps.echo(_) >> null
-    
+
     when:
     def testHelm = new Helm(testSteps, CHART)
-    
+
     then:
     testHelm.isDualPublishEnabled() == false
   }
@@ -190,10 +190,10 @@ class HelmTest extends Specification {
                       SECONDARY_REGISTRY_RESOURCE_GROUP: "hmcts-old-rg",
                       SECONDARY_REGISTRY_SUBSCRIPTION: "old-sub"]
     testSteps.echo(_) >> null
-    
+
     when:
     def testHelm = new Helm(testSteps, CHART)
-    
+
     then:
     testHelm.isDualPublishEnabled() == true
     testHelm.secondaryRegistryName == "hmctsold"

--- a/test/uk/gov/hmcts/contino/HelmTest.groovy
+++ b/test/uk/gov/hmcts/contino/HelmTest.groovy
@@ -69,11 +69,8 @@ class HelmTest extends Specification {
     })
     1 * steps.sh({it.containsKey('label') && 
       it.get('label') == 'wait for install' &&
-      it.get('script').contains("Waiting 30s for initial pod creation...") &&
-      it.get('script').contains("sleep 30") &&
-      it.get('script').contains('POD_COUNT=') &&
-      it.get('script').contains('kubectl get pods') &&
-      it.get('script').contains("wc -l") &&
+      it.get('script').contains("Waiting for initial pod creation...") &&
+      it.get('script').contains('timeout 60 kubectl get pods -n cnp -l app.kubernetes.io/instance=my-chart-pr-1,' + "'!job-name'" + ' -w 2>/dev/null | grep -m1 "Running\\|Pending" > /dev/null') &&
       it.get('script').contains('No pods found matching selector - this chart may only contain jobs/cronjobs') &&
       it.get('script').contains("ImagePullBackOff|ErrImagePull|CrashLoopBackOff|CreateContainerConfigError") &&
       it.get('script').contains("Waiting for pods to be scheduled and ready...") &&


### PR DESCRIPTION
Currently, there is a sleep set so the wait for pods to spin up is at least 30 seconds. The proposed change uses the kubectl -w flag to wait for the pod to come up and moves on immediately.

In my test change on IA linked below, the pod was brought up in 8 seconds.

The saving is modest but it's an easy efficiency win :)

Tested change on IA: https://build.hmcts.net/blue/organizations/jenkins/HMCTS_d_to_i%2Fia-aip-frontend/detail/PR-1515/2/pipeline/132/

Linter also removed a bunch of whitespaces automatically.
