### PR TITLE
Allow archive build branch for pipeline testing

### DIFF
--- a/resources/uk/gov/hmcts/library/allowed-library-branches.yml
+++ b/resources/uk/gov/hmcts/library/allowed-library-branches.yml
@@ -23,3 +23,5 @@ branches:
     allowed: true
   - name: poll_for_helm
     allowed: true
+  - name: archive-complete-build-results
+    allowed: true


### PR DESCRIPTION
Allows application pipeline tests to load the archive-complete-build-results library branch.

The library control is fetched from master, so this must be merged before the feature PR can run its downstream Jenkins tests.