### PR TITLE
Isolate Puppeteer cache per workspace

### DIFF
--- a/src/uk/gov/hmcts/contino/AbstractBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/AbstractBuilder.groovy
@@ -12,6 +12,13 @@ abstract class AbstractBuilder implements Builder, Serializable {
     this.securitytest = new SecurityScan(this.steps)
   }
 
+  protected def withPuppeteerCache(Closure body) {
+    def cacheRoot = steps.env.WORKSPACE_TMP ?: steps.env.WORKSPACE ?: '.'
+    steps.withEnv(["PUPPETEER_CACHE_DIR=${cacheRoot}/puppeteer-cache"]) {
+      body()
+    }
+  }
+
   @Override
   def performanceTest() {
     executeGatling()

--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -236,7 +236,8 @@ class GradleBuilder extends AbstractBuilder {
   @Override
   def addVersionInfo() {
     addInitScript()
-    localSteps.sh '''
+    withPuppeteerCache {
+      localSteps.sh '''
 mkdir -p src/main/resources/META-INF
 
 tee src/main/resources/META-INF/build-info.properties <<EOF 2>/dev/null
@@ -247,6 +248,7 @@ build.date=$(date)
 EOF
 
 '''
+    }
   }
 
   def runProviderVerification(pactBrokerUrl, version, publish) {
@@ -280,13 +282,17 @@ EOF
     }
     addInitScript()
     withAdoMavenPat {
-      localSteps.sh("${prepend}./gradlew --no-daemon --init-script init.gradle ${task}")
+      withPuppeteerCache {
+        localSteps.sh("${prepend}./gradlew --no-daemon --init-script init.gradle ${task}")
+      }
     }
   }
 
   private String gradleWithOutput(String task) {
     addInitScript()
-    localSteps.sh(script: "./gradlew --no-daemon --init-script init.gradle ${task}", returnStdout: true).trim()
+    withPuppeteerCache {
+      localSteps.sh(script: "./gradlew --no-daemon --init-script init.gradle ${task}", returnStdout: true).trim()
+    }
   }
 
   def fullFunctionalTest() {

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -326,8 +326,9 @@ EOF
         prepend += ' '
       }
 
-      if (steps.fileExists(NVMRC)) {
-        def status = steps.sh(script: """
+      withPuppeteerCache {
+        if (steps.fileExists(NVMRC)) {
+          def status = steps.sh(script: """
           set +ex
           export NVM_DIR='/home/jenkinsssh/.nvm'
           . /opt/nvm/nvm.sh || true
@@ -341,11 +342,11 @@ EOF
           fi
         """, returnStatus: true)
 
-        if (status != 0 && !task.contains('install')) {
-          steps.error("Yarn task '${task}' failed with status ${status}")
-        }
-      } else {
-        def status = steps.sh(script: """
+          if (status != 0 && !task.contains('install')) {
+            steps.error("Yarn task '${task}' failed with status ${status}")
+          }
+        } else {
+          def status = steps.sh(script: """
           export PATH=\$HOME/.local/bin:\$PATH
 
           if ${prepend.toBoolean()}; then
@@ -355,8 +356,9 @@ EOF
           fi
         """, returnStatus: true)
 
-        if (status != 0 && !task.contains('install')) {
-          steps.error("Yarn task '${task}' failed with status ${status}")
+          if (status != 0 && !task.contains('install')) {
+            steps.error("Yarn task '${task}' failed with status ${status}")
+          }
         }
       }
   }
@@ -365,7 +367,9 @@ EOF
     if (prepend && !prepend.endsWith(' ')) {
       prepend += ' '
     }
-    def status = steps.sh(script: """
+    def status
+    withPuppeteerCache {
+      status = steps.sh(script: """
       export PATH=\$HOME/.local/bin:\$PATH
 
       if ${prepend.toBoolean()}; then
@@ -374,6 +378,7 @@ EOF
         yarn ${task} 1> /dev/null 2> /dev/null
       fi
     """, returnStatus: true)
+    }
     steps.echo("yarnQuiet ${task} -> ${status}")
     return status == 0  // only a 0 return status is success
   }

--- a/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/GradleBuilderTest.groovy
@@ -15,13 +15,14 @@ class GradleBuilderTest extends Specification {
 
   def setup() {
     steps = Mock(JenkinsStepMock.class)
-    envVars = [BRANCH_NAME: 'master']
+    envVars = [BRANCH_NAME: 'master', WORKSPACE_TMP: '/tmp/jenkins-workspace']
     steps.getEnv() >> envVars
     builder = new GradleBuilder(steps, 'test')
     sampleCVEReport = new File(this.getClass().getClassLoader().getResource('dependency-check-report.json').toURI()).text
     steps.readFile(_ as String) >> sampleCVEReport
     // Pass the ADO_MAVEN_PAT withAzureKeyvault wrapper through to the closure body.
     steps.withAzureKeyvault(_, _) >> { args -> args[1].call() }
+    steps.withEnv(_, _) >> { args -> args[1].call() }
   }
 
   def "build calls 'gradle assemble'"() {
@@ -96,6 +97,13 @@ class GradleBuilderTest extends Specification {
       builder.smokeTest()
     then:
       1 * steps.sh({ it.startsWith(GRADLE_CMD) && it.contains('smoke') && it.contains('--rerun-tasks') })
+  }
+
+  def "gradle commands use a workspace puppeteer cache"() {
+    when:
+      builder.smokeTest()
+    then:
+      1 * steps.withEnv(['PUPPETEER_CACHE_DIR=/tmp/jenkins-workspace/puppeteer-cache'], _ as Closure)
   }
 
   def "functionalTest calls 'gradle functional' with '--rerun-tasks' flag"() {

--- a/test/uk/gov/hmcts/contino/JenkinsStepMock.groovy
+++ b/test/uk/gov/hmcts/contino/JenkinsStepMock.groovy
@@ -17,6 +17,7 @@ interface JenkinsStepMock {
   Object writeFile(Map)
   Object withCredentials(ArrayList, Closure)
   Object withAzureKeyvault(ArrayList, Closure)
+  Object withEnv(List, Closure)
   Object httpRequest(LinkedHashMap)
 
   Object ansiColor(String, Closure)
@@ -37,5 +38,4 @@ interface JenkinsStepMock {
 
   void azureCosmosDBCreateDocument(LinkedHashMap)
 }
-
 

--- a/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
+++ b/test/uk/gov/hmcts/contino/YarnBuilderTest.groovy
@@ -38,11 +38,12 @@ class YarnBuilderTest extends Specification {
 
     def sampleCVEReport = new File(this.getClass().getClassLoader().getResource('yarn-audit-report-no-issues.txt').toURI()).text
     steps.readFile({ String path -> path != 'package.json' }) >> sampleCVEReport
-    envVars = [BRANCH_NAME: 'master']
+    envVars = [BRANCH_NAME: 'master', WORKSPACE_TMP: '/tmp/jenkins-workspace']
     steps.getEnv() >> envVars
     def closure
     steps.withCredentials(_, { it.call() }) >> { closure = it }
     steps.withSauceConnect(_, { it.call() }) >> { closure = it }
+    steps.withEnv(_, _) >> { args -> args[1].call() }
     steps.usernamePassword(_ as Map) >> [:]
 
     builder = new YarnBuilder(steps)
@@ -130,6 +131,13 @@ class YarnBuilderTest extends Specification {
           builder.smokeTest()
       then:
           1 * steps.sh({ it instanceof Map && it.script.contains('yarn test:smoke') && it.returnStatus == true })
+  }
+
+  def "yarn commands use a workspace puppeteer cache"() {
+      when:
+          builder.smokeTest()
+      then:
+          2 * steps.withEnv(['PUPPETEER_CACHE_DIR=/tmp/jenkins-workspace/puppeteer-cache'], _ as Closure)
   }
 
   def "functionalTest calls 'yarn test:functional'"() {


### PR DESCRIPTION
Puppeteer browser downloads currently use the Jenkins user cache, so a partial download on one agent can break unrelated Gradle or Yarn jobs later. This sets PUPPETEER_CACHE_DIR from the shared builders so Java Gradle pipelines and Node Yarn pipelines use the workspace temp cache instead of /home/jenkinsssh/.cache/puppeteer.