### PR TITLE
Fix Helm registry secret interpolation warning

### DIFF
--- a/src/uk/gov/hmcts/contino/Helm.groovy
+++ b/src/uk/gov/hmcts/contino/Helm.groovy
@@ -101,7 +101,7 @@ class Helm {
 
   def removeRepo() {
     this.steps.echo 'Clear out helm repo before re-adding'
-    this.steps.sh(label: "helm repo rm ${registryName}", script: 'helm repo rm $REGISTRY_NAME || echo "Helm repo may not exist on disk, skipping remove"', env: [REGISTRY_NAME: registryName])
+    this.steps.sh(label: 'helm repo rm', script: 'helm repo rm "$REGISTRY_NAME" || echo "Helm repo may not exist on disk, skipping remove"')
   }
 
   /**

--- a/test/uk/gov/hmcts/contino/HelmTest.groovy
+++ b/test/uk/gov/hmcts/contino/HelmTest.groovy
@@ -44,6 +44,17 @@ class HelmTest extends Specification {
       it.get('script').contains("env AZURE_CONFIG_DIR=/opt/jenkins/.azure-${SUBSCRIPTION}")})
   }
 
+  def "removeRepo() should use the registry environment variable without Groovy interpolation"() {
+    when:
+    helm.removeRepo()
+
+    then:
+    1 * steps.echo('Clear out helm repo before re-adding')
+    1 * steps.sh({it.get('label') == 'helm repo rm' &&
+      it.get('script') == 'helm repo rm "$REGISTRY_NAME" || echo "Helm repo may not exist on disk, skipping remove"' &&
+      !it.containsKey('env')})
+  }
+
   def "installOrUpgrade() on PR branch should execute without --wait flag and do manual wait"() {
     when:
     helm.installOrUpgrade("pr-1", ["val1", "val2"], ["--namespace cnp"])


### PR DESCRIPTION
## Change
- avoid interpolating the Key Vault-backed registry name into the `sh` step label
- remove the unsupported `env` parameter from the Jenkins `sh` step
- use the existing `REGISTRY_NAME` environment variable directly in the shell script
- add a regression test for the safe step arguments

This removes both the Jenkins secret interpolation warning and the `Unknown parameter(s) ... ShellStep: env` warning emitted during Helm setup.