### PR TITLE
Fix ruby bundle stash excludes

### DIFF
--- a/test/withEnvironmentAgentTest.groovy
+++ b/test/withEnvironmentAgentTest.groovy
@@ -135,6 +135,8 @@ class WithEnvironmentAgentTest extends BasePipelineTest {
       assertThat(args.excludes as String).contains('.yarn_dependencies_installed')
       assertThat(args.excludes as String).doesNotContain('.yarn/cache/**')
       assertThat(args.excludes as String).contains('.yarn/install-state.gz')
+      assertThat(args.excludes as String).contains('vendor/bundle/**')
+      assertThat(args.excludes as String).contains('.bundle/cache/**')
     }
   }
 

--- a/vars/withEnvironmentAgent.groovy
+++ b/vars/withEnvironmentAgent.groovy
@@ -32,6 +32,10 @@ def call(String environment, String product, String agentLabelOverride, Closure 
     '**/.yarn/install-state.gz',
     '.gradle/**',
     '**/.gradle/**',
+    'vendor/bundle/**',
+    '**/vendor/bundle/**',
+    '.bundle/cache/**',
+    '**/.bundle/cache/**',
     '.venv/**',
     '**/.venv/**'
   ].join(',')


### PR DESCRIPTION
During ruby tests, we are regularly getting permission problems such as this


08:30:52  hudson.remoting.ProxyException: java.nio.file.AccessDeniedException: /opt/jenkins/workspace/HMCTS_d_to_i_et-pet-api_PR-758/vendor/bundle/ruby/3.3.0/cache/bundler/git/ApplicationInsights-Ruby-09b07ab732ea84391d378e4b026b5d94b08f73eb/objects/pack/pack-6b1b5f53631bce8016310944bf536c1c87f79dad.idx

This is caused by caching and the fact that the ruby bundle directory is not excluded (it will be built by 'bundle install') and I am assuming that users are different between different machines that run this.

All other languages exclude the build directories so I am just following their lead really.

Note that it is not clear which branch this code is supposed to merged into, I chose DTSPO-30107-jenkins-agents as that appears to be what 2.4.3 is based on and we have been forced to use 2.4.0
