### PR TITLE
Make the library version a warning instead of an error

### DIFF
--- a/resources/uk/gov/hmcts/library/check-old-library-version.sh
+++ b/resources/uk/gov/hmcts/library/check-old-library-version.sh
@@ -31,7 +31,7 @@ FAILED_FILES=()
 
 echo "Checking for old library version references: ${OLD_LIBRARY_VERSION}"
 
-if [[ "$JOB_NAME" == *"nightly"* ]]; then
+if [[ "${JOB_NAME,,}" == *"nightly"* ]]; then
     echo "Running nightly pipeline. No need to check for old library version."
     no_old_library_found
 fi

--- a/vars/warnAboutOldLibraryVersion.groovy
+++ b/vars/warnAboutOldLibraryVersion.groovy
@@ -43,6 +43,8 @@ Migration guide: https://tools.hmcts.net/confluence/spaces/DTSPO/pages/197350993
 Rollout tracker: https://tools.hmcts.net/confluence/spaces/DTSPO/pages/1973305638/Migration+rollout+tracker"""
                 LocalDate deprecationDate = LocalDate.parse(deprecation.date_deadline)
 
+                unstable("Old library version detected. Update to Infrastructure@${deprecation.version}.")
+
                 try {
                     WarningCollector.addPipelineWarning(
                         "old_library_version",
@@ -50,7 +52,6 @@ Rollout tracker: https://tools.hmcts.net/confluence/spaces/DTSPO/pages/197330563
                         deprecationDate
                     )
                 } catch (RuntimeException ignored) {
-                    unstable("Old library version detected. Update to Infrastructure@${deprecation.version}.")
                     echo "${warningMessage} This change is enforced from ${deprecationDate.format(WarningCollector.DATE_FORMATTER)}"
                 }
             }

--- a/vars/warnAboutOldLibraryVersion.groovy
+++ b/vars/warnAboutOldLibraryVersion.groovy
@@ -25,23 +25,34 @@ def call(String repoUrl = null) {
         }
 
         patterns.each { pattern ->
-            try {
-                sh """
+            int status = sh(
+                script: """
                 chmod +x check-old-library-version.sh
                 ./check-old-library-version.sh '${pattern}' '${deprecation.version}' '${deprecation.date_deadline}'
-                """
-            } catch(ignored) {
-                WarningCollector.addPipelineWarning(
-                    "old_library_version",
-                    """Your Jenkinsfile references an old or unpinned Jenkins library version.
+                """,
+                returnStatus: true
+            )
+
+            if (status != 0) {
+                String warningMessage = """Your Jenkinsfile references an old or unpinned Jenkins library version.
 
 Update it to use *Infrastructure@${deprecation.version}*, then check the migration guide and rollout tracker before raising a PR. Some repositories also need Key Vault or PostgreSQL module changes as part of this migration.
 
 Migration guide: https://tools.hmcts.net/confluence/spaces/DTSPO/pages/1973509936/Jenkins+Library+Migration+Guide
 
-Rollout tracker: https://tools.hmcts.net/confluence/spaces/DTSPO/pages/1973305638/Migration+rollout+tracker""",
-                    LocalDate.parse(deprecation.date_deadline)
-                )
+Rollout tracker: https://tools.hmcts.net/confluence/spaces/DTSPO/pages/1973305638/Migration+rollout+tracker"""
+                LocalDate deprecationDate = LocalDate.parse(deprecation.date_deadline)
+
+                try {
+                    WarningCollector.addPipelineWarning(
+                        "old_library_version",
+                        warningMessage,
+                        deprecationDate
+                    )
+                } catch (RuntimeException ignored) {
+                    unstable("Old library version detected. Update to Infrastructure@${deprecation.version}.")
+                    echo "${warningMessage} This change is enforced from ${deprecationDate.format(WarningCollector.DATE_FORMATTER)}"
+                }
             }
         }
     }


### PR DESCRIPTION
Make the icon in the pipeline orange instead of red so it's more obvious it's not a critical error.

Also make the nightly check case insensitive so it doesn't send notifications for nightly pipelines which don't necessarily need to move across yet.