### PR TITLE
DTSPO-33498: Fix NotSerializableException for Cause objects in sectio…

### DIFF
--- a/resources/uk/gov/hmcts/library/allowed-library-branches.yml
+++ b/resources/uk/gov/hmcts/library/allowed-library-branches.yml
@@ -25,3 +25,5 @@ branches:
     allowed: true
   - name: archive-complete-build-results
     allowed: true
+  - name: DTSPO-33498-fix-cause-serialization
+    allowed: true

--- a/vars/sectionNightlyTests.groovy
+++ b/vars/sectionNightlyTests.groovy
@@ -1,3 +1,4 @@
+import com.cloudbees.groovy.cps.NonCPS
 import org.springframework.security.task.DelegatingSecurityContextAsyncTaskExecutor
 import uk.gov.hmcts.contino.Environment
 

--- a/vars/sectionNightlyTests.groovy
+++ b/vars/sectionNightlyTests.groovy
@@ -1,6 +1,13 @@
 import org.springframework.security.task.DelegatingSecurityContextAsyncTaskExecutor
 import uk.gov.hmcts.contino.Environment
 
+@NonCPS
+boolean isTriggeredByTimer() {
+  return currentBuild.rawBuild.getCauses().any {
+    it.getClass().getName().contains('TimerTriggerCause')
+  }
+}
+
 def call(pcr, config, pipelineType, String product, String component, String subscription) {
 
   Environment environment = new Environment(env)
@@ -84,10 +91,7 @@ def call(pcr, config, pipelineType, String product, String component, String sub
     if (config.performanceTest) {
 
       //Check if build started by chron job
-      def causes = currentBuild.rawBuild?.getCauses() ?: []
-      def triggeredByTimer = causes.any { cause ->
-        cause.getClass().getSimpleName() == "TimerTriggerCause"
-      }
+      boolean triggeredByTimer = isTriggeredByTimer()
 
       boolean doSecondRun = false //This is set to true if first
       def stages = ['Performance test', 'Failed Test Rerun']

--- a/vars/sectionNightlyTests.groovy
+++ b/vars/sectionNightlyTests.groovy
@@ -4,7 +4,8 @@ import uk.gov.hmcts.contino.Environment
 
 @NonCPS
 boolean isTriggeredByTimer() {
-  return currentBuild.rawBuild.getCauses().any {
+  def causes = currentBuild.rawBuild?.getCauses() ?: []
+  return causes.any {
     it.getClass().getName().contains('TimerTriggerCause')
   }
 }


### PR DESCRIPTION
…nNightlyTests

Use @NonCPS to check build trigger so Cause objects from rawBuild.getCauses() never enter CPS serialization scope. Fixes NotSerializableException for BranchEventCause, UserIdCause and any other Cause subclasses that became non-serializable in Jenkins 2.4.4 plugin updates.

Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
*
*
*
