### PR TITLE
Add poll_for_pods to allowed library branches

### DIFF
--- a/resources/uk/gov/hmcts/library/allowed-library-branches.yml
+++ b/resources/uk/gov/hmcts/library/allowed-library-branches.yml
@@ -21,3 +21,5 @@ branches:
     allowed: true
   - name: DTSPO-30107-jenkins-agents-2
     allowed: true
+  - name: poll_for_pods
+    allowed: true


### PR DESCRIPTION
I want to test this change https://github.com/hmcts/cnp-jenkins-library/pull/1474 against a service. I will remove this entry from the list as part of the above PR or by itself depending on success outcome.