### PR TITLE
DTSPO-31434: Add Java 25 support to pipeline builds

### DIFF
--- a/src/uk/gov/hmcts/contino/GradleBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/GradleBuilder.groovy
@@ -337,6 +337,13 @@ EOF
       steps.env.PATH = "${steps.env.JAVA_HOME}/bin:${steps.env.PATH}"
     }
 
+    def statusCodeJava25 = steps.sh script: 'grep -F "JavaLanguageVersion.of(25)" build.gradle', returnStatus: true
+    if (statusCodeJava25 == 0) {
+      def javaHomeLocation = steps.sh(script: 'ls -d /usr/lib/jvm/temurin-25-jdk-*', returnStdout: true, label: 'Detect Java location').trim()
+      steps.env.JAVA_HOME = javaHomeLocation
+      steps.env.PATH = "${steps.env.JAVA_HOME}/bin:${steps.env.PATH}"
+    }
+
     // Workaround jacocoTestReport issue https://github.com/gradle/gradle/issues/18508#issuecomment-1049998305
     steps.env.GRADLE_OPTS = "--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED"
     gradle("--version") // ensure wrapper has been downloaded

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -465,8 +465,11 @@ EOF
       steps.env.PATH = "${steps.env.JAVA_HOME}/bin:${steps.env.PATH}"
     }
 
+    // grep -q . guards against the `find -exec ... +` gotcha: with no build.gradle present
+    // find still exits 0, which would otherwise wrongly enter the Java 25 branch on pure
+    // yarn/frontend repos and fail at the temurin-25 lookup.
     def statusCodeJava25 = steps.sh(script: """
-      find . -name "build.gradle" -exec grep -l "JavaLanguageVersion.of(25)" {} + > /dev/null
+      find . -name "build.gradle" -exec grep -l "JavaLanguageVersion.of(25)" {} + | grep -q .
       """, returnStatus: true)
     if (statusCodeJava25 == 0) {
       def javaHomeLocation = steps.sh(script: 'ls -d /usr/lib/jvm/temurin-25-jdk-*', returnStdout: true, label: 'Detect Java location').trim()

--- a/src/uk/gov/hmcts/contino/YarnBuilder.groovy
+++ b/src/uk/gov/hmcts/contino/YarnBuilder.groovy
@@ -465,6 +465,15 @@ EOF
       steps.env.PATH = "${steps.env.JAVA_HOME}/bin:${steps.env.PATH}"
     }
 
+    def statusCodeJava25 = steps.sh(script: """
+      find . -name "build.gradle" -exec grep -l "JavaLanguageVersion.of(25)" {} + > /dev/null
+      """, returnStatus: true)
+    if (statusCodeJava25 == 0) {
+      def javaHomeLocation = steps.sh(script: 'ls -d /usr/lib/jvm/temurin-25-jdk-*', returnStdout: true, label: 'Detect Java location').trim()
+      steps.env.JAVA_HOME = javaHomeLocation
+      steps.env.PATH = "${steps.env.JAVA_HOME}/bin:${steps.env.PATH}"
+    }
+
     localSteps.sh "java -version"
     nagAboutOldNodeJSVersions()
   }


### PR DESCRIPTION
Detect JavaLanguageVersion.of(25) in build.gradle and point JAVA_HOME at the Temurin 25 JDK on the agent, mirroring the existing Java 21 handling in both GradleBuilder and YarnBuilder.


https://tools.hmcts.net/jira/browse/DTSPO-31434


Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
*
*
*
