### PR TITLE
Archive failed Jenkins build results

### DIFF
--- a/README.md
+++ b/README.md
@@ -1215,7 +1215,7 @@ The following global environment variables configure the archive:
 | --- | --- | --- |
 | `BUILD_ARCHIVE_JENKINS_CREDENTIALS_ID` | required | Jenkins API credential |
 | `BUILD_ARCHIVE_JENKINS_API_URL` | `JENKINS_URL` | Optional controller-internal base URL |
-| `BUILD_ARCHIVE_STORAGE_SUBSCRIPTION` | `DCD-CFT-Sandbox` | Azure subscription |
+| `BUILD_ARCHIVE_STORAGE_SUBSCRIPTION` | `sandbox` | Azure subscription alias |
 | `BUILD_ARCHIVE_STORAGE_CREDENTIALS_ID` | `buildlog-storage-account` | Storage credential |
 | `BUILD_ARCHIVE_STORAGE_CONTAINER` | `jenkins-build-archive` | Blob container |
 | `BUILD_ARCHIVE_STORAGE_PREFIX` | `builds` | Path below the container |

--- a/README.md
+++ b/README.md
@@ -1181,13 +1181,13 @@ Branches must be allowed in the [yaml file](resources/uk/gov/hmcts/library/allow
 ## Completed build archives
 
 The application pipeline can queue a separate Jenkins job to copy completed build
-records to Azure Blob Storage. This is disabled unless the global
-`BUILD_ARCHIVE_JOB` environment variable names the archive job.
+records to Azure Blob Storage for PR, master and nightly builds. Every build
+queues the root Jenkins job named `Archive Completed Builds`.
 
-Before queuing the archive job, `withPipeline` adds common Gradle, Playwright,
-functional-test and pod-log outputs to the source build's Jenkins artifacts. The
-archive job must call `archiveCompletedBuild` with the parameters passed by
-`queueBuildArchive`:
+Before queuing the archive job, the application and nightly pipelines add common
+Gradle, Playwright, functional-test and pod-log outputs to the source build's
+Jenkins artifacts. The archive job must call `archiveCompletedBuild` with the
+parameters passed by `queueBuildArchive`:
 
 ```groovy
 @Library('Infrastructure') _
@@ -1204,13 +1204,15 @@ archiveCompletedBuild(
 
 The archive job waits for the source build to finish, then captures its complete
 console output, build metadata, test-result metadata and artifact ZIP. It uploads
-the resulting directory using the existing `azureBlobUpload` step.
+the resulting directory using the existing `azureBlobUpload` step. Archive names
+include the final outcome and, when Jenkins reports one, the failed stage, for
+example `completed-build_42_SUCCESS` or
+`completed-build_43_FAILURE_Deploy_to_AKS`.
 
 The following global environment variables configure the archive:
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `BUILD_ARCHIVE_JOB` | disabled | Full name of the archive Jenkins job |
 | `BUILD_ARCHIVE_JENKINS_CREDENTIALS_ID` | required | Jenkins API credential |
 | `BUILD_ARCHIVE_JENKINS_API_URL` | `JENKINS_URL` | Optional controller-internal base URL |
 | `BUILD_ARCHIVE_STORAGE_SUBSCRIPTION` | `DCD-CFT-Sandbox` | Azure subscription |

--- a/README.md
+++ b/README.md
@@ -1180,9 +1180,10 @@ Branches must be allowed in the [yaml file](resources/uk/gov/hmcts/library/allow
 
 ## Completed build archives
 
-The application pipeline can queue a separate Jenkins job to copy completed build
-records to Azure Blob Storage for PR, master and nightly builds. Every build
-queues the root Jenkins job named `Archive Completed Builds`.
+The application pipeline can queue a separate Jenkins job to copy failed build
+records to Azure Blob Storage for PR, master and nightly builds. Successful,
+unstable and aborted builds are ignored. Every failed build queues the root
+Jenkins job named `Archive Completed Builds`.
 
 Before queuing the archive job, the application and nightly pipelines add common
 Gradle, Playwright, functional-test and pod-log outputs to the source build's
@@ -1206,8 +1207,7 @@ The archive job waits for the source build to finish, then captures its complete
 console output, build metadata, test-result metadata and artifact ZIP. It uploads
 the resulting directory using the existing `azureBlobUpload` step. Archive names
 include the final outcome and, when Jenkins reports one, the failed stage, for
-example `completed-build_42_SUCCESS` or
-`completed-build_43_FAILURE_Deploy_to_AKS`.
+example `completed-build_43_FAILURE_Deploy_to_AKS`.
 
 The following global environment variables configure the archive:
 

--- a/README.md
+++ b/README.md
@@ -1177,3 +1177,45 @@ Branches must be allowed in the [yaml file](resources/uk/gov/hmcts/library/allow
 ```groovy
 @Library('Infrastructure@<your-branch-name>') _
 ```
+
+## Completed build archives
+
+The application pipeline can queue a separate Jenkins job to copy completed build
+records to Azure Blob Storage. This is disabled unless the global
+`BUILD_ARCHIVE_JOB` environment variable names the archive job.
+
+Before queuing the archive job, `withPipeline` adds common Gradle, Playwright,
+functional-test and pod-log outputs to the source build's Jenkins artifacts. The
+archive job must call `archiveCompletedBuild` with the parameters passed by
+`queueBuildArchive`:
+
+```groovy
+@Library('Infrastructure') _
+
+archiveCompletedBuild(
+  sourceBuildUrl: params.SOURCE_BUILD_URL,
+  sourceJobName: params.SOURCE_JOB_NAME,
+  sourceBuildNumber: params.SOURCE_BUILD_NUMBER,
+  sourceBuildResult: params.SOURCE_BUILD_RESULT,
+  sourceProduct: params.SOURCE_PRODUCT,
+  sourceComponent: params.SOURCE_COMPONENT
+)
+```
+
+The archive job waits for the source build to finish, then captures its complete
+console output, build metadata, test-result metadata and artifact ZIP. It uploads
+the resulting directory using the existing `azureBlobUpload` step.
+
+The following global environment variables configure the archive:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `BUILD_ARCHIVE_JOB` | disabled | Full name of the archive Jenkins job |
+| `BUILD_ARCHIVE_JENKINS_CREDENTIALS_ID` | required | Jenkins API credential |
+| `BUILD_ARCHIVE_JENKINS_API_URL` | `JENKINS_URL` | Optional controller-internal base URL |
+| `BUILD_ARCHIVE_STORAGE_SUBSCRIPTION` | `DCD-CFT-Sandbox` | Azure subscription |
+| `BUILD_ARCHIVE_STORAGE_CREDENTIALS_ID` | `buildlog-storage-account` | Storage credential |
+| `BUILD_ARCHIVE_STORAGE_CONTAINER` | `jenkins-build-archive` | Blob container |
+| `BUILD_ARCHIVE_STORAGE_PREFIX` | `builds` | Path below the container |
+| `BUILD_ARCHIVE_AGENT` | any agent | Label used by the archive job |
+| `BUILD_ARCHIVE_LOCAL_ONLY` | `false` | Archive back to Jenkins instead of Azure for local testing |

--- a/README.md
+++ b/README.md
@@ -1183,7 +1183,8 @@ Branches must be allowed in the [yaml file](resources/uk/gov/hmcts/library/allow
 The application pipeline can queue a separate Jenkins job to copy failed build
 records to Azure Blob Storage for PR, master and nightly builds. Successful,
 unstable and aborted builds are ignored. Every failed build queues the root
-Jenkins job named `Archive Completed Builds`.
+Jenkins job named `Archive Completed Builds` after any agent retries are
+exhausted.
 
 Before queuing the archive job, the application and nightly pipelines add common
 Gradle, Playwright, functional-test and pod-log outputs to the source build's
@@ -1221,3 +1222,6 @@ The following global environment variables configure the archive:
 | `BUILD_ARCHIVE_STORAGE_PREFIX` | `builds` | Path below the container |
 | `BUILD_ARCHIVE_AGENT` | any agent | Label used by the archive job |
 | `BUILD_ARCHIVE_LOCAL_ONLY` | `false` | Archive back to Jenkins instead of Azure for local testing |
+| `BUILD_ARCHIVE_WAIT_TIMEOUT_MINUTES` | `300` | Maximum wait for the source build to finish |
+| `BUILD_ARCHIVE_OPERATION_TIMEOUT_MINUTES` | `120` | Maximum time for capture and upload |
+| `BUILD_ARCHIVE_HTTP_TIMEOUT_SECONDS` | `1800` | Timeout for each Jenkins API request |

--- a/README.md
+++ b/README.md
@@ -1204,18 +1204,18 @@ archiveCompletedBuild(
 )
 ```
 
-The archive job waits for the source build to finish, then captures its complete
-console output, build metadata, test-result metadata and artifact ZIP. It uploads
-the resulting directory using the existing `azureBlobUpload` step. Archive names
-include the final outcome and, when Jenkins reports one, the failed stage, for
-example `completed-build_43_FAILURE_Deploy_to_AKS`.
+The archive job waits for the source build to finish, then reads it directly
+from the same Jenkins controller. It captures the complete console output,
+build metadata, test-result metadata and artifact ZIP without a separate
+Jenkins API credential. It uploads the resulting directory using the existing
+`azureBlobUpload` step. Archive names include the final outcome and, when
+Jenkins reports one, the failed stage, for example
+`completed-build_43_FAILURE_Deploy_to_AKS`.
 
 The following global environment variables configure the archive:
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `BUILD_ARCHIVE_JENKINS_CREDENTIALS_ID` | required | Jenkins API credential |
-| `BUILD_ARCHIVE_JENKINS_API_URL` | `JENKINS_URL` | Optional controller-internal base URL |
 | `BUILD_ARCHIVE_STORAGE_SUBSCRIPTION` | `sandbox` | Azure subscription alias |
 | `BUILD_ARCHIVE_STORAGE_CREDENTIALS_ID` | `buildlog-storage-account` | Storage credential |
 | `BUILD_ARCHIVE_STORAGE_CONTAINER` | `jenkins-build-archive` | Blob container |
@@ -1224,4 +1224,3 @@ The following global environment variables configure the archive:
 | `BUILD_ARCHIVE_LOCAL_ONLY` | `false` | Archive back to Jenkins instead of Azure for local testing |
 | `BUILD_ARCHIVE_WAIT_TIMEOUT_MINUTES` | `300` | Maximum wait for the source build to finish |
 | `BUILD_ARCHIVE_OPERATION_TIMEOUT_MINUTES` | `120` | Maximum time for capture and upload |
-| `BUILD_ARCHIVE_HTTP_TIMEOUT_SECONDS` | `1800` | Timeout for each Jenkins API request |

--- a/resources/uk/gov/hmcts/library/allowed-library-branches.yml
+++ b/resources/uk/gov/hmcts/library/allowed-library-branches.yml
@@ -23,3 +23,5 @@ branches:
     allowed: true
   - name: poll_for_helm
     allowed: true
+  - name: archive-complete-build-results
+    allowed: true

--- a/src/uk/gov/hmcts/contino/CompletedBuildReader.groovy
+++ b/src/uk/gov/hmcts/contino/CompletedBuildReader.groovy
@@ -108,6 +108,7 @@ class CompletedBuildReader implements Serializable {
     ]
   }
 
+  @NonCPS
   private static boolean hasNoArgMethod(def target, String methodName) {
     target.getClass().getMethods().any { method ->
       method.name == methodName && method.parameterCount == 0

--- a/src/uk/gov/hmcts/contino/CompletedBuildReader.groovy
+++ b/src/uk/gov/hmcts/contino/CompletedBuildReader.groovy
@@ -88,9 +88,9 @@ class CompletedBuildReader implements Serializable {
   static Map testMetadata(def build) {
     def action = build.getAllActions().find { candidate ->
       candidate != null &&
-        candidate.metaClass.respondsTo(candidate, 'getFailCount') &&
-        candidate.metaClass.respondsTo(candidate, 'getSkipCount') &&
-        candidate.metaClass.respondsTo(candidate, 'getTotalCount')
+        hasNoArgMethod(candidate, 'getFailCount') &&
+        hasNoArgMethod(candidate, 'getSkipCount') &&
+        hasNoArgMethod(candidate, 'getTotalCount')
     }
     if (action == null) {
       return null
@@ -106,6 +106,12 @@ class CompletedBuildReader implements Serializable {
       skipCount: skipCount,
       passCount: totalCount - failCount - skipCount
     ]
+  }
+
+  private static boolean hasNoArgMethod(def target, String methodName) {
+    target.getClass().getMethods().any { method ->
+      method.name == methodName && method.parameterCount == 0
+    }
   }
 
   @NonCPS

--- a/src/uk/gov/hmcts/contino/CompletedBuildReader.groovy
+++ b/src/uk/gov/hmcts/contino/CompletedBuildReader.groovy
@@ -85,9 +85,10 @@ class CompletedBuildReader implements Serializable {
   }
 
   @NonCPS
-  private static Map testMetadata(def build) {
+  static Map testMetadata(def build) {
     def action = build.getAllActions().find { candidate ->
-      candidate.metaClass.respondsTo(candidate, 'getFailCount') &&
+      candidate != null &&
+        candidate.metaClass.respondsTo(candidate, 'getFailCount') &&
         candidate.metaClass.respondsTo(candidate, 'getSkipCount') &&
         candidate.metaClass.respondsTo(candidate, 'getTotalCount')
     }

--- a/src/uk/gov/hmcts/contino/CompletedBuildReader.groovy
+++ b/src/uk/gov/hmcts/contino/CompletedBuildReader.groovy
@@ -72,7 +72,7 @@ class CompletedBuildReader implements Serializable {
 
   @NonCPS
   private static void copyArtifacts(def build, FilePath target) {
-    if (!build.hasArtifact()) {
+    if (!build.getHasArtifacts()) {
       return
     }
 

--- a/src/uk/gov/hmcts/contino/CompletedBuildReader.groovy
+++ b/src/uk/gov/hmcts/contino/CompletedBuildReader.groovy
@@ -1,0 +1,157 @@
+package uk.gov.hmcts.contino
+
+import com.cloudbees.groovy.cps.NonCPS
+import hudson.FilePath
+import jenkins.model.Jenkins
+
+/**
+ * Reads completed builds directly from the Jenkins controller.
+ *
+ * This class deliberately has no state so it remains safe to retain across
+ * Pipeline suspensions while the archive worker waits for a source build.
+ */
+class CompletedBuildReader implements Serializable {
+
+  private static final long serialVersionUID = 1L
+
+  @NonCPS
+  Map snapshot(String jobName, int buildNumber) {
+    def build = requiredBuild(jobName, buildNumber)
+
+    [
+      building: build.isBuilding(),
+      result: build.getResult()?.toString(),
+      number: build.getNumber(),
+      url: build.getUrl(),
+      displayName: build.getDisplayName(),
+      fullDisplayName: build.getFullDisplayName(),
+      timestamp: build.getTimeInMillis(),
+      duration: build.getDuration(),
+      estimatedDuration: build.getEstimatedDuration(),
+      workflow: workflowMetadata(build),
+      tests: testMetadata(build)
+    ]
+  }
+
+  @NonCPS
+  void copyOutputs(String jobName, int buildNumber, FilePath archiveDirectory) {
+    def build = requiredBuild(jobName, buildNumber)
+    if (build.isBuilding()) {
+      throw new IllegalStateException("Refusing to copy outputs from running build ${jobName} #${buildNumber}")
+    }
+
+    archiveDirectory.mkdirs()
+    copyConsole(build, archiveDirectory.child('console.txt'))
+    copyArtifacts(build, archiveDirectory.child('artifacts.zip'))
+  }
+
+  @NonCPS
+  private static def requiredBuild(String jobName, int buildNumber) {
+    def job = Jenkins.get().getItemByFullName(jobName)
+    if (job == null) {
+      throw new IllegalArgumentException("Unable to find Jenkins job: ${jobName}")
+    }
+
+    def build = job.getBuildByNumber(buildNumber)
+    if (build == null) {
+      throw new IllegalArgumentException("Unable to find Jenkins build: ${jobName} #${buildNumber}")
+    }
+
+    build
+  }
+
+  @NonCPS
+  private static void copyConsole(def build, FilePath target) {
+    OutputStream output = target.write()
+    try {
+      build.writeWholeLogTo(output)
+    } finally {
+      output.close()
+    }
+  }
+
+  @NonCPS
+  private static void copyArtifacts(def build, FilePath target) {
+    if (!build.hasArtifact()) {
+      return
+    }
+
+    OutputStream output = target.write()
+    try {
+      build.getArtifactManager().root().zip(output, '**', null, true, '')
+    } finally {
+      output.close()
+    }
+  }
+
+  @NonCPS
+  private static Map testMetadata(def build) {
+    def action = build.getAllActions().find { candidate ->
+      candidate.metaClass.respondsTo(candidate, 'getFailCount') &&
+        candidate.metaClass.respondsTo(candidate, 'getSkipCount') &&
+        candidate.metaClass.respondsTo(candidate, 'getTotalCount')
+    }
+    if (action == null) {
+      return null
+    }
+
+    int totalCount = action.getTotalCount() as int
+    int failCount = action.getFailCount() as int
+    int skipCount = action.getSkipCount() as int
+
+    [
+      totalCount: totalCount,
+      failCount: failCount,
+      skipCount: skipCount,
+      passCount: totalCount - failCount - skipCount
+    ]
+  }
+
+  @NonCPS
+  private static Map workflowMetadata(def build) {
+    if (!build.metaClass.respondsTo(build, 'getExecution')) {
+      return null
+    }
+
+    def execution = build.getExecution()
+    if (execution == null) {
+      return null
+    }
+
+    try {
+      Class walkerType = build.class.classLoader.loadClass(
+        'org.jenkinsci.plugins.workflow.graph.FlowGraphWalker'
+      )
+      def walker = walkerType.newInstance(execution)
+      List nodes = walker.iterator().collect { it }
+      List stages = nodes.findResults { node ->
+        def stageAction = node.getAllActions().find { action ->
+          action.class.name == 'org.jenkinsci.plugins.workflow.actions.StageAction'
+        }
+        if (stageAction == null) {
+          return null
+        }
+
+        boolean failed = nodes.any { candidate ->
+          hasError(candidate) &&
+            (candidate == node || candidate.getEnclosingBlocks().contains(node))
+        }
+        [
+          name: stageAction.getStageName(),
+          status: failed ? 'FAILED' : 'SUCCESS'
+        ]
+      }.reverse()
+
+      stages ? [stages: stages] : null
+    } catch (Exception ignored) {
+      null
+    }
+  }
+
+  @NonCPS
+  private static boolean hasError(def node) {
+    node.getAllActions().any { action ->
+      action.class.name == 'org.jenkinsci.plugins.workflow.actions.ErrorAction'
+    }
+  }
+}

--- a/test/archiveBuildOutputsTest.groovy
+++ b/test/archiveBuildOutputsTest.groovy
@@ -1,0 +1,34 @@
+import com.lesfurets.jenkins.unit.BasePipelineTest
+import org.junit.Before
+import org.junit.Test
+
+import static com.lesfurets.jenkins.unit.MethodCall.callArgsToString
+import static org.assertj.core.api.Assertions.assertThat
+
+class archiveBuildOutputsTest extends BasePipelineTest {
+
+  def script
+
+  @Override
+  @Before
+  void setUp() {
+    super.setUp()
+    helper.registerAllowedMethod('archiveArtifacts', [Map.class], {})
+    helper.registerAllowedMethod('echo', [String.class], {})
+    script = loadScript('vars/archiveBuildOutputs.groovy')
+  }
+
+  @Test
+  void archivesCommonBuildOutputs() {
+    script.call()
+
+    def archiveCall = helper.callStack.find { it.methodName == 'archiveArtifacts' }
+    def arguments = callArgsToString(archiveCall)
+
+    assertThat(arguments).contains('**/build/test-results/**')
+    assertThat(arguments).contains('**/playwright-report/**')
+    assertThat(arguments).contains('functional-output/**')
+    assertThat(arguments).contains('pods-logs-*/**')
+    assertThat(arguments).contains('allowEmptyArchive=true')
+  }
+}

--- a/test/archiveBuildOutputsTest.groovy
+++ b/test/archiveBuildOutputsTest.groovy
@@ -1,4 +1,6 @@
 import com.lesfurets.jenkins.unit.BasePipelineTest
+import hudson.model.Result
+import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
 import org.junit.Before
 import org.junit.Test
 
@@ -8,12 +10,17 @@ import static org.assertj.core.api.Assertions.assertThat
 class archiveBuildOutputsTest extends BasePipelineTest {
 
   def script
+  def archiveFailure
 
   @Override
   @Before
   void setUp() {
     super.setUp()
-    helper.registerAllowedMethod('archiveArtifacts', [Map.class], {})
+    helper.registerAllowedMethod('archiveArtifacts', [Map.class], {
+      if (archiveFailure) {
+        throw archiveFailure
+      }
+    })
     helper.registerAllowedMethod('echo', [String.class], {})
     script = loadScript('vars/archiveBuildOutputs.groovy')
   }
@@ -30,5 +37,20 @@ class archiveBuildOutputsTest extends BasePipelineTest {
     assertThat(arguments).contains('functional-output/**')
     assertThat(arguments).contains('pods-logs-*/**')
     assertThat(arguments).contains('allowEmptyArchive=true')
+  }
+
+  @Test
+  void preservesAnInterruptionWhileArchivingOutputs() {
+    def interruption = new FlowInterruptedException(Result.ABORTED, true)
+    archiveFailure = interruption
+
+    try {
+      script.call()
+    } catch (FlowInterruptedException expected) {
+      assertThat(expected).isSameAs(interruption)
+      return
+    }
+
+    throw new AssertionError('Expected the archive interruption to propagate')
   }
 }

--- a/test/archiveCompletedBuildTest.groovy
+++ b/test/archiveCompletedBuildTest.groovy
@@ -180,6 +180,16 @@ class archiveCompletedBuildTest extends BasePipelineTest {
   }
 
   @Test
+  void rejectsJobNamesThatDoNotMatchTheBuildUrl() {
+    assertInvalidBuildIdentity(
+      sourceBuildUrl: 'https://build.example/job/service/job/PR-1/4/',
+      sourceJobName: 'different-service/PR-1',
+      sourceBuildNumber: '4',
+      expectedMessage: 'mismatched Jenkins build details'
+    )
+  }
+
+  @Test
   void rejectsUnsafeJobPathSegments() {
     assertInvalidBuildIdentity(
       sourceBuildUrl: 'https://build.example/job/service/4/',

--- a/test/archiveCompletedBuildTest.groovy
+++ b/test/archiveCompletedBuildTest.groovy
@@ -1,0 +1,108 @@
+import com.lesfurets.jenkins.unit.BasePipelineTest
+import org.junit.Before
+import org.junit.Test
+import groovy.json.JsonSlurperClassic
+
+import static org.assertj.core.api.Assertions.assertThat
+
+class archiveCompletedBuildTest extends BasePipelineTest {
+
+  def archived
+  def downloads = []
+  def uploads = []
+  def writes = [:]
+  def metadataChecks = 0
+  def script
+
+  @Override
+  @Before
+  void setUp() {
+    super.setUp()
+    binding.setVariable('env', [
+      JENKINS_URL: 'https://build.example/',
+      BUILD_ARCHIVE_JENKINS_API_URL: 'http://localhost:8080/',
+      BUILD_ARCHIVE_LOCAL_ONLY: 'true',
+      BUILD_ARCHIVE_AGENT: ''
+    ])
+
+    helper.registerAllowedMethod('node', [String.class, Closure.class], { _, body -> body.call() })
+    helper.registerAllowedMethod('deleteDir', [], {})
+    helper.registerAllowedMethod('dir', [String.class, Closure.class], { _, body -> body.call() })
+    helper.registerAllowedMethod('timeout', [Map.class, Closure.class], { _, body -> body.call() })
+    helper.registerAllowedMethod('waitUntil', [Map.class, Closure.class], { _, body ->
+      while (!body.call()) {
+        // Repeat until the mocked build reports completion.
+      }
+    })
+    helper.registerAllowedMethod('httpRequest', [Map.class], { request ->
+      if (request.url.endsWith('/api/json') && !request.url.contains('testReport')) {
+        metadataChecks++
+        return [
+          status: 200,
+          content: metadataChecks == 1
+            ? '{"building":true}'
+            : '{"building":false,"result":"SUCCESS"}'
+        ]
+      }
+
+      downloads << request
+      return [status: 200, content: '']
+    })
+    helper.registerAllowedMethod('readJSON', [Map.class], {
+      new JsonSlurperClassic().parseText(it.text)
+    })
+    helper.registerAllowedMethod('writeFile', [Map.class], { writes[it.file] = it.text })
+    helper.registerAllowedMethod('writeJSON', [Map.class], { writes[it.file] = it.json })
+    helper.registerAllowedMethod('archiveArtifacts', [Map.class], { archived = it })
+    helper.registerAllowedMethod('azureBlobUpload', [String.class, String.class, String.class, String.class], {
+      uploads << it
+    })
+    helper.registerAllowedMethod('sh', [Map.class], {
+      it.returnStdout ? '2026-07-23T14:30:00Z\n' : null
+    })
+    helper.registerAllowedMethod('echo', [String.class], {})
+    helper.registerAllowedMethod('error', [String.class], { throw new IllegalArgumentException(it) })
+
+    script = loadScript('vars/archiveCompletedBuild.groovy')
+  }
+
+  @Test
+  void waitsForCompletionAndArchivesTheWholeBuildLocally() {
+    script.call(
+      sourceBuildUrl: 'https://build.example/job/service/job/PR-1/4/',
+      sourceJobName: 'service/PR-1',
+      sourceBuildNumber: '4',
+      sourceBuildResult: 'SUCCESS',
+      sourceProduct: 'et',
+      sourceComponent: 'cos'
+    )
+
+    assertThat(metadataChecks).isEqualTo(2)
+    assertThat(downloads*.url).containsExactlyInAnyOrder(
+      'http://localhost:8080/job/service/job/PR-1/4/consoleText',
+      'http://localhost:8080/job/service/job/PR-1/4/artifact/*zip*/archive.zip',
+      'http://localhost:8080/job/service/job/PR-1/4/testReport/api/json'
+    )
+    assertThat(writes['build.json'].toString()).contains('"result":"SUCCESS"')
+    assertThat(writes['archive-metadata.json'].sourceJobName).isEqualTo('service/PR-1')
+    assertThat(writes['archive-metadata.json'].archivedAt).isEqualTo('2026-07-23T14:30:00Z')
+    assertThat(archived.artifacts.toString()).isEqualTo('completed-build-4/**')
+    assertThat(uploads).isEmpty()
+  }
+
+  @Test
+  void rejectsBuildUrlsOutsideTheConfiguredJenkins() {
+    try {
+      script.call(
+        sourceBuildUrl: 'https://malicious.example/job/service/4/',
+        sourceJobName: 'service',
+        sourceBuildNumber: '4'
+      )
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected.message).contains('invalid Jenkins build URL')
+      return
+    }
+
+    throw new AssertionError('Expected an invalid build URL to be rejected')
+  }
+}

--- a/test/archiveCompletedBuildTest.groovy
+++ b/test/archiveCompletedBuildTest.groovy
@@ -1,4 +1,6 @@
 import com.lesfurets.jenkins.unit.BasePipelineTest
+import hudson.model.Result
+import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
 import org.junit.Before
 import org.junit.Test
 import groovy.json.JsonSlurperClassic
@@ -9,11 +11,14 @@ class archiveCompletedBuildTest extends BasePipelineTest {
 
   def archived
   def downloads = []
+  def requests = []
+  def timeouts = []
   def uploads = []
   def writes = [:]
   def metadataChecks = 0
-  def buildResult = 'SUCCESS'
+  def buildResult = 'FAILURE'
   def workflowStages = []
+  def workflowFailure
   def script
 
   @Override
@@ -30,13 +35,17 @@ class archiveCompletedBuildTest extends BasePipelineTest {
     helper.registerAllowedMethod('node', [String.class, Closure.class], { _, body -> body.call() })
     helper.registerAllowedMethod('deleteDir', [], {})
     helper.registerAllowedMethod('dir', [String.class, Closure.class], { _, body -> body.call() })
-    helper.registerAllowedMethod('timeout', [Map.class, Closure.class], { _, body -> body.call() })
+    helper.registerAllowedMethod('timeout', [Map.class, Closure.class], { options, body ->
+      timeouts << options
+      body.call()
+    })
     helper.registerAllowedMethod('waitUntil', [Map.class, Closure.class], { _, body ->
       while (!body.call()) {
         // Repeat until the mocked build reports completion.
       }
     })
     helper.registerAllowedMethod('httpRequest', [Map.class], { request ->
+      requests << request
       if (request.url.endsWith('/api/json') && !request.url.contains('testReport')) {
         metadataChecks++
         return [
@@ -48,6 +57,9 @@ class archiveCompletedBuildTest extends BasePipelineTest {
       }
 
       if (request.url.endsWith('/wfapi/describe')) {
+        if (workflowFailure) {
+          throw workflowFailure
+        }
         return [
           status: 200,
           content: groovy.json.JsonOutput.toJson([stages: workflowStages])
@@ -76,7 +88,11 @@ class archiveCompletedBuildTest extends BasePipelineTest {
   }
 
   @Test
-  void waitsForCompletionAndArchivesTheWholeBuildLocally() {
+  void streamsDownloadsAndAppliesConfiguredTimeouts() {
+    binding.getVariable('env').BUILD_ARCHIVE_WAIT_TIMEOUT_MINUTES = '301'
+    binding.getVariable('env').BUILD_ARCHIVE_OPERATION_TIMEOUT_MINUTES = '121'
+    binding.getVariable('env').BUILD_ARCHIVE_HTTP_TIMEOUT_SECONDS = '1801'
+
     script.call(
       sourceBuildUrl: 'https://build.example/job/service/job/PR-1/4/',
       sourceJobName: 'service/PR-1',
@@ -92,10 +108,13 @@ class archiveCompletedBuildTest extends BasePipelineTest {
       'http://localhost:8080/job/service/job/PR-1/4/artifact/*zip*/archive.zip',
       'http://localhost:8080/job/service/job/PR-1/4/testReport/api/json'
     )
-    assertThat(writes['build.json'].toString()).contains('"result":"SUCCESS"')
+    assertThat(downloads*.responseHandle).containsOnly('NONE')
+    assertThat(requests*.timeout).containsOnly(1801)
+    assertThat(timeouts*.time).containsExactly(301, 121)
+    assertThat(writes['build.json'].toString()).contains('"result":"FAILURE"')
     assertThat(writes['archive-metadata.json'].sourceJobName).isEqualTo('service/PR-1')
     assertThat(writes['archive-metadata.json'].archivedAt).isEqualTo('2026-07-23T14:30:00Z')
-    assertThat(archived.artifacts.toString()).isEqualTo('completed-build_4_SUCCESS/**')
+    assertThat(archived.artifacts.toString()).isEqualTo('completed-build_4_FAILURE/**')
     assertThat(uploads).isEmpty()
   }
 
@@ -138,9 +157,43 @@ class archiveCompletedBuildTest extends BasePipelineTest {
     assertThat(uploads[0]*.toString()).containsExactly(
       'sandbox',
       'buildlog-storage-account',
-      'completed-build_4_SUCCESS',
+      'completed-build_4_FAILURE',
       'jenkins-build-archive/builds/service/PR-1'
     )
+  }
+
+  @Test
+  void ignoresAnAbortedBuildAfterPollingItsFinalResult() {
+    buildResult = 'ABORTED'
+
+    script.call(
+      sourceBuildUrl: 'https://build.example/job/service/job/PR-1/4/',
+      sourceJobName: 'service/PR-1',
+      sourceBuildNumber: '4'
+    )
+
+    assertThat(downloads).isEmpty()
+    assertThat(uploads).isEmpty()
+    assertThat(archived).isNull()
+  }
+
+  @Test
+  void preservesAnInterruptionWhileReadingWorkflowMetadata() {
+    def interruption = new FlowInterruptedException(Result.ABORTED, true)
+    workflowFailure = interruption
+
+    try {
+      script.call(
+        sourceBuildUrl: 'https://build.example/job/service/job/PR-1/4/',
+        sourceJobName: 'service/PR-1',
+        sourceBuildNumber: '4'
+      )
+    } catch (FlowInterruptedException expected) {
+      assertThat(expected).isSameAs(interruption)
+      return
+    }
+
+    throw new AssertionError('Expected the workflow metadata interruption to propagate')
   }
 
   @Test

--- a/test/archiveCompletedBuildTest.groovy
+++ b/test/archiveCompletedBuildTest.groovy
@@ -139,7 +139,7 @@ class archiveCompletedBuildTest extends BasePipelineTest {
       'sandbox',
       'buildlog-storage-account',
       'completed-build_4_SUCCESS',
-      'jenkins-build-archive/builds/service/PR-1/completed-build_4_SUCCESS'
+      'jenkins-build-archive/builds/service/PR-1'
     )
   }
 

--- a/test/archiveCompletedBuildTest.groovy
+++ b/test/archiveCompletedBuildTest.groovy
@@ -124,6 +124,26 @@ class archiveCompletedBuildTest extends BasePipelineTest {
   }
 
   @Test
+  void uploadsToTheSandboxStorageSubscriptionByDefault() {
+    binding.getVariable('env').BUILD_ARCHIVE_LOCAL_ONLY = 'false'
+    binding.getVariable('env').BUILD_ARCHIVE_JENKINS_CREDENTIALS_ID = 'jenkins-api'
+
+    script.call(
+      sourceBuildUrl: 'https://build.example/job/service/job/PR-1/4/',
+      sourceJobName: 'service/PR-1',
+      sourceBuildNumber: '4'
+    )
+
+    assertThat(uploads).hasSize(1)
+    assertThat(uploads[0]*.toString()).containsExactly(
+      'sandbox',
+      'buildlog-storage-account',
+      'completed-build_4_SUCCESS',
+      'jenkins-build-archive/builds/service/PR-1/completed-build_4_SUCCESS'
+    )
+  }
+
+  @Test
   void rejectsBuildUrlsOutsideTheConfiguredJenkins() {
     try {
       script.call(
@@ -137,5 +157,50 @@ class archiveCompletedBuildTest extends BasePipelineTest {
     }
 
     throw new AssertionError('Expected an invalid build URL to be rejected')
+  }
+
+  @Test
+  void rejectsNonNumericBuildNumbers() {
+    assertInvalidBuildIdentity(
+      sourceBuildUrl: 'https://build.example/job/service/4/',
+      sourceJobName: 'service',
+      sourceBuildNumber: '../4',
+      expectedMessage: 'invalid Jenkins build number'
+    )
+  }
+
+  @Test
+  void rejectsBuildNumbersThatDoNotMatchTheBuildUrl() {
+    assertInvalidBuildIdentity(
+      sourceBuildUrl: 'https://build.example/job/service/4/',
+      sourceJobName: 'service',
+      sourceBuildNumber: '5',
+      expectedMessage: 'mismatched Jenkins build details'
+    )
+  }
+
+  @Test
+  void rejectsUnsafeJobPathSegments() {
+    assertInvalidBuildIdentity(
+      sourceBuildUrl: 'https://build.example/job/service/4/',
+      sourceJobName: '../service',
+      sourceBuildNumber: '4',
+      expectedMessage: 'invalid Jenkins job name'
+    )
+  }
+
+  private void assertInvalidBuildIdentity(Map params) {
+    try {
+      script.call(
+        sourceBuildUrl: params.sourceBuildUrl,
+        sourceJobName: params.sourceJobName,
+        sourceBuildNumber: params.sourceBuildNumber
+      )
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected.message).contains(params.expectedMessage)
+      return
+    }
+
+    throw new AssertionError("Expected build archive validation to reject ${params}")
   }
 }

--- a/test/archiveCompletedBuildTest.groovy
+++ b/test/archiveCompletedBuildTest.groovy
@@ -12,6 +12,8 @@ class archiveCompletedBuildTest extends BasePipelineTest {
   def uploads = []
   def writes = [:]
   def metadataChecks = 0
+  def buildResult = 'SUCCESS'
+  def workflowStages = []
   def script
 
   @Override
@@ -41,7 +43,14 @@ class archiveCompletedBuildTest extends BasePipelineTest {
           status: 200,
           content: metadataChecks == 1
             ? '{"building":true}'
-            : '{"building":false,"result":"SUCCESS"}'
+            : """{"building":false,"result":"${buildResult}"}"""
+        ]
+      }
+
+      if (request.url.endsWith('/wfapi/describe')) {
+        return [
+          status: 200,
+          content: groovy.json.JsonOutput.toJson([stages: workflowStages])
         ]
       }
 
@@ -86,8 +95,32 @@ class archiveCompletedBuildTest extends BasePipelineTest {
     assertThat(writes['build.json'].toString()).contains('"result":"SUCCESS"')
     assertThat(writes['archive-metadata.json'].sourceJobName).isEqualTo('service/PR-1')
     assertThat(writes['archive-metadata.json'].archivedAt).isEqualTo('2026-07-23T14:30:00Z')
-    assertThat(archived.artifacts.toString()).isEqualTo('completed-build-4/**')
+    assertThat(archived.artifacts.toString()).isEqualTo('completed-build_4_SUCCESS/**')
     assertThat(uploads).isEmpty()
+  }
+
+  @Test
+  void includesTheOutcomeAndFailedStageInTheArchiveName() {
+    buildResult = 'FAILURE'
+    workflowStages = [
+      [name: 'Build and test', status: 'SUCCESS'],
+      [name: 'Deploy to AKS / Preview', status: 'FAILED']
+    ]
+
+    script.call(
+      sourceBuildUrl: 'https://build.example/job/service/job/PR-1/4/',
+      sourceJobName: 'service/PR-1',
+      sourceBuildNumber: '4',
+      sourceBuildResult: 'SUCCESS',
+      sourceProduct: 'et',
+      sourceComponent: 'cos'
+    )
+
+    assertThat(archived.artifacts.toString())
+      .isEqualTo('completed-build_4_FAILURE_Deploy_to_AKS_Preview/**')
+    assertThat(writes['archive-metadata.json'].sourceBuildResult).isEqualTo('FAILURE')
+    assertThat(writes['archive-metadata.json'].failedStage).isEqualTo('Deploy to AKS / Preview')
+    assertThat(writes['workflow.json'].stages[1].status).isEqualTo('FAILED')
   }
 
   @Test

--- a/test/archiveCompletedBuildTest.groovy
+++ b/test/archiveCompletedBuildTest.groovy
@@ -1,24 +1,20 @@
 import com.lesfurets.jenkins.unit.BasePipelineTest
+import hudson.FilePath
 import hudson.model.Result
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
 import org.junit.Before
 import org.junit.Test
-import groovy.json.JsonSlurperClassic
 
 import static org.assertj.core.api.Assertions.assertThat
 
 class archiveCompletedBuildTest extends BasePipelineTest {
 
   def archived
-  def downloads = []
-  def requests = []
   def timeouts = []
   def uploads = []
   def writes = [:]
-  def metadataChecks = 0
-  def buildResult = 'FAILURE'
-  def workflowStages = []
-  def workflowFailure
+  def buildReader
+  def workspace
   def script
 
   @Override
@@ -27,14 +23,17 @@ class archiveCompletedBuildTest extends BasePipelineTest {
     super.setUp()
     binding.setVariable('env', [
       JENKINS_URL: 'https://build.example/',
-      BUILD_ARCHIVE_JENKINS_API_URL: 'http://localhost:8080/',
       BUILD_ARCHIVE_LOCAL_ONLY: 'true',
       BUILD_ARCHIVE_AGENT: ''
     ])
 
+    buildReader = new FakeCompletedBuildReader()
+    workspace = new FilePath(new File('build/archive-test-workspace'))
+
     helper.registerAllowedMethod('node', [String.class, Closure.class], { _, body -> body.call() })
     helper.registerAllowedMethod('deleteDir', [], {})
     helper.registerAllowedMethod('dir', [String.class, Closure.class], { _, body -> body.call() })
+    helper.registerAllowedMethod('getContext', [Class.class], { workspace })
     helper.registerAllowedMethod('timeout', [Map.class, Closure.class], { options, body ->
       timeouts << options
       body.call()
@@ -44,35 +43,6 @@ class archiveCompletedBuildTest extends BasePipelineTest {
         // Repeat until the mocked build reports completion.
       }
     })
-    helper.registerAllowedMethod('httpRequest', [Map.class], { request ->
-      requests << request
-      if (request.url.endsWith('/api/json') && !request.url.contains('testReport')) {
-        metadataChecks++
-        return [
-          status: 200,
-          content: metadataChecks == 1
-            ? '{"building":true}'
-            : """{"building":false,"result":"${buildResult}"}"""
-        ]
-      }
-
-      if (request.url.endsWith('/wfapi/describe')) {
-        if (workflowFailure) {
-          throw workflowFailure
-        }
-        return [
-          status: 200,
-          content: groovy.json.JsonOutput.toJson([stages: workflowStages])
-        ]
-      }
-
-      downloads << request
-      return [status: 200, content: '']
-    })
-    helper.registerAllowedMethod('readJSON', [Map.class], {
-      new JsonSlurperClassic().parseText(it.text)
-    })
-    helper.registerAllowedMethod('writeFile', [Map.class], { writes[it.file] = it.text })
     helper.registerAllowedMethod('writeJSON', [Map.class], { writes[it.file] = it.json })
     helper.registerAllowedMethod('archiveArtifacts', [Map.class], { archived = it })
     helper.registerAllowedMethod('azureBlobUpload', [String.class, String.class, String.class, String.class], {
@@ -88,42 +58,12 @@ class archiveCompletedBuildTest extends BasePipelineTest {
   }
 
   @Test
-  void streamsDownloadsAndAppliesConfiguredTimeouts() {
+  void copiesCompletedBuildOutputsWithoutAnApiCredential() {
     binding.getVariable('env').BUILD_ARCHIVE_WAIT_TIMEOUT_MINUTES = '301'
     binding.getVariable('env').BUILD_ARCHIVE_OPERATION_TIMEOUT_MINUTES = '121'
-    binding.getVariable('env').BUILD_ARCHIVE_HTTP_TIMEOUT_SECONDS = '1801'
-
-    script.call(
-      sourceBuildUrl: 'https://build.example/job/service/job/PR-1/4/',
-      sourceJobName: 'service/PR-1',
-      sourceBuildNumber: '4',
-      sourceBuildResult: 'SUCCESS',
-      sourceProduct: 'et',
-      sourceComponent: 'cos'
-    )
-
-    assertThat(metadataChecks).isEqualTo(2)
-    assertThat(downloads*.url).containsExactlyInAnyOrder(
-      'http://localhost:8080/job/service/job/PR-1/4/consoleText',
-      'http://localhost:8080/job/service/job/PR-1/4/artifact/*zip*/archive.zip',
-      'http://localhost:8080/job/service/job/PR-1/4/testReport/api/json'
-    )
-    assertThat(downloads*.responseHandle).containsOnly('NONE')
-    assertThat(requests*.timeout).containsOnly(1801)
-    assertThat(timeouts*.time).containsExactly(301, 121)
-    assertThat(writes['build.json'].toString()).contains('"result":"FAILURE"')
-    assertThat(writes['archive-metadata.json'].sourceJobName).isEqualTo('service/PR-1')
-    assertThat(writes['archive-metadata.json'].archivedAt).isEqualTo('2026-07-23T14:30:00Z')
-    assertThat(archived.artifacts.toString()).isEqualTo('completed-build_4_FAILURE/**')
-    assertThat(uploads).isEmpty()
-  }
-
-  @Test
-  void includesTheOutcomeAndFailedStageInTheArchiveName() {
-    buildResult = 'FAILURE'
-    workflowStages = [
-      [name: 'Build and test', status: 'SUCCESS'],
-      [name: 'Deploy to AKS / Preview', status: 'FAILED']
+    buildReader.snapshots = [
+      [building: true],
+      completedBuild()
     ]
 
     script.call(
@@ -132,25 +72,37 @@ class archiveCompletedBuildTest extends BasePipelineTest {
       sourceBuildNumber: '4',
       sourceBuildResult: 'SUCCESS',
       sourceProduct: 'et',
-      sourceComponent: 'cos'
+      sourceComponent: 'cos',
+      buildReader: buildReader
     )
 
+    assertThat(buildReader.snapshotRequests).containsExactly(
+      ['service/PR-1', 4],
+      ['service/PR-1', 4]
+    )
+    assertThat(buildReader.copyRequests).hasSize(1)
+    assertThat(buildReader.copyRequests[0].take(2)).containsExactly('service/PR-1', 4)
+    assertThat(timeouts*.time).containsExactly(301, 121)
+    assertThat(writes['build.json'].result).isEqualTo('FAILURE')
+    assertThat(writes['build.json']).doesNotContainKeys('workflow', 'tests')
+    assertThat(writes['test-results.json'].failCount).isEqualTo(2)
+    assertThat(writes['archive-metadata.json'].sourceJobName).isEqualTo('service/PR-1')
+    assertThat(writes['archive-metadata.json'].archivedAt).isEqualTo('2026-07-23T14:30:00Z')
     assertThat(archived.artifacts.toString())
       .isEqualTo('completed-build_4_FAILURE_Deploy_to_AKS_Preview/**')
-    assertThat(writes['archive-metadata.json'].sourceBuildResult).isEqualTo('FAILURE')
-    assertThat(writes['archive-metadata.json'].failedStage).isEqualTo('Deploy to AKS / Preview')
-    assertThat(writes['workflow.json'].stages[1].status).isEqualTo('FAILED')
+    assertThat(uploads).isEmpty()
   }
 
   @Test
   void uploadsToTheSandboxStorageSubscriptionByDefault() {
     binding.getVariable('env').BUILD_ARCHIVE_LOCAL_ONLY = 'false'
-    binding.getVariable('env').BUILD_ARCHIVE_JENKINS_CREDENTIALS_ID = 'jenkins-api'
+    buildReader.snapshots = [completedBuild(workflow: null, tests: null)]
 
     script.call(
       sourceBuildUrl: 'https://build.example/job/service/job/PR-1/4/',
       sourceJobName: 'service/PR-1',
-      sourceBuildNumber: '4'
+      sourceBuildNumber: '4',
+      buildReader: buildReader
     )
 
     assertThat(uploads).hasSize(1)
@@ -163,37 +115,39 @@ class archiveCompletedBuildTest extends BasePipelineTest {
   }
 
   @Test
-  void ignoresAnAbortedBuildAfterPollingItsFinalResult() {
-    buildResult = 'ABORTED'
+  void ignoresAnAbortedBuildAfterReadingItsFinalResult() {
+    buildReader.snapshots = [completedBuild(result: 'ABORTED')]
 
     script.call(
       sourceBuildUrl: 'https://build.example/job/service/job/PR-1/4/',
       sourceJobName: 'service/PR-1',
-      sourceBuildNumber: '4'
+      sourceBuildNumber: '4',
+      buildReader: buildReader
     )
 
-    assertThat(downloads).isEmpty()
+    assertThat(buildReader.copyRequests).isEmpty()
     assertThat(uploads).isEmpty()
     assertThat(archived).isNull()
   }
 
   @Test
-  void preservesAnInterruptionWhileReadingWorkflowMetadata() {
+  void preservesAnInterruptionWhileReadingTheCompletedBuild() {
     def interruption = new FlowInterruptedException(Result.ABORTED, true)
-    workflowFailure = interruption
+    buildReader.failure = interruption
 
     try {
       script.call(
         sourceBuildUrl: 'https://build.example/job/service/job/PR-1/4/',
         sourceJobName: 'service/PR-1',
-        sourceBuildNumber: '4'
+        sourceBuildNumber: '4',
+        buildReader: buildReader
       )
     } catch (FlowInterruptedException expected) {
       assertThat(expected).isSameAs(interruption)
       return
     }
 
-    throw new AssertionError('Expected the workflow metadata interruption to propagate')
+    throw new AssertionError('Expected the completed build interruption to propagate')
   }
 
   @Test
@@ -202,7 +156,8 @@ class archiveCompletedBuildTest extends BasePipelineTest {
       script.call(
         sourceBuildUrl: 'https://malicious.example/job/service/4/',
         sourceJobName: 'service',
-        sourceBuildNumber: '4'
+        sourceBuildNumber: '4',
+        buildReader: buildReader
       )
     } catch (IllegalArgumentException expected) {
       assertThat(expected.message).contains('invalid Jenkins build URL')
@@ -252,12 +207,39 @@ class archiveCompletedBuildTest extends BasePipelineTest {
     )
   }
 
+  private static Map completedBuild(Map overrides = [:]) {
+    [
+      building: false,
+      result: 'FAILURE',
+      number: 4,
+      url: 'job/service/job/PR-1/4/',
+      displayName: '#4',
+      fullDisplayName: 'service/PR-1 #4',
+      timestamp: 1785240000000,
+      duration: 5000,
+      estimatedDuration: 4000,
+      workflow: [
+        stages: [
+          [name: 'Build and test', status: 'SUCCESS'],
+          [name: 'Deploy to AKS / Preview', status: 'FAILED']
+        ]
+      ],
+      tests: [
+        totalCount: 10,
+        failCount: 2,
+        skipCount: 1,
+        passCount: 7
+      ]
+    ] + overrides
+  }
+
   private void assertInvalidBuildIdentity(Map params) {
     try {
       script.call(
         sourceBuildUrl: params.sourceBuildUrl,
         sourceJobName: params.sourceJobName,
-        sourceBuildNumber: params.sourceBuildNumber
+        sourceBuildNumber: params.sourceBuildNumber,
+        buildReader: buildReader
       )
     } catch (IllegalArgumentException expected) {
       assertThat(expected.message).contains(params.expectedMessage)
@@ -265,5 +247,27 @@ class archiveCompletedBuildTest extends BasePipelineTest {
     }
 
     throw new AssertionError("Expected build archive validation to reject ${params}")
+  }
+}
+
+class FakeCompletedBuildReader implements Serializable {
+
+  private static final long serialVersionUID = 1L
+
+  List<Map> snapshots = []
+  List snapshotRequests = []
+  List copyRequests = []
+  Throwable failure
+
+  Map snapshot(String jobName, int buildNumber) {
+    snapshotRequests << [jobName, buildNumber]
+    if (failure) {
+      throw failure
+    }
+    snapshots.remove(0)
+  }
+
+  void copyOutputs(String jobName, int buildNumber, FilePath workspace) {
+    copyRequests << [jobName, buildNumber, workspace]
   }
 }

--- a/test/queueBuildArchiveTest.groovy
+++ b/test/queueBuildArchiveTest.groovy
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat
 class queueBuildArchiveTest extends BasePipelineTest {
 
   def queuedBuild
+  def queuedBuildCount = 0
   def script
 
   @Override
@@ -20,7 +21,10 @@ class queueBuildArchiveTest extends BasePipelineTest {
     ])
     binding.setVariable('currentBuild', [result: 'FAILURE'])
     helper.registerAllowedMethod('string', [Map.class], { it })
-    helper.registerAllowedMethod('build', [Map.class], { queuedBuild = it })
+    helper.registerAllowedMethod('build', [Map.class], {
+      queuedBuild = it
+      queuedBuildCount++
+    })
     helper.registerAllowedMethod('echo', [String.class], {})
     script = loadScript('vars/queueBuildArchive.groovy')
   }
@@ -29,7 +33,7 @@ class queueBuildArchiveTest extends BasePipelineTest {
   void queuesTheConfiguredArchiveJobWithoutWaiting() {
     script.call(product: 'et', component: 'cos')
 
-    assertThat(queuedBuild.job).isEqualTo('Archive Completed Builds')
+    assertThat(queuedBuild.job).isEqualTo('/Archive Completed Builds')
     assertThat(queuedBuild.wait).isFalse()
     assertThat(queuedBuild.propagate).isFalse()
     assertThat(parameter('SOURCE_BUILD_URL')).isEqualTo('https://build.example/job/service/job/PR-1/4/')
@@ -38,6 +42,24 @@ class queueBuildArchiveTest extends BasePipelineTest {
     assertThat(parameter('SOURCE_BUILD_RESULT')).isEqualTo('FAILURE')
     assertThat(parameter('SOURCE_PRODUCT')).isEqualTo('et')
     assertThat(parameter('SOURCE_COMPONENT')).isEqualTo('cos')
+    assertThat(binding.getVariable('env').BUILD_ARCHIVE_QUEUED).isEqualTo('true')
+  }
+
+  @Test
+  void queuesOnlyOnceWhenCalledForMultipleRetryAttempts() {
+    script.call(product: 'et', component: 'cos')
+    script.call(product: 'et', component: 'cos')
+
+    assertThat(queuedBuildCount).isEqualTo(1)
+  }
+
+  @Test
+  void doesNotQueueFromTheArchiveJobItself() {
+    binding.getVariable('env').JOB_NAME = 'Archive Completed Builds'
+
+    script.call(product: 'et', component: 'cos')
+
+    assertThat(queuedBuild).isNull()
   }
 
   @Test

--- a/test/queueBuildArchiveTest.groovy
+++ b/test/queueBuildArchiveTest.groovy
@@ -1,0 +1,65 @@
+import com.lesfurets.jenkins.unit.BasePipelineTest
+import org.junit.Before
+import org.junit.Test
+
+import static org.assertj.core.api.Assertions.assertThat
+
+class queueBuildArchiveTest extends BasePipelineTest {
+
+  def queuedBuild
+  def script
+
+  @Override
+  @Before
+  void setUp() {
+    super.setUp()
+    binding.setVariable('env', [
+      BUILD_ARCHIVE_JOB: 'platform/build-archive',
+      BUILD_URL: 'https://build.example/job/service/job/PR-1/4/',
+      JOB_NAME: 'service/PR-1',
+      BUILD_NUMBER: '4'
+    ])
+    binding.setVariable('currentBuild', [result: 'FAILURE'])
+    helper.registerAllowedMethod('string', [Map.class], { it })
+    helper.registerAllowedMethod('build', [Map.class], { queuedBuild = it })
+    helper.registerAllowedMethod('echo', [String.class], {})
+    script = loadScript('vars/queueBuildArchive.groovy')
+  }
+
+  @Test
+  void queuesTheConfiguredArchiveJobWithoutWaiting() {
+    script.call(product: 'et', component: 'cos')
+
+    assertThat(queuedBuild.job).isEqualTo('platform/build-archive')
+    assertThat(queuedBuild.wait).isFalse()
+    assertThat(queuedBuild.propagate).isFalse()
+    assertThat(parameter('SOURCE_BUILD_URL')).isEqualTo('https://build.example/job/service/job/PR-1/4/')
+    assertThat(parameter('SOURCE_JOB_NAME')).isEqualTo('service/PR-1')
+    assertThat(parameter('SOURCE_BUILD_NUMBER')).isEqualTo('4')
+    assertThat(parameter('SOURCE_BUILD_RESULT')).isEqualTo('FAILURE')
+    assertThat(parameter('SOURCE_PRODUCT')).isEqualTo('et')
+    assertThat(parameter('SOURCE_COMPONENT')).isEqualTo('cos')
+  }
+
+  @Test
+  void doesNothingWhenArchivingIsNotConfigured() {
+    binding.getVariable('env').BUILD_ARCHIVE_JOB = ''
+
+    script.call(product: 'et', component: 'cos')
+
+    assertThat(queuedBuild).isNull()
+  }
+
+  @Test
+  void doesNothingWhenTheBuildUrlIsUnavailable() {
+    binding.getVariable('env').BUILD_URL = ''
+
+    script.call(product: 'et', component: 'cos')
+
+    assertThat(queuedBuild).isNull()
+  }
+
+  private String parameter(String name) {
+    queuedBuild.parameters.find { it.name == name }.value
+  }
+}

--- a/test/queueBuildArchiveTest.groovy
+++ b/test/queueBuildArchiveTest.groovy
@@ -1,4 +1,6 @@
 import com.lesfurets.jenkins.unit.BasePipelineTest
+import hudson.model.Result
+import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
 import org.junit.Before
 import org.junit.Test
 
@@ -8,6 +10,7 @@ class queueBuildArchiveTest extends BasePipelineTest {
 
   def queuedBuild
   def queuedBuildCount = 0
+  def buildFailure
   def script
 
   @Override
@@ -22,6 +25,9 @@ class queueBuildArchiveTest extends BasePipelineTest {
     binding.setVariable('currentBuild', [result: 'FAILURE'])
     helper.registerAllowedMethod('string', [Map.class], { it })
     helper.registerAllowedMethod('build', [Map.class], {
+      if (buildFailure) {
+        throw buildFailure
+      }
       queuedBuild = it
       queuedBuildCount++
     })
@@ -78,6 +84,21 @@ class queueBuildArchiveTest extends BasePipelineTest {
     script.call(product: 'et', component: 'cos')
 
     assertThat(queuedBuild).isNull()
+  }
+
+  @Test
+  void preservesAnInterruptionWhileQueuingTheArchive() {
+    def interruption = new FlowInterruptedException(Result.ABORTED, true)
+    buildFailure = interruption
+
+    try {
+      script.call(product: 'et', component: 'cos')
+    } catch (FlowInterruptedException expected) {
+      assertThat(expected).isSameAs(interruption)
+      return
+    }
+
+    throw new AssertionError('Expected the queue interruption to propagate')
   }
 
   private String parameter(String name) {

--- a/test/queueBuildArchiveTest.groovy
+++ b/test/queueBuildArchiveTest.groovy
@@ -14,7 +14,6 @@ class queueBuildArchiveTest extends BasePipelineTest {
   void setUp() {
     super.setUp()
     binding.setVariable('env', [
-      BUILD_ARCHIVE_JOB: 'platform/build-archive',
       BUILD_URL: 'https://build.example/job/service/job/PR-1/4/',
       JOB_NAME: 'service/PR-1',
       BUILD_NUMBER: '4'
@@ -30,7 +29,7 @@ class queueBuildArchiveTest extends BasePipelineTest {
   void queuesTheConfiguredArchiveJobWithoutWaiting() {
     script.call(product: 'et', component: 'cos')
 
-    assertThat(queuedBuild.job).isEqualTo('platform/build-archive')
+    assertThat(queuedBuild.job).isEqualTo('Archive Completed Builds')
     assertThat(queuedBuild.wait).isFalse()
     assertThat(queuedBuild.propagate).isFalse()
     assertThat(parameter('SOURCE_BUILD_URL')).isEqualTo('https://build.example/job/service/job/PR-1/4/')
@@ -39,15 +38,6 @@ class queueBuildArchiveTest extends BasePipelineTest {
     assertThat(parameter('SOURCE_BUILD_RESULT')).isEqualTo('FAILURE')
     assertThat(parameter('SOURCE_PRODUCT')).isEqualTo('et')
     assertThat(parameter('SOURCE_COMPONENT')).isEqualTo('cos')
-  }
-
-  @Test
-  void doesNothingWhenArchivingIsNotConfigured() {
-    binding.getVariable('env').BUILD_ARCHIVE_JOB = ''
-
-    script.call(product: 'et', component: 'cos')
-
-    assertThat(queuedBuild).isNull()
   }
 
   @Test

--- a/test/queueBuildArchiveTest.groovy
+++ b/test/queueBuildArchiveTest.groovy
@@ -41,6 +41,15 @@ class queueBuildArchiveTest extends BasePipelineTest {
   }
 
   @Test
+  void ignoresSuccessfulBuilds() {
+    binding.getVariable('currentBuild').result = 'SUCCESS'
+
+    script.call(product: 'et', component: 'cos')
+
+    assertThat(queuedBuild).isNull()
+  }
+
+  @Test
   void doesNothingWhenTheBuildUrlIsUnavailable() {
     binding.getVariable('env').BUILD_URL = ''
 

--- a/test/uk/gov/hmcts/contino/CompletedBuildReaderTest.groovy
+++ b/test/uk/gov/hmcts/contino/CompletedBuildReaderTest.groovy
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.contino
+
+import org.junit.Test
+
+import static org.assertj.core.api.Assertions.assertThat
+
+class CompletedBuildReaderTest {
+
+  @Test
+  void ignoresNullActionsWhenReadingTestMetadata() {
+    def testResult = new TestResultAction(totalCount: 12, failCount: 2, skipCount: 3)
+    def build = [getAllActions: { [null, new Object(), testResult] }]
+
+    def metadata = CompletedBuildReader.testMetadata(build)
+
+    assertThat(metadata).isEqualTo([
+      totalCount: 12,
+      failCount: 2,
+      skipCount: 3,
+      passCount: 7
+    ])
+  }
+
+  private static class TestResultAction {
+    int totalCount
+    int failCount
+    int skipCount
+  }
+}

--- a/test/withNightlyPipeline/withNightlyPipelineArchiveInterruptionTests.groovy
+++ b/test/withNightlyPipeline/withNightlyPipelineArchiveInterruptionTests.groovy
@@ -1,0 +1,43 @@
+package withNightlyPipeline
+
+import groovy.mock.interceptor.StubFor
+import hudson.model.Result
+import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
+import org.junit.Test
+import uk.gov.hmcts.contino.GradleBuilder
+import withPipeline.BaseCnpPipelineTest
+
+import static org.assertj.core.api.Assertions.assertThat
+
+class withNightlyPipelineArchiveInterruptionTests extends BaseCnpPipelineTest {
+  final static jenkinsFile = "exampleJavaNightlyPipeline.jenkins"
+
+  withNightlyPipelineArchiveInterruptionTests() {
+    super("master", jenkinsFile)
+
+    helper.registerAllowedMethod("node", [String, Closure], { _, body -> body.call() })
+    helper.registerAllowedMethod("timeout", [Map, Closure], { _, body -> body.call() })
+  }
+
+  @Test
+  void doesNotArchiveAnInterruptedNightlyPipeline() {
+    def interruption = new FlowInterruptedException(Result.ABORTED, true)
+    def stubBuilder = new StubFor(GradleBuilder)
+    stubBuilder.demand.setupToolVersion(1) {
+      throw interruption
+    }
+
+    def caughtInterruption = null
+    try {
+      stubBuilder.use {
+        runScript("testResources/$jenkinsFile")
+      }
+    } catch (FlowInterruptedException expected) {
+      caughtInterruption = expected
+    }
+
+    assertThat(caughtInterruption).isSameAs(interruption)
+    assertThat(binding.getVariable('currentBuild').result).isEqualTo('ABORTED')
+    assertThat(helper.callStack*.methodName).doesNotContain('queueBuildArchive')
+  }
+}

--- a/test/withNightlyPipeline/withNightlyPipelineArchiveInterruptionTests.groovy
+++ b/test/withNightlyPipeline/withNightlyPipelineArchiveInterruptionTests.groovy
@@ -3,6 +3,7 @@ package withNightlyPipeline
 import groovy.mock.interceptor.StubFor
 import hudson.model.Result
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
+import org.junit.Before
 import org.junit.Test
 import uk.gov.hmcts.contino.GradleBuilder
 import withPipeline.BaseCnpPipelineTest
@@ -14,7 +15,10 @@ class withNightlyPipelineArchiveInterruptionTests extends BaseCnpPipelineTest {
 
   withNightlyPipelineArchiveInterruptionTests() {
     super("master", jenkinsFile)
+  }
 
+  @Before
+  void registerArchiveInterruptionSteps() {
     helper.registerAllowedMethod("node", [String, Closure], { _, body -> body.call() })
     helper.registerAllowedMethod("timeout", [Map, Closure], { _, body -> body.call() })
   }

--- a/test/withNightlyPipeline/withNightlyPipelineArchiveInterruptionTests.groovy
+++ b/test/withNightlyPipeline/withNightlyPipelineArchiveInterruptionTests.groovy
@@ -1,11 +1,9 @@
 package withNightlyPipeline
 
-import groovy.mock.interceptor.StubFor
 import hudson.model.Result
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
 import org.junit.Before
 import org.junit.Test
-import uk.gov.hmcts.contino.GradleBuilder
 import withPipeline.BaseCnpPipelineTest
 
 import static org.assertj.core.api.Assertions.assertThat
@@ -26,16 +24,16 @@ class withNightlyPipelineArchiveInterruptionTests extends BaseCnpPipelineTest {
   @Test
   void doesNotArchiveAnInterruptedNightlyPipeline() {
     def interruption = new FlowInterruptedException(Result.ABORTED, true)
-    def stubBuilder = new StubFor(GradleBuilder)
-    stubBuilder.demand.setupToolVersion(1) {
-      throw interruption
-    }
+    helper.registerAllowedMethod("sh", [Map], { options ->
+      if (options.script.startsWith('grep -F "JavaLanguageVersion')) {
+        throw interruption
+      }
+      return options.returnStatus ? 1 : ''
+    })
 
     def caughtInterruption = null
     try {
-      stubBuilder.use {
-        runScript("testResources/$jenkinsFile")
-      }
+      runScript("testResources/$jenkinsFile")
     } catch (FlowInterruptedException expected) {
       caughtInterruption = expected
     }

--- a/test/withPipeline/BaseCnpPipelineTest.groovy
+++ b/test/withPipeline/BaseCnpPipelineTest.groovy
@@ -110,6 +110,11 @@ abstract class BaseCnpPipelineTest extends BasePipelineTest {
         return GithubAPITest.response
       } else if (m.get('url') == 'https://raw.githubusercontent.com/hmcts/cnp-deprecation-map/master/nagger-versions.yaml') {
         return DeprecationConfigTest.response
+      } else if (m.get('url') == 'https://raw.githubusercontent.com/hmcts/cnp-jenkins-library/master/resources/uk/gov/hmcts/library/allowed-library-branches.yml') {
+        return ['content': '''branches:
+  - name: master
+    allowed: true
+''']
       } else {
         return ['content': '{"azure_subscription": "fake_subscription_name","azure_client_id": "fake_client_id",' +
           '"azure_client_secret": "fake_secret","azure_tenant_id": "fake_tenant_id"}']

--- a/test/withPipeline/withPipelineArchiveInterruptionTests.groovy
+++ b/test/withPipeline/withPipelineArchiveInterruptionTests.groovy
@@ -1,0 +1,43 @@
+package withPipeline
+
+import groovy.mock.interceptor.StubFor
+import hudson.model.Result
+import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
+import org.junit.Test
+import uk.gov.hmcts.contino.GradleBuilder
+
+import static org.assertj.core.api.Assertions.assertThat
+
+class withPipelineArchiveInterruptionTests extends BaseCnpPipelineTest {
+  final static jenkinsFile = "exampleJavaPipeline.jenkins"
+
+  withPipelineArchiveInterruptionTests() {
+    super("master", jenkinsFile)
+
+    helper.registerAllowedMethod("retry", [LinkedHashMap, Closure], { _, body -> body.call() })
+    helper.registerAllowedMethod("node", [String, Closure], { _, body -> body.call() })
+    helper.registerAllowedMethod("timeout", [Map, Closure], { _, body -> body.call() })
+  }
+
+  @Test
+  void doesNotArchiveAnInterruptedApplicationPipeline() {
+    def interruption = new FlowInterruptedException(Result.ABORTED, true)
+    def stubBuilder = new StubFor(GradleBuilder)
+    stubBuilder.demand.setupToolVersion(1) {
+      throw interruption
+    }
+
+    def caughtInterruption = null
+    try {
+      stubBuilder.use {
+        runScript("testResources/$jenkinsFile")
+      }
+    } catch (FlowInterruptedException expected) {
+      caughtInterruption = expected
+    }
+
+    assertThat(caughtInterruption).isSameAs(interruption)
+    assertThat(binding.getVariable('currentBuild').result).isEqualTo('ABORTED')
+    assertThat(helper.callStack*.methodName).doesNotContain('queueBuildArchive')
+  }
+}

--- a/test/withPipeline/withPipelineArchiveInterruptionTests.groovy
+++ b/test/withPipeline/withPipelineArchiveInterruptionTests.groovy
@@ -40,4 +40,49 @@ class withPipelineArchiveInterruptionTests extends BaseCnpPipelineTest {
     assertThat(binding.getVariable('currentBuild').result).isEqualTo('ABORTED')
     assertThat(helper.callStack*.methodName).doesNotContain('queueBuildArchive')
   }
+
+  @Test
+  void queuesTheArchiveOnlyAfterAgentRetriesAreExhausted() {
+    def failure = new RuntimeException('agent lost')
+    def attempts = 0
+    def queueCount = 0
+    def retryComplete = false
+    helper.registerAllowedMethod("archiveBuildOutputs", [], {})
+    helper.registerAllowedMethod("build", [Map], {
+      assertThat(retryComplete).isTrue()
+      queueCount++
+    })
+    helper.registerAllowedMethod("retry", [LinkedHashMap, Closure], { _, body ->
+      try {
+        attempts++
+        body.call()
+      } catch (RuntimeException firstFailure) {
+        assertThat(queueCount).isZero()
+        attempts++
+        body.call()
+      } finally {
+        retryComplete = true
+      }
+    })
+    binding.getVariable('env').BUILD_URL = 'https://build.example/job/service/job/PR-1/4/'
+    binding.getVariable('env').JOB_NAME = 'service/PR-1'
+    binding.getVariable('env').BUILD_NUMBER = '4'
+
+    def stubBuilder = new StubFor(GradleBuilder)
+    stubBuilder.demand.setupToolVersion(2) {
+      throw failure
+    }
+
+    try {
+      stubBuilder.use {
+        runScript("testResources/$jenkinsFile")
+      }
+    } catch (RuntimeException expected) {
+      assertThat(expected).isSameAs(failure)
+    }
+
+    assertThat(attempts).isEqualTo(2)
+    assertThat(queueCount).isEqualTo(1)
+    assertThat(binding.getVariable('currentBuild').result).isEqualTo('FAILURE')
+  }
 }

--- a/test/withPipeline/withPipelineArchiveInterruptionTests.groovy
+++ b/test/withPipeline/withPipelineArchiveInterruptionTests.groovy
@@ -3,6 +3,7 @@ package withPipeline
 import groovy.mock.interceptor.StubFor
 import hudson.model.Result
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
+import org.junit.Before
 import org.junit.Test
 import uk.gov.hmcts.contino.GradleBuilder
 
@@ -13,7 +14,10 @@ class withPipelineArchiveInterruptionTests extends BaseCnpPipelineTest {
 
   withPipelineArchiveInterruptionTests() {
     super("master", jenkinsFile)
+  }
 
+  @Before
+  void registerArchiveInterruptionSteps() {
     helper.registerAllowedMethod("retry", [LinkedHashMap, Closure], { _, body -> body.call() })
     helper.registerAllowedMethod("node", [String, Closure], { _, body -> body.call() })
     helper.registerAllowedMethod("timeout", [Map, Closure], { _, body -> body.call() })

--- a/test/withPipeline/withPipelineArchiveInterruptionTests.groovy
+++ b/test/withPipeline/withPipelineArchiveInterruptionTests.groovy
@@ -1,11 +1,9 @@
 package withPipeline
 
-import groovy.mock.interceptor.StubFor
 import hudson.model.Result
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
 import org.junit.Before
 import org.junit.Test
-import uk.gov.hmcts.contino.GradleBuilder
 
 import static org.assertj.core.api.Assertions.assertThat
 
@@ -26,16 +24,16 @@ class withPipelineArchiveInterruptionTests extends BaseCnpPipelineTest {
   @Test
   void doesNotArchiveAnInterruptedApplicationPipeline() {
     def interruption = new FlowInterruptedException(Result.ABORTED, true)
-    def stubBuilder = new StubFor(GradleBuilder)
-    stubBuilder.demand.setupToolVersion(1) {
-      throw interruption
-    }
+    helper.registerAllowedMethod("sh", [Map], { options ->
+      if (options.script.startsWith('grep -F "JavaLanguageVersion')) {
+        throw interruption
+      }
+      return options.returnStatus ? 1 : ''
+    })
 
     def caughtInterruption = null
     try {
-      stubBuilder.use {
-        runScript("testResources/$jenkinsFile")
-      }
+      runScript("testResources/$jenkinsFile")
     } catch (FlowInterruptedException expected) {
       caughtInterruption = expected
     }
@@ -72,15 +70,15 @@ class withPipelineArchiveInterruptionTests extends BaseCnpPipelineTest {
     binding.getVariable('env').JOB_NAME = 'service/PR-1'
     binding.getVariable('env').BUILD_NUMBER = '4'
 
-    def stubBuilder = new StubFor(GradleBuilder)
-    stubBuilder.demand.setupToolVersion(2) {
-      throw failure
-    }
+    helper.registerAllowedMethod("sh", [Map], { options ->
+      if (options.script.startsWith('grep -F "JavaLanguageVersion')) {
+        throw failure
+      }
+      return options.returnStatus ? 1 : ''
+    })
 
     try {
-      stubBuilder.use {
-        runScript("testResources/$jenkinsFile")
-      }
+      runScript("testResources/$jenkinsFile")
     } catch (RuntimeException expected) {
       assertThat(expected).isSameAs(failure)
     }

--- a/vars/archiveBuildOutputs.groovy
+++ b/vars/archiveBuildOutputs.groovy
@@ -1,3 +1,5 @@
+import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
+
 def call() {
   try {
     archiveArtifacts(
@@ -14,6 +16,8 @@ def call() {
         'pods-logs-*/**'
       ].join(',')
     )
+  } catch (FlowInterruptedException err) {
+    throw err
   } catch (err) {
     echo "Unable to archive build outputs: ${err.message}"
   }

--- a/vars/archiveBuildOutputs.groovy
+++ b/vars/archiveBuildOutputs.groovy
@@ -1,0 +1,20 @@
+def call() {
+  try {
+    archiveArtifacts(
+      allowEmptyArchive: true,
+      artifacts: [
+        '**/build/reports/**',
+        '**/build/test-results/**',
+        '**/playwright-report/**',
+        '**/test-results/**',
+        'api-output/**',
+        'e2e-output/**',
+        'functional-output/**',
+        'smoke-output/**',
+        'pods-logs-*/**'
+      ].join(',')
+    )
+  } catch (err) {
+    echo "Unable to archive build outputs: ${err.message}"
+  }
+}

--- a/vars/archiveCompletedBuild.groovy
+++ b/vars/archiveCompletedBuild.groovy
@@ -223,7 +223,9 @@ private void validateBuildIdentity(String sourceBuildUrl, String sourceJobName, 
     error("Refusing to archive an invalid Jenkins build number: ${sourceBuildNumber}")
   }
 
-  def buildNumberFromUrl = (sourceBuildUrl =~ /\/(\d+)\/$/)[0][1]
+  def relativeBuildUrl = sourceBuildUrl.substring(env.JENKINS_URL.length())
+  def buildUrlParts = relativeBuildUrl =~ /^job\/(.+)\/(\d+)\/$/
+  def buildNumberFromUrl = buildUrlParts[0][2]
   if (buildNumberFromUrl != sourceBuildNumber) {
     error("Refusing to archive mismatched Jenkins build details")
   }
@@ -231,6 +233,14 @@ private void validateBuildIdentity(String sourceBuildUrl, String sourceJobName, 
   def jobSegments = sourceJobName.split('/', -1)
   if (jobSegments.any { segment -> !segment || segment in ['.', '..'] }) {
     error("Refusing to archive an invalid Jenkins job name: ${sourceJobName}")
+  }
+
+  def jobNameFromUrl = buildUrlParts[0][1]
+    .split('/job/', -1)
+    .collect { segment -> new URI("https://jenkins.invalid/${segment}").path.substring(1) }
+    .join('/')
+  if (jobNameFromUrl != sourceJobName) {
+    error("Refusing to archive mismatched Jenkins build details")
   }
 }
 

--- a/vars/archiveCompletedBuild.groovy
+++ b/vars/archiveCompletedBuild.groovy
@@ -10,9 +10,10 @@ def call(Map params = [:]) {
   }
 
   validateBuildUrl(sourceBuildUrl)
+  validateBuildIdentity(sourceBuildUrl, sourceJobName, sourceBuildNumber)
 
   def buildApiUrl = apiBuildUrl(sourceBuildUrl)
-  def storageSubscription = params.storageSubscription ?: env.BUILD_ARCHIVE_STORAGE_SUBSCRIPTION ?: 'DCD-CFT-Sandbox'
+  def storageSubscription = params.storageSubscription ?: env.BUILD_ARCHIVE_STORAGE_SUBSCRIPTION ?: 'sandbox'
   def storageCredentialsId = params.storageCredentialsId ?: env.BUILD_ARCHIVE_STORAGE_CREDENTIALS_ID ?: 'buildlog-storage-account'
   def storageContainer = params.storageContainer ?: env.BUILD_ARCHIVE_STORAGE_CONTAINER ?: 'jenkins-build-archive'
   def storagePrefix = params.storagePrefix ?: env.BUILD_ARCHIVE_STORAGE_PREFIX ?: 'builds'
@@ -214,6 +215,22 @@ private void validateBuildUrl(String sourceBuildUrl) {
   def jenkinsUrl = env.JENKINS_URL
   if (!jenkinsUrl || !sourceBuildUrl.startsWith(jenkinsUrl) || !(sourceBuildUrl ==~ /https?:\/\/[^\/]+\/job\/.+\/\d+\/$/)) {
     error("Refusing to archive an invalid Jenkins build URL: ${sourceBuildUrl}")
+  }
+}
+
+private void validateBuildIdentity(String sourceBuildUrl, String sourceJobName, String sourceBuildNumber) {
+  if (!(sourceBuildNumber ==~ /\d+/)) {
+    error("Refusing to archive an invalid Jenkins build number: ${sourceBuildNumber}")
+  }
+
+  def buildNumberFromUrl = (sourceBuildUrl =~ /\/(\d+)\/$/)[0][1]
+  if (buildNumberFromUrl != sourceBuildNumber) {
+    error("Refusing to archive mismatched Jenkins build details")
+  }
+
+  def jobSegments = sourceJobName.split('/', -1)
+  if (jobSegments.any { segment -> !segment || segment in ['.', '..'] }) {
+    error("Refusing to archive an invalid Jenkins job name: ${sourceJobName}")
   }
 }
 

--- a/vars/archiveCompletedBuild.groovy
+++ b/vars/archiveCompletedBuild.groovy
@@ -1,3 +1,5 @@
+import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
+
 def call(Map params = [:]) {
   def sourceBuildUrl = required(params, 'sourceBuildUrl')
   def sourceJobName = required(params, 'sourceJobName')
@@ -17,83 +19,99 @@ def call(Map params = [:]) {
   def storageCredentialsId = params.storageCredentialsId ?: env.BUILD_ARCHIVE_STORAGE_CREDENTIALS_ID ?: 'buildlog-storage-account'
   def storageContainer = params.storageContainer ?: env.BUILD_ARCHIVE_STORAGE_CONTAINER ?: 'jenkins-build-archive'
   def storagePrefix = params.storagePrefix ?: env.BUILD_ARCHIVE_STORAGE_PREFIX ?: 'builds'
+  def waitTimeoutMinutes = configuredTimeout(env.BUILD_ARCHIVE_WAIT_TIMEOUT_MINUTES, 300, 'BUILD_ARCHIVE_WAIT_TIMEOUT_MINUTES')
+  def operationTimeoutMinutes = configuredTimeout(env.BUILD_ARCHIVE_OPERATION_TIMEOUT_MINUTES, 120, 'BUILD_ARCHIVE_OPERATION_TIMEOUT_MINUTES')
+  def httpTimeoutSeconds = configuredTimeout(env.BUILD_ARCHIVE_HTTP_TIMEOUT_SECONDS, 1800, 'BUILD_ARCHIVE_HTTP_TIMEOUT_SECONDS')
 
   node(env.BUILD_ARCHIVE_AGENT ?: '') {
     try {
       deleteDir()
 
-      def buildMetadata = waitForBuildCompletion(buildApiUrl, jenkinsCredentialsId)
+      def buildMetadata = waitForBuildCompletion(
+        buildApiUrl,
+        jenkinsCredentialsId,
+        waitTimeoutMinutes,
+        httpTimeoutSeconds
+      )
       def buildDetails = readJSON(text: buildMetadata)
       def buildResult = (buildDetails.result ?: params.sourceBuildResult ?: 'UNKNOWN').toString().toUpperCase()
-      def workflowMetadata = buildResult == 'SUCCESS'
-        ? null
-        : getWorkflowMetadata(buildApiUrl, jenkinsCredentialsId)
-      def failedStage = findFailedStage(workflowMetadata)
-      def archiveName = archiveName(sourceBuildNumber, buildResult, failedStage)
-      def destination = "${storageContainer}/${storagePrefix}/${safeJobPath(sourceJobName)}"
+      if (buildResult != 'FAILURE') {
+        echo "Skipping build archive because final result is ${buildResult}"
+        return
+      }
 
-      dir(archiveName) {
-        writeFile(file: 'build.json', text: buildMetadata)
+      timeout(time: operationTimeoutMinutes, unit: 'MINUTES') {
+        def workflowMetadata = getWorkflowMetadata(buildApiUrl, jenkinsCredentialsId, httpTimeoutSeconds)
+        def failedStage = findFailedStage(workflowMetadata)
+        def archiveName = archiveName(sourceBuildNumber, buildResult, failedStage)
+        def destination = "${storageContainer}/${storagePrefix}/${safeJobPath(sourceJobName)}"
 
-        downloadRequired(
-          "${buildApiUrl}consoleText",
-          'console.txt',
-          jenkinsCredentialsId
-        )
+        dir(archiveName) {
+          writeFile(file: 'build.json', text: buildMetadata)
 
-        downloadOptional(
-          "${buildApiUrl}artifact/*zip*/archive.zip",
-          'artifacts.zip',
-          jenkinsCredentialsId
-        )
+          downloadRequired(
+            "${buildApiUrl}consoleText",
+            'console.txt',
+            jenkinsCredentialsId,
+            httpTimeoutSeconds
+          )
 
-        downloadOptional(
-          "${buildApiUrl}testReport/api/json",
-          'test-results.json',
-          jenkinsCredentialsId
-        )
+          downloadOptional(
+            "${buildApiUrl}artifact/*zip*/archive.zip",
+            'artifacts.zip',
+            jenkinsCredentialsId,
+            httpTimeoutSeconds
+          )
 
-        if (workflowMetadata) {
+          downloadOptional(
+            "${buildApiUrl}testReport/api/json",
+            'test-results.json',
+            jenkinsCredentialsId,
+            httpTimeoutSeconds
+          )
+
+          if (workflowMetadata) {
+            writeJSON(
+              file: 'workflow.json',
+              json: workflowMetadata,
+              pretty: 2
+            )
+          }
+
           writeJSON(
-            file: 'workflow.json',
-            json: workflowMetadata,
+            file: 'archive-metadata.json',
+            json: [
+              sourceBuildUrl: sourceBuildUrl,
+              sourceJobName: sourceJobName,
+              sourceBuildNumber: sourceBuildNumber,
+              sourceBuildResult: buildResult,
+              failedStage: failedStage ?: '',
+              sourceProduct: params.sourceProduct ?: '',
+              sourceComponent: params.sourceComponent ?: '',
+              archivedAt: sh(
+                script: "date -u '+%Y-%m-%dT%H:%M:%SZ'",
+                returnStdout: true
+              ).trim()
+            ],
             pretty: 2
           )
         }
 
-        writeJSON(
-          file: 'archive-metadata.json',
-          json: [
-            sourceBuildUrl: sourceBuildUrl,
-            sourceJobName: sourceJobName,
-            sourceBuildNumber: sourceBuildNumber,
-            sourceBuildResult: buildResult,
-            failedStage: failedStage ?: '',
-            sourceProduct: params.sourceProduct ?: '',
-            sourceComponent: params.sourceComponent ?: '',
-            archivedAt: sh(
-              script: "date -u '+%Y-%m-%dT%H:%M:%SZ'",
-              returnStdout: true
-            ).trim()
-          ],
-          pretty: 2
-        )
-      }
-
-      if (localOnly) {
-        archiveArtifacts(
-          allowEmptyArchive: false,
-          artifacts: "${archiveName}/**"
-        )
-        echo "Archived ${sourceJobName} #${sourceBuildNumber} in the local Jenkins archive"
-      } else {
-        azureBlobUpload(
-          storageSubscription,
-          storageCredentialsId,
-          archiveName,
-          destination
-        )
-        echo "Archived ${sourceJobName} #${sourceBuildNumber} to ${destination}"
+        if (localOnly) {
+          archiveArtifacts(
+            allowEmptyArchive: false,
+            artifacts: "${archiveName}/**"
+          )
+          echo "Archived ${sourceJobName} #${sourceBuildNumber} in the local Jenkins archive"
+        } else {
+          azureBlobUpload(
+            storageSubscription,
+            storageCredentialsId,
+            archiveName,
+            destination
+          )
+          echo "Archived ${sourceJobName} #${sourceBuildNumber} to ${destination}"
+        }
       }
     } finally {
       deleteDir()
@@ -101,11 +119,12 @@ def call(Map params = [:]) {
   }
 }
 
-private Map getWorkflowMetadata(String sourceBuildUrl, String credentialsId) {
+private Map getWorkflowMetadata(String sourceBuildUrl, String credentialsId, int httpTimeoutSeconds) {
   try {
     def request = [
       httpMode: 'GET',
       quiet: true,
+      timeout: httpTimeoutSeconds,
       url: "${sourceBuildUrl}wfapi/describe",
       validResponseCodes: '200,404'
     ]
@@ -113,6 +132,8 @@ private Map getWorkflowMetadata(String sourceBuildUrl, String credentialsId) {
     def response = httpRequest(request)
 
     response.status == 200 ? readJSON(text: response.content) as Map : null
+  } catch (FlowInterruptedException err) {
+    throw err
   } catch (err) {
     echo "Unable to determine failed build stage: ${err.message}"
     null
@@ -142,14 +163,20 @@ private String safeFileNamePart(String value) {
     .take(100) ?: 'unknown'
 }
 
-private String waitForBuildCompletion(String sourceBuildUrl, String credentialsId) {
+private String waitForBuildCompletion(
+  String sourceBuildUrl,
+  String credentialsId,
+  int waitTimeoutMinutes,
+  int httpTimeoutSeconds
+) {
   def completedBuildMetadata = null
 
-  timeout(time: 30, unit: 'MINUTES') {
+  timeout(time: waitTimeoutMinutes, unit: 'MINUTES') {
     waitUntil(initialRecurrencePeriod: 5000) {
       def request = [
         httpMode: 'GET',
         quiet: true,
+        timeout: httpTimeoutSeconds,
         url: "${sourceBuildUrl}api/json",
         validResponseCodes: '200'
       ]
@@ -169,11 +196,13 @@ private String waitForBuildCompletion(String sourceBuildUrl, String credentialsI
   completedBuildMetadata
 }
 
-private void downloadRequired(String url, String outputFile, String credentialsId) {
+private void downloadRequired(String url, String outputFile, String credentialsId, int httpTimeoutSeconds) {
   def request = [
     httpMode: 'GET',
     outputFile: outputFile,
     quiet: true,
+    responseHandle: 'NONE',
+    timeout: httpTimeoutSeconds,
     url: url,
     validResponseCodes: '200'
   ]
@@ -181,11 +210,13 @@ private void downloadRequired(String url, String outputFile, String credentialsI
   httpRequest(request)
 }
 
-private void downloadOptional(String url, String outputFile, String credentialsId) {
+private void downloadOptional(String url, String outputFile, String credentialsId, int httpTimeoutSeconds) {
   def request = [
     httpMode: 'GET',
     outputFile: outputFile,
     quiet: true,
+    responseHandle: 'NONE',
+    timeout: httpTimeoutSeconds,
     url: url,
     validResponseCodes: '200,404'
   ]
@@ -201,6 +232,14 @@ private void addAuthentication(Map request, String credentialsId) {
   if (credentialsId) {
     request.authentication = credentialsId
   }
+}
+
+private int configuredTimeout(def value, int defaultValue, String variableName) {
+  def configuredValue = value ?: defaultValue.toString()
+  if (!(configuredValue.toString() ==~ /\d+/) || configuredValue.toString().toInteger() < 1) {
+    error("${variableName} must be a positive integer")
+  }
+  configuredValue.toString().toInteger()
 }
 
 private String required(Map params, String name) {

--- a/vars/archiveCompletedBuild.groovy
+++ b/vars/archiveCompletedBuild.groovy
@@ -16,16 +16,22 @@ def call(Map params = [:]) {
   def storageCredentialsId = params.storageCredentialsId ?: env.BUILD_ARCHIVE_STORAGE_CREDENTIALS_ID ?: 'buildlog-storage-account'
   def storageContainer = params.storageContainer ?: env.BUILD_ARCHIVE_STORAGE_CONTAINER ?: 'jenkins-build-archive'
   def storagePrefix = params.storagePrefix ?: env.BUILD_ARCHIVE_STORAGE_PREFIX ?: 'builds'
-  def archiveDirectory = "completed-build-${sourceBuildNumber}"
-  def destination = "${storageContainer}/${storagePrefix}/${safeJobPath(sourceJobName)}/${sourceBuildNumber}"
 
   node(env.BUILD_ARCHIVE_AGENT ?: '') {
     try {
       deleteDir()
 
       def buildMetadata = waitForBuildCompletion(buildApiUrl, jenkinsCredentialsId)
+      def buildDetails = readJSON(text: buildMetadata)
+      def buildResult = (buildDetails.result ?: params.sourceBuildResult ?: 'UNKNOWN').toString().toUpperCase()
+      def workflowMetadata = buildResult == 'SUCCESS'
+        ? null
+        : getWorkflowMetadata(buildApiUrl, jenkinsCredentialsId)
+      def failedStage = findFailedStage(workflowMetadata)
+      def archiveName = archiveName(sourceBuildNumber, buildResult, failedStage)
+      def destination = "${storageContainer}/${storagePrefix}/${safeJobPath(sourceJobName)}/${archiveName}"
 
-      dir(archiveDirectory) {
+      dir(archiveName) {
         writeFile(file: 'build.json', text: buildMetadata)
 
         downloadRequired(
@@ -46,13 +52,22 @@ def call(Map params = [:]) {
           jenkinsCredentialsId
         )
 
+        if (workflowMetadata) {
+          writeJSON(
+            file: 'workflow.json',
+            json: workflowMetadata,
+            pretty: 2
+          )
+        }
+
         writeJSON(
           file: 'archive-metadata.json',
           json: [
             sourceBuildUrl: sourceBuildUrl,
             sourceJobName: sourceJobName,
             sourceBuildNumber: sourceBuildNumber,
-            sourceBuildResult: params.sourceBuildResult ?: '',
+            sourceBuildResult: buildResult,
+            failedStage: failedStage ?: '',
             sourceProduct: params.sourceProduct ?: '',
             sourceComponent: params.sourceComponent ?: '',
             archivedAt: sh(
@@ -67,14 +82,14 @@ def call(Map params = [:]) {
       if (localOnly) {
         archiveArtifacts(
           allowEmptyArchive: false,
-          artifacts: "${archiveDirectory}/**"
+          artifacts: "${archiveName}/**"
         )
         echo "Archived ${sourceJobName} #${sourceBuildNumber} in the local Jenkins archive"
       } else {
         azureBlobUpload(
           storageSubscription,
           storageCredentialsId,
-          archiveDirectory,
+          archiveName,
           destination
         )
         echo "Archived ${sourceJobName} #${sourceBuildNumber} to ${destination}"
@@ -83,6 +98,47 @@ def call(Map params = [:]) {
       deleteDir()
     }
   }
+}
+
+private Map getWorkflowMetadata(String sourceBuildUrl, String credentialsId) {
+  try {
+    def request = [
+      httpMode: 'GET',
+      quiet: true,
+      url: "${sourceBuildUrl}wfapi/describe",
+      validResponseCodes: '200,404'
+    ]
+    addAuthentication(request, credentialsId)
+    def response = httpRequest(request)
+
+    response.status == 200 ? readJSON(text: response.content) as Map : null
+  } catch (err) {
+    echo "Unable to determine failed build stage: ${err.message}"
+    null
+  }
+}
+
+private String findFailedStage(Map workflowMetadata) {
+  def failedStage = workflowMetadata?.stages?.find { stage ->
+    stage.status?.toString()?.toUpperCase() in ['FAILED', 'FAILURE', 'UNSTABLE', 'ABORTED']
+  }
+
+  failedStage?.name?.toString()
+}
+
+private String archiveName(String buildNumber, String buildResult, String failedStage) {
+  def parts = ['completed-build', safeFileNamePart(buildNumber), safeFileNamePart(buildResult)]
+  if (failedStage) {
+    parts << safeFileNamePart(failedStage)
+  }
+  parts.join('_')
+}
+
+private String safeFileNamePart(String value) {
+  value
+    .replaceAll(/[^A-Za-z0-9.-]+/, '_')
+    .replaceAll(/^_+|_+$/, '')
+    .take(100) ?: 'unknown'
 }
 
 private String waitForBuildCompletion(String sourceBuildUrl, String credentialsId) {

--- a/vars/archiveCompletedBuild.groovy
+++ b/vars/archiveCompletedBuild.groovy
@@ -1,0 +1,182 @@
+def call(Map params = [:]) {
+  def sourceBuildUrl = required(params, 'sourceBuildUrl')
+  def sourceJobName = required(params, 'sourceJobName')
+  def sourceBuildNumber = required(params, 'sourceBuildNumber')
+  def localOnly = params.localOnly == true || env.BUILD_ARCHIVE_LOCAL_ONLY == 'true'
+
+  def jenkinsCredentialsId = params.jenkinsCredentialsId ?: env.BUILD_ARCHIVE_JENKINS_CREDENTIALS_ID
+  if (!jenkinsCredentialsId && !localOnly) {
+    error('A Jenkins API credential is required in BUILD_ARCHIVE_JENKINS_CREDENTIALS_ID')
+  }
+
+  validateBuildUrl(sourceBuildUrl)
+
+  def buildApiUrl = apiBuildUrl(sourceBuildUrl)
+  def storageSubscription = params.storageSubscription ?: env.BUILD_ARCHIVE_STORAGE_SUBSCRIPTION ?: 'DCD-CFT-Sandbox'
+  def storageCredentialsId = params.storageCredentialsId ?: env.BUILD_ARCHIVE_STORAGE_CREDENTIALS_ID ?: 'buildlog-storage-account'
+  def storageContainer = params.storageContainer ?: env.BUILD_ARCHIVE_STORAGE_CONTAINER ?: 'jenkins-build-archive'
+  def storagePrefix = params.storagePrefix ?: env.BUILD_ARCHIVE_STORAGE_PREFIX ?: 'builds'
+  def archiveDirectory = "completed-build-${sourceBuildNumber}"
+  def destination = "${storageContainer}/${storagePrefix}/${safeJobPath(sourceJobName)}/${sourceBuildNumber}"
+
+  node(env.BUILD_ARCHIVE_AGENT ?: '') {
+    try {
+      deleteDir()
+
+      def buildMetadata = waitForBuildCompletion(buildApiUrl, jenkinsCredentialsId)
+
+      dir(archiveDirectory) {
+        writeFile(file: 'build.json', text: buildMetadata)
+
+        downloadRequired(
+          "${buildApiUrl}consoleText",
+          'console.txt',
+          jenkinsCredentialsId
+        )
+
+        downloadOptional(
+          "${buildApiUrl}artifact/*zip*/archive.zip",
+          'artifacts.zip',
+          jenkinsCredentialsId
+        )
+
+        downloadOptional(
+          "${buildApiUrl}testReport/api/json",
+          'test-results.json',
+          jenkinsCredentialsId
+        )
+
+        writeJSON(
+          file: 'archive-metadata.json',
+          json: [
+            sourceBuildUrl: sourceBuildUrl,
+            sourceJobName: sourceJobName,
+            sourceBuildNumber: sourceBuildNumber,
+            sourceBuildResult: params.sourceBuildResult ?: '',
+            sourceProduct: params.sourceProduct ?: '',
+            sourceComponent: params.sourceComponent ?: '',
+            archivedAt: sh(
+              script: "date -u '+%Y-%m-%dT%H:%M:%SZ'",
+              returnStdout: true
+            ).trim()
+          ],
+          pretty: 2
+        )
+      }
+
+      if (localOnly) {
+        archiveArtifacts(
+          allowEmptyArchive: false,
+          artifacts: "${archiveDirectory}/**"
+        )
+        echo "Archived ${sourceJobName} #${sourceBuildNumber} in the local Jenkins archive"
+      } else {
+        azureBlobUpload(
+          storageSubscription,
+          storageCredentialsId,
+          archiveDirectory,
+          destination
+        )
+        echo "Archived ${sourceJobName} #${sourceBuildNumber} to ${destination}"
+      }
+    } finally {
+      deleteDir()
+    }
+  }
+}
+
+private String waitForBuildCompletion(String sourceBuildUrl, String credentialsId) {
+  def completedBuildMetadata = null
+
+  timeout(time: 30, unit: 'MINUTES') {
+    waitUntil(initialRecurrencePeriod: 5000) {
+      def request = [
+        httpMode: 'GET',
+        quiet: true,
+        url: "${sourceBuildUrl}api/json",
+        validResponseCodes: '200'
+      ]
+      addAuthentication(request, credentialsId)
+      def response = httpRequest(request)
+      def metadata = readJSON(text: response.content)
+
+      if (metadata.building) {
+        return false
+      }
+
+      completedBuildMetadata = response.content
+      return true
+    }
+  }
+
+  completedBuildMetadata
+}
+
+private void downloadRequired(String url, String outputFile, String credentialsId) {
+  def request = [
+    httpMode: 'GET',
+    outputFile: outputFile,
+    quiet: true,
+    url: url,
+    validResponseCodes: '200'
+  ]
+  addAuthentication(request, credentialsId)
+  httpRequest(request)
+}
+
+private void downloadOptional(String url, String outputFile, String credentialsId) {
+  def request = [
+    httpMode: 'GET',
+    outputFile: outputFile,
+    quiet: true,
+    url: url,
+    validResponseCodes: '200,404'
+  ]
+  addAuthentication(request, credentialsId)
+  def response = httpRequest(request)
+
+  if (response.status == 404) {
+    sh(label: "Remove missing ${outputFile}", script: "rm -f '${outputFile}'")
+  }
+}
+
+private void addAuthentication(Map request, String credentialsId) {
+  if (credentialsId) {
+    request.authentication = credentialsId
+  }
+}
+
+private String required(Map params, String name) {
+  def value = params[name]
+  if (!value) {
+    error("Missing required build archive parameter: ${name}")
+  }
+  value.toString()
+}
+
+private void validateBuildUrl(String sourceBuildUrl) {
+  def jenkinsUrl = env.JENKINS_URL
+  if (!jenkinsUrl || !sourceBuildUrl.startsWith(jenkinsUrl) || !(sourceBuildUrl ==~ /https?:\/\/[^\/]+\/job\/.+\/\d+\/$/)) {
+    error("Refusing to archive an invalid Jenkins build URL: ${sourceBuildUrl}")
+  }
+}
+
+private String apiBuildUrl(String sourceBuildUrl) {
+  def apiBaseUrl = env.BUILD_ARCHIVE_JENKINS_API_URL
+  if (!apiBaseUrl) {
+    return sourceBuildUrl
+  }
+
+  if (!(apiBaseUrl ==~ /https?:\/\/[^\/]+(?::\d+)?\/$/)) {
+    error("Refusing to use an invalid Jenkins API base URL: ${apiBaseUrl}")
+  }
+
+  "${apiBaseUrl}${sourceBuildUrl.substring(env.JENKINS_URL.length())}"
+}
+
+private String safeJobPath(String sourceJobName) {
+  sourceJobName
+    .tokenize('/')
+    .collect { segment -> segment.replaceAll(/[^A-Za-z0-9._-]/, '_') }
+    .join('/')
+}

--- a/vars/archiveCompletedBuild.groovy
+++ b/vars/archiveCompletedBuild.groovy
@@ -30,7 +30,7 @@ def call(Map params = [:]) {
         : getWorkflowMetadata(buildApiUrl, jenkinsCredentialsId)
       def failedStage = findFailedStage(workflowMetadata)
       def archiveName = archiveName(sourceBuildNumber, buildResult, failedStage)
-      def destination = "${storageContainer}/${storagePrefix}/${safeJobPath(sourceJobName)}/${archiveName}"
+      def destination = "${storageContainer}/${storagePrefix}/${safeJobPath(sourceJobName)}"
 
       dir(archiveName) {
         writeFile(file: 'build.json', text: buildMetadata)

--- a/vars/archiveCompletedBuild.groovy
+++ b/vars/archiveCompletedBuild.groovy
@@ -1,39 +1,42 @@
-import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
+import hudson.FilePath
+import uk.gov.hmcts.contino.CompletedBuildReader
 
 def call(Map params = [:]) {
   def sourceBuildUrl = required(params, 'sourceBuildUrl')
   def sourceJobName = required(params, 'sourceJobName')
   def sourceBuildNumber = required(params, 'sourceBuildNumber')
   def localOnly = params.localOnly == true || env.BUILD_ARCHIVE_LOCAL_ONLY == 'true'
-
-  def jenkinsCredentialsId = params.jenkinsCredentialsId ?: env.BUILD_ARCHIVE_JENKINS_CREDENTIALS_ID
-  if (!jenkinsCredentialsId && !localOnly) {
-    error('A Jenkins API credential is required in BUILD_ARCHIVE_JENKINS_CREDENTIALS_ID')
-  }
+  def buildReader = params.buildReader ?: new CompletedBuildReader()
 
   validateBuildUrl(sourceBuildUrl)
   validateBuildIdentity(sourceBuildUrl, sourceJobName, sourceBuildNumber)
 
-  def buildApiUrl = apiBuildUrl(sourceBuildUrl)
   def storageSubscription = params.storageSubscription ?: env.BUILD_ARCHIVE_STORAGE_SUBSCRIPTION ?: 'sandbox'
-  def storageCredentialsId = params.storageCredentialsId ?: env.BUILD_ARCHIVE_STORAGE_CREDENTIALS_ID ?: 'buildlog-storage-account'
+  def storageCredentialsId = params.storageCredentialsId ?: env.BUILD_ARCHIVE_STORAGE_CREDENTIALS_ID ?:
+    'buildlog-storage-account'
   def storageContainer = params.storageContainer ?: env.BUILD_ARCHIVE_STORAGE_CONTAINER ?: 'jenkins-build-archive'
   def storagePrefix = params.storagePrefix ?: env.BUILD_ARCHIVE_STORAGE_PREFIX ?: 'builds'
-  def waitTimeoutMinutes = configuredTimeout(env.BUILD_ARCHIVE_WAIT_TIMEOUT_MINUTES, 300, 'BUILD_ARCHIVE_WAIT_TIMEOUT_MINUTES')
-  def operationTimeoutMinutes = configuredTimeout(env.BUILD_ARCHIVE_OPERATION_TIMEOUT_MINUTES, 120, 'BUILD_ARCHIVE_OPERATION_TIMEOUT_MINUTES')
-  def httpTimeoutSeconds = configuredTimeout(env.BUILD_ARCHIVE_HTTP_TIMEOUT_SECONDS, 1800, 'BUILD_ARCHIVE_HTTP_TIMEOUT_SECONDS')
+  def waitTimeoutMinutes = configuredTimeout(
+    env.BUILD_ARCHIVE_WAIT_TIMEOUT_MINUTES,
+    300,
+    'BUILD_ARCHIVE_WAIT_TIMEOUT_MINUTES'
+  )
+  def operationTimeoutMinutes = configuredTimeout(
+    env.BUILD_ARCHIVE_OPERATION_TIMEOUT_MINUTES,
+    120,
+    'BUILD_ARCHIVE_OPERATION_TIMEOUT_MINUTES'
+  )
 
   node(env.BUILD_ARCHIVE_AGENT ?: '') {
     try {
       deleteDir()
 
-      def buildMetadata = waitForBuildCompletion(
-        buildApiUrl,
-        jenkinsCredentialsId,
-        waitTimeoutMinutes,
-        httpTimeoutSeconds
+      def buildDetails = waitForBuildCompletion(
+        buildReader,
+        sourceJobName,
+        sourceBuildNumber,
+        waitTimeoutMinutes
       )
-      def buildDetails = readJSON(text: buildMetadata)
       def buildResult = (buildDetails.result ?: params.sourceBuildResult ?: 'UNKNOWN').toString().toUpperCase()
       if (buildResult != 'FAILURE') {
         echo "Skipping build archive because final result is ${buildResult}"
@@ -41,34 +44,31 @@ def call(Map params = [:]) {
       }
 
       timeout(time: operationTimeoutMinutes, unit: 'MINUTES') {
-        def workflowMetadata = getWorkflowMetadata(buildApiUrl, jenkinsCredentialsId, httpTimeoutSeconds)
+        def workflowMetadata = buildDetails.workflow as Map
         def failedStage = findFailedStage(workflowMetadata)
         def archiveName = archiveName(sourceBuildNumber, buildResult, failedStage)
         def destination = "${storageContainer}/${storagePrefix}/${safeJobPath(sourceJobName)}"
 
         dir(archiveName) {
-          writeFile(file: 'build.json', text: buildMetadata)
-
-          downloadRequired(
-            "${buildApiUrl}consoleText",
-            'console.txt',
-            jenkinsCredentialsId,
-            httpTimeoutSeconds
+          writeJSON(
+            file: 'build.json',
+            json: buildDetails.findAll { key, _ -> !(key in ['workflow', 'tests']) },
+            pretty: 2
           )
 
-          downloadOptional(
-            "${buildApiUrl}artifact/*zip*/archive.zip",
-            'artifacts.zip',
-            jenkinsCredentialsId,
-            httpTimeoutSeconds
+          buildReader.copyOutputs(
+            sourceJobName,
+            sourceBuildNumber.toInteger(),
+            getContext(FilePath)
           )
 
-          downloadOptional(
-            "${buildApiUrl}testReport/api/json",
-            'test-results.json',
-            jenkinsCredentialsId,
-            httpTimeoutSeconds
-          )
+          if (buildDetails.tests) {
+            writeJSON(
+              file: 'test-results.json',
+              json: buildDetails.tests,
+              pretty: 2
+            )
+          }
 
           if (workflowMetadata) {
             writeJSON(
@@ -119,25 +119,27 @@ def call(Map params = [:]) {
   }
 }
 
-private Map getWorkflowMetadata(String sourceBuildUrl, String credentialsId, int httpTimeoutSeconds) {
-  try {
-    def request = [
-      httpMode: 'GET',
-      quiet: true,
-      timeout: httpTimeoutSeconds,
-      url: "${sourceBuildUrl}wfapi/describe",
-      validResponseCodes: '200,404'
-    ]
-    addAuthentication(request, credentialsId)
-    def response = httpRequest(request)
+private Map waitForBuildCompletion(
+  def buildReader,
+  String sourceJobName,
+  String sourceBuildNumber,
+  int waitTimeoutMinutes
+) {
+  def completedBuildMetadata = null
 
-    response.status == 200 ? readJSON(text: response.content) as Map : null
-  } catch (FlowInterruptedException err) {
-    throw err
-  } catch (err) {
-    echo "Unable to determine failed build stage: ${err.message}"
-    null
+  timeout(time: waitTimeoutMinutes, unit: 'MINUTES') {
+    waitUntil(initialRecurrencePeriod: 5000) {
+      def metadata = buildReader.snapshot(sourceJobName, sourceBuildNumber.toInteger())
+      if (metadata.building) {
+        return false
+      }
+
+      completedBuildMetadata = metadata
+      return true
+    }
   }
+
+  completedBuildMetadata
 }
 
 private String findFailedStage(Map workflowMetadata) {
@@ -163,77 +165,6 @@ private String safeFileNamePart(String value) {
     .take(100) ?: 'unknown'
 }
 
-private String waitForBuildCompletion(
-  String sourceBuildUrl,
-  String credentialsId,
-  int waitTimeoutMinutes,
-  int httpTimeoutSeconds
-) {
-  def completedBuildMetadata = null
-
-  timeout(time: waitTimeoutMinutes, unit: 'MINUTES') {
-    waitUntil(initialRecurrencePeriod: 5000) {
-      def request = [
-        httpMode: 'GET',
-        quiet: true,
-        timeout: httpTimeoutSeconds,
-        url: "${sourceBuildUrl}api/json",
-        validResponseCodes: '200'
-      ]
-      addAuthentication(request, credentialsId)
-      def response = httpRequest(request)
-      def metadata = readJSON(text: response.content)
-
-      if (metadata.building) {
-        return false
-      }
-
-      completedBuildMetadata = response.content
-      return true
-    }
-  }
-
-  completedBuildMetadata
-}
-
-private void downloadRequired(String url, String outputFile, String credentialsId, int httpTimeoutSeconds) {
-  def request = [
-    httpMode: 'GET',
-    outputFile: outputFile,
-    quiet: true,
-    responseHandle: 'NONE',
-    timeout: httpTimeoutSeconds,
-    url: url,
-    validResponseCodes: '200'
-  ]
-  addAuthentication(request, credentialsId)
-  httpRequest(request)
-}
-
-private void downloadOptional(String url, String outputFile, String credentialsId, int httpTimeoutSeconds) {
-  def request = [
-    httpMode: 'GET',
-    outputFile: outputFile,
-    quiet: true,
-    responseHandle: 'NONE',
-    timeout: httpTimeoutSeconds,
-    url: url,
-    validResponseCodes: '200,404'
-  ]
-  addAuthentication(request, credentialsId)
-  def response = httpRequest(request)
-
-  if (response.status == 404) {
-    sh(label: "Remove missing ${outputFile}", script: "rm -f '${outputFile}'")
-  }
-}
-
-private void addAuthentication(Map request, String credentialsId) {
-  if (credentialsId) {
-    request.authentication = credentialsId
-  }
-}
-
 private int configuredTimeout(def value, int defaultValue, String variableName) {
   def configuredValue = value ?: defaultValue.toString()
   if (!(configuredValue.toString() ==~ /\d+/) || configuredValue.toString().toInteger() < 1) {
@@ -252,7 +183,8 @@ private String required(Map params, String name) {
 
 private void validateBuildUrl(String sourceBuildUrl) {
   def jenkinsUrl = env.JENKINS_URL
-  if (!jenkinsUrl || !sourceBuildUrl.startsWith(jenkinsUrl) || !(sourceBuildUrl ==~ /https?:\/\/[^\/]+\/job\/.+\/\d+\/$/)) {
+  if (!jenkinsUrl || !sourceBuildUrl.startsWith(jenkinsUrl) ||
+    !(sourceBuildUrl ==~ /https?:\/\/[^\/]+\/job\/.+\/\d+\/$/)) {
     error("Refusing to archive an invalid Jenkins build URL: ${sourceBuildUrl}")
   }
 }
@@ -266,7 +198,7 @@ private void validateBuildIdentity(String sourceBuildUrl, String sourceJobName, 
   def buildUrlParts = relativeBuildUrl =~ /^job\/(.+)\/(\d+)\/$/
   def buildNumberFromUrl = buildUrlParts[0][2]
   if (buildNumberFromUrl != sourceBuildNumber) {
-    error("Refusing to archive mismatched Jenkins build details")
+    error('Refusing to archive mismatched Jenkins build details')
   }
 
   def jobSegments = sourceJobName.split('/', -1)
@@ -279,21 +211,8 @@ private void validateBuildIdentity(String sourceBuildUrl, String sourceJobName, 
     .collect { segment -> new URI("https://jenkins.invalid/${segment}").path.substring(1) }
     .join('/')
   if (jobNameFromUrl != sourceJobName) {
-    error("Refusing to archive mismatched Jenkins build details")
+    error('Refusing to archive mismatched Jenkins build details')
   }
-}
-
-private String apiBuildUrl(String sourceBuildUrl) {
-  def apiBaseUrl = env.BUILD_ARCHIVE_JENKINS_API_URL
-  if (!apiBaseUrl) {
-    return sourceBuildUrl
-  }
-
-  if (!(apiBaseUrl ==~ /https?:\/\/[^\/]+(?::\d+)?\/$/)) {
-    error("Refusing to use an invalid Jenkins API base URL: ${apiBaseUrl}")
-  }
-
-  "${apiBaseUrl}${sourceBuildUrl.substring(env.JENKINS_URL.length())}"
 }
 
 private String safeJobPath(String sourceJobName) {

--- a/vars/azureBlobUpload.groovy
+++ b/vars/azureBlobUpload.groovy
@@ -1,12 +1,10 @@
 def call(String subscription, String credentialsId, String source, String destination) {
     withCredentials([usernamePassword(credentialsId: credentialsId, passwordVariable: 'STORAGE_ACCOUNT_KEY', usernameVariable: 'STORAGE_ACCOUNT_NAME')]) {
-      withSubscriptionLogin(subscription) {
-        withEnv(["SOURCE=${source}", "DESTINATION=${destination}"]) {
-          sh 'export AZCOPY_AUTO_LOGIN_TYPE=MSI && \
-          azcopy cp ${SOURCE} \
-            https://${STORAGE_ACCOUNT_NAME}.blob.core.windows.net/${DESTINATION} \
-            --recursive=true'
-        }
+      withEnv(["SOURCE=${source}", "DESTINATION=${destination}"]) {
+        sh 'export AZCOPY_AUTO_LOGIN_TYPE=MSI && \
+        azcopy cp ${SOURCE} \
+          https://${STORAGE_ACCOUNT_NAME}.blob.core.windows.net/${DESTINATION} \
+          --recursive=true'
       }
     }
 }

--- a/vars/queueBuildArchive.groovy
+++ b/vars/queueBuildArchive.groovy
@@ -1,9 +1,5 @@
 def call(Map params = [:]) {
-  def archiveJob = env.BUILD_ARCHIVE_JOB
-
-  if (!archiveJob) {
-    return
-  }
+  def archiveJob = 'Archive Completed Builds'
 
   if (env.JOB_NAME == archiveJob) {
     echo "Skipping build archive trigger for the archive job itself"

--- a/vars/queueBuildArchive.groovy
+++ b/vars/queueBuildArchive.groovy
@@ -1,3 +1,5 @@
+import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
+
 def call(Map params = [:]) {
   def archiveJob = '/Archive Completed Builds'
   def buildResult = currentBuild.result ?: currentBuild.currentResult ?: 'SUCCESS'
@@ -37,6 +39,8 @@ def call(Map params = [:]) {
     )
     env.BUILD_ARCHIVE_QUEUED = 'true'
     echo "Queued build archive for ${env.JOB_NAME} #${env.BUILD_NUMBER}"
+  } catch (FlowInterruptedException err) {
+    throw err
   } catch (err) {
     echo "Unable to queue build archive: ${err.message}"
   }

--- a/vars/queueBuildArchive.groovy
+++ b/vars/queueBuildArchive.groovy
@@ -1,12 +1,17 @@
 def call(Map params = [:]) {
-  def archiveJob = 'Archive Completed Builds'
+  def archiveJob = '/Archive Completed Builds'
   def buildResult = currentBuild.result ?: currentBuild.currentResult ?: 'SUCCESS'
 
   if (buildResult != 'FAILURE') {
     return
   }
 
-  if (env.JOB_NAME == archiveJob) {
+  if (env.BUILD_ARCHIVE_QUEUED == 'true') {
+    echo "Skipping duplicate build archive trigger"
+    return
+  }
+
+  if (env.JOB_NAME == archiveJob.substring(1)) {
     echo "Skipping build archive trigger for the archive job itself"
     return
   }
@@ -30,6 +35,7 @@ def call(Map params = [:]) {
         string(name: 'SOURCE_COMPONENT', value: params.component ?: '')
       ]
     )
+    env.BUILD_ARCHIVE_QUEUED = 'true'
     echo "Queued build archive for ${env.JOB_NAME} #${env.BUILD_NUMBER}"
   } catch (err) {
     echo "Unable to queue build archive: ${err.message}"

--- a/vars/queueBuildArchive.groovy
+++ b/vars/queueBuildArchive.groovy
@@ -1,5 +1,10 @@
 def call(Map params = [:]) {
   def archiveJob = 'Archive Completed Builds'
+  def buildResult = currentBuild.result ?: currentBuild.currentResult ?: 'SUCCESS'
+
+  if (buildResult != 'FAILURE') {
+    return
+  }
 
   if (env.JOB_NAME == archiveJob) {
     echo "Skipping build archive trigger for the archive job itself"
@@ -20,7 +25,7 @@ def call(Map params = [:]) {
         string(name: 'SOURCE_BUILD_URL', value: env.BUILD_URL),
         string(name: 'SOURCE_JOB_NAME', value: env.JOB_NAME),
         string(name: 'SOURCE_BUILD_NUMBER', value: env.BUILD_NUMBER),
-        string(name: 'SOURCE_BUILD_RESULT', value: currentBuild.result ?: 'SUCCESS'),
+        string(name: 'SOURCE_BUILD_RESULT', value: buildResult),
         string(name: 'SOURCE_PRODUCT', value: params.product ?: ''),
         string(name: 'SOURCE_COMPONENT', value: params.component ?: '')
       ]

--- a/vars/queueBuildArchive.groovy
+++ b/vars/queueBuildArchive.groovy
@@ -1,0 +1,36 @@
+def call(Map params = [:]) {
+  def archiveJob = env.BUILD_ARCHIVE_JOB
+
+  if (!archiveJob) {
+    return
+  }
+
+  if (env.JOB_NAME == archiveJob) {
+    echo "Skipping build archive trigger for the archive job itself"
+    return
+  }
+
+  if (!env.BUILD_URL || !env.JOB_NAME || !env.BUILD_NUMBER) {
+    echo "Skipping build archive because Jenkins build metadata is incomplete"
+    return
+  }
+
+  try {
+    build(
+      job: archiveJob,
+      wait: false,
+      propagate: false,
+      parameters: [
+        string(name: 'SOURCE_BUILD_URL', value: env.BUILD_URL),
+        string(name: 'SOURCE_JOB_NAME', value: env.JOB_NAME),
+        string(name: 'SOURCE_BUILD_NUMBER', value: env.BUILD_NUMBER),
+        string(name: 'SOURCE_BUILD_RESULT', value: currentBuild.result ?: 'SUCCESS'),
+        string(name: 'SOURCE_PRODUCT', value: params.product ?: ''),
+        string(name: 'SOURCE_COMPONENT', value: params.component ?: '')
+      ]
+    )
+    echo "Queued build archive for ${env.JOB_NAME} #${env.BUILD_NUMBER}"
+  } catch (err) {
+    echo "Unable to queue build archive: ${err.message}"
+  }
+}

--- a/vars/withNightlyPipeline.groovy
+++ b/vars/withNightlyPipeline.groovy
@@ -12,6 +12,7 @@ import uk.gov.hmcts.contino.PipelineCallbacksConfig
 import uk.gov.hmcts.contino.PipelineCallbacksRunner
 import uk.gov.hmcts.pipeline.TeamConfig
 import uk.gov.hmcts.pipeline.LibraryBranchControls
+import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
 
 def call(type, product, component, timeout = 300, Closure body) {
 
@@ -84,6 +85,9 @@ def call(type, product, component, timeout = 300, Closure body) {
           }
         }
         assert  pipelineType!= null
+      } catch (FlowInterruptedException err) {
+        currentBuild.result = err.result.toString()
+        throw err
       } catch (err) {
         currentBuild.result = "FAILURE"
         notifyBuildFailure channel: slackChannel

--- a/vars/withNightlyPipeline.groovy
+++ b/vars/withNightlyPipeline.groovy
@@ -93,8 +93,10 @@ def call(type, product, component, timeout = 300, Closure body) {
         throw err
       } finally {
         notifyPipelineDeprecations(slackChannel, metricsPublisher)
-        archiveBuildOutputs()
-        queueBuildArchive(product: product, component: component)
+        if ((currentBuild.result ?: currentBuild.currentResult) == 'FAILURE') {
+          archiveBuildOutputs()
+          queueBuildArchive(product: product, component: component)
+        }
         deleteDir()
       }
 

--- a/vars/withNightlyPipeline.groovy
+++ b/vars/withNightlyPipeline.groovy
@@ -93,6 +93,8 @@ def call(type, product, component, timeout = 300, Closure body) {
         throw err
       } finally {
         notifyPipelineDeprecations(slackChannel, metricsPublisher)
+        archiveBuildOutputs()
+        queueBuildArchive(product: product, component: component)
         deleteDir()
       }
 

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -154,6 +154,10 @@ def call(type, String product, String component, Closure body) {
           throw err
         } finally {
           notifyPipelineDeprecations(slackChannel, metricsPublisher)
+          if (env.BUILD_ARCHIVE_JOB) {
+            archiveBuildOutputs()
+            queueBuildArchive(product: product, component: component)
+          }
           if (env.KEEP_DIR_FOR_DEBUGGING != "true") {
             deleteDir()
           }

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -154,10 +154,8 @@ def call(type, String product, String component, Closure body) {
           throw err
         } finally {
           notifyPipelineDeprecations(slackChannel, metricsPublisher)
-          if (env.BUILD_ARCHIVE_JOB) {
-            archiveBuildOutputs()
-            queueBuildArchive(product: product, component: component)
-          }
+          archiveBuildOutputs()
+          queueBuildArchive(product: product, component: component)
           if (env.KEEP_DIR_FOR_DEBUGGING != "true") {
             deleteDir()
           }

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -18,6 +18,7 @@ import uk.gov.hmcts.pipeline.TeamConfig
 import uk.gov.hmcts.contino.GithubAPI
 import uk.gov.hmcts.pipeline.DeprecationConfig
 import uk.gov.hmcts.pipeline.LibraryBranchControls
+import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
 
 def call(type, String product, String component, Closure body) {
 
@@ -140,6 +141,9 @@ def call(type, String product, String component, Closure body) {
             }
           } // end approvedDeploymentRepository
 
+        } catch (FlowInterruptedException err) {
+          currentBuild.result = err.result.toString()
+          throw err
         } catch (err) {
           if (err.message != null && err.message.startsWith('AUTO_ABORT')) {
             currentBuild.result = 'ABORTED'

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -72,106 +72,116 @@ def call(type, String product, String component, Closure body) {
   String agentType = env.BUILD_AGENT_TYPE
 
   def libraryBranchAllowed = new LibraryBranchControls(this).isBranchAllowed(pipelineConfig)
+  def slackChannel = env.BUILD_NOTICES_SLACK_CHANNEL
 
-  retry(conditions: [agent()], count: 2) {
-    node(agentType) {
-      timeoutWithMsg(time: 180, unit: 'MINUTES', action: 'pipeline') {
-        def slackChannel = env.BUILD_NOTICES_SLACK_CHANNEL
-        try {
-          if (!libraryBranchAllowed) {
-            currentBuild.result = "FAILURE"
-            return
-          }
+  try {
+    retry(conditions: [agent()], count: 2) {
+      node(agentType) {
+        timeoutWithMsg(time: 180, unit: 'MINUTES', action: 'pipeline') {
+          def attemptFailed = false
+          try {
+            if (!libraryBranchAllowed) {
+              currentBuild.result = "FAILURE"
+              return
+            }
 
-          dockerAgentSetup()
-          env.PATH = "$env.PATH:/usr/local/bin"
+            dockerAgentSetup()
+            env.PATH = "$env.PATH:/usr/local/bin"
 
-          def deploymentEnabled = sectionBuildAndTest(
-            appPipelineConfig: pipelineConfig,
-            pipelineCallbacksRunner: callbacksRunner,
-            builder: pipelineType.builder,
-            subscription: subscription.nonProdName,
-            environment: environment.nonProdName,
-            product: product,
-            component: component
-          )
+            def deploymentEnabled = sectionBuildAndTest(
+              appPipelineConfig: pipelineConfig,
+              pipelineCallbacksRunner: callbacksRunner,
+              builder: pipelineType.builder,
+              subscription: subscription.nonProdName,
+              environment: environment.nonProdName,
+              product: product,
+              component: component
+            )
 
-          if (deploymentEnabled) {
-            if (new ProjectBranch(env.BRANCH_NAME).isPreview()) {
-              stage('Publish Helm chart') {
-                helmPublish(
+            if (deploymentEnabled) {
+              if (new ProjectBranch(env.BRANCH_NAME).isPreview()) {
+                stage('Publish Helm chart') {
+                  helmPublish(
+                    appPipelineConfig: pipelineConfig,
+                    subscription: subscription.nonProdName,
+                    environment: environment.nonProdName,
+                    product: product,
+                    component: component
+                  )
+                }
+
+                sectionPromoteBuildToStage(
                   appPipelineConfig: pipelineConfig,
+                  pipelineCallbacksRunner: callbacksRunner,
+                  pipelineType: pipelineType,
                   subscription: subscription.nonProdName,
-                  environment: environment.nonProdName,
                   product: product,
-                  component: component
+                  component: component,
+                  stage: DockerImage.DeploymentStage.PREVIEW,
+                  environment: environment.nonProdName
                 )
               }
 
-              sectionPromoteBuildToStage(
-                appPipelineConfig: pipelineConfig,
-                pipelineCallbacksRunner: callbacksRunner,
-                pipelineType: pipelineType,
-                subscription: subscription.nonProdName,
-                product: product,
-                component: component,
-                stage: DockerImage.DeploymentStage.PREVIEW,
-                environment: environment.nonProdName
-              )
-            }
+              handlePRDeployment(branch, aksSubscriptions, subscription, environment, pipelineConfig, callbacksRunner, pipelineType, product, component)
+              handleMasterDeployment(subscription, environment, aksSubscriptions, pipelineConfig, callbacksRunner, pipelineType, product, component)
+              onAutoDeployBranch { subscriptionName, environmentName, aksSubscription ->
+                handleAutoDeployBranch(subscriptionName, environmentName, aksSubscription, pipelineConfig, callbacksRunner, pipelineType, product, component)
+              }
 
-            handlePRDeployment(branch, aksSubscriptions, subscription, environment, pipelineConfig, callbacksRunner, pipelineType, product, component)
-            handleMasterDeployment(subscription, environment, aksSubscriptions, pipelineConfig, callbacksRunner, pipelineType, product, component)
-            onAutoDeployBranch { subscriptionName, environmentName, aksSubscription ->
-              handleAutoDeployBranch(subscriptionName, environmentName, aksSubscription, pipelineConfig, callbacksRunner, pipelineType, product, component)
-            }
+              onPreview {
+                sectionDeployToEnvironment(
+                  appPipelineConfig: pipelineConfig,
+                  pipelineCallbacksRunner: callbacksRunner,
+                  pipelineType: pipelineType,
+                  subscription: subscription.previewName,
+                  environment: environment.previewName,
+                  product: deploymentProduct,
+                  component: component,
+                  aksSubscription: aksSubscriptions.preview,
+                  tfPlanOnly: false
+                )
+              }
+            } // end approvedDeploymentRepository
 
-            onPreview {
-              sectionDeployToEnvironment(
-                appPipelineConfig: pipelineConfig,
-                pipelineCallbacksRunner: callbacksRunner,
-                pipelineType: pipelineType,
-                subscription: subscription.previewName,
-                environment: environment.previewName,
-                product: deploymentProduct,
-                component: component,
-                aksSubscription: aksSubscriptions.preview,
-                tfPlanOnly: false
-              )
+          } catch (FlowInterruptedException err) {
+            throw err
+          } catch (err) {
+            if (err.message != null && err.message.startsWith('AUTO_ABORT')) {
+              currentBuild.result = 'ABORTED'
+              metricsPublisher.publish(err.message)
+              return
             }
-          } // end approvedDeploymentRepository
+            attemptFailed = true
+            throw err
+          } finally {
+            notifyPipelineDeprecations(slackChannel, metricsPublisher)
+            if (attemptFailed || (currentBuild.result ?: currentBuild.currentResult) == 'FAILURE') {
+              archiveBuildOutputs()
+            }
+            if (env.KEEP_DIR_FOR_DEBUGGING != "true") {
+              deleteDir()
+            }
+          }
 
-        } catch (FlowInterruptedException err) {
-          currentBuild.result = err.result.toString()
-          throw err
-        } catch (err) {
-          if (err.message != null && err.message.startsWith('AUTO_ABORT')) {
-            currentBuild.result = 'ABORTED'
-            metricsPublisher.publish(err.message)
-            return
-          } else {
-            currentBuild.result = "FAILURE"
-            notifyBuildFailure channel: slackChannel
-            metricsPublisher.publish('Pipeline Failed')
-          }
-          callbacksRunner.call('onFailure')
-          throw err
-        } finally {
-          notifyPipelineDeprecations(slackChannel, metricsPublisher)
-          if ((currentBuild.result ?: currentBuild.currentResult) == 'FAILURE') {
-            archiveBuildOutputs()
-            queueBuildArchive(product: product, component: component)
-          }
-          if (env.KEEP_DIR_FOR_DEBUGGING != "true") {
-            deleteDir()
-          }
+          notifyBuildFixed channel: slackChannel
+
+          callbacksRunner.call('onSuccess')
+          metricsPublisher.publish('Pipeline Succeeded')
         }
-
-        notifyBuildFixed channel: slackChannel
-
-        callbacksRunner.call('onSuccess')
-        metricsPublisher.publish('Pipeline Succeeded')
       }
+    }
+  } catch (FlowInterruptedException err) {
+    currentBuild.result = err.result.toString()
+    throw err
+  } catch (err) {
+    currentBuild.result = "FAILURE"
+    notifyBuildFailure channel: slackChannel
+    metricsPublisher.publish('Pipeline Failed')
+    callbacksRunner.call('onFailure')
+    throw err
+  } finally {
+    if ((currentBuild.result ?: currentBuild.currentResult) == 'FAILURE') {
+      queueBuildArchive(product: product, component: component)
     }
   }
 }

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -154,8 +154,10 @@ def call(type, String product, String component, Closure body) {
           throw err
         } finally {
           notifyPipelineDeprecations(slackChannel, metricsPublisher)
-          archiveBuildOutputs()
-          queueBuildArchive(product: product, component: component)
+          if ((currentBuild.result ?: currentBuild.currentResult) == 'FAILURE') {
+            archiveBuildOutputs()
+            queueBuildArchive(product: product, component: component)
+          }
           if (env.KEEP_DIR_FOR_DEBUGGING != "true") {
             deleteDir()
           }


### PR DESCRIPTION
Archives failed build logs & artifacts to Azure Blob Storage for longer term retention.

This will be helpful in analysing and investigating flakey build patterns.

Depends on [#1496](https://github.com/hmcts/cnp-jenkins-library/pull/1496), which must be merged first.