### PR TITLE
DTSPO-31434: Allow library branch DTSPO-31434-java-25 for testing

### DIFF
--- a/resources/uk/gov/hmcts/library/allowed-library-branches.yml
+++ b/resources/uk/gov/hmcts/library/allowed-library-branches.yml
@@ -27,3 +27,5 @@ branches:
     allowed: true
   - name: DTSPO-33489/disable-sonar-scan
     allowed: true
+  - name: DTSPO-31434-java-25
+    allowed: true


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
https://tools.hmcts.net/jira/browse/DTSPO-31434

* Add DTSPO-31434-java-25 to the allowed-library-branches allowlist so app pipelines can pin @Library('Infrastructure@DTSPO-31434-java-25') to validate the Java 25 support before it is merged. 
The allowlist is read from master by LibraryBranchControls, so this must land on master to take effect.
