### PR TITLE
Archive builds without Jenkins API credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1204,18 +1204,18 @@ archiveCompletedBuild(
 )
 ```
 
-The archive job waits for the source build to finish, then captures its complete
-console output, build metadata, test-result metadata and artifact ZIP. It uploads
-the resulting directory using the existing `azureBlobUpload` step. Archive names
-include the final outcome and, when Jenkins reports one, the failed stage, for
-example `completed-build_43_FAILURE_Deploy_to_AKS`.
+The archive job waits for the source build to finish, then reads it directly
+from the same Jenkins controller. It captures the complete console output,
+build metadata, test-result metadata and artifact ZIP without a separate
+Jenkins API credential. It uploads the resulting directory using the existing
+`azureBlobUpload` step. Archive names include the final outcome and, when
+Jenkins reports one, the failed stage, for example
+`completed-build_43_FAILURE_Deploy_to_AKS`.
 
 The following global environment variables configure the archive:
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `BUILD_ARCHIVE_JENKINS_CREDENTIALS_ID` | required | Jenkins API credential |
-| `BUILD_ARCHIVE_JENKINS_API_URL` | `JENKINS_URL` | Optional controller-internal base URL |
 | `BUILD_ARCHIVE_STORAGE_SUBSCRIPTION` | `sandbox` | Azure subscription alias |
 | `BUILD_ARCHIVE_STORAGE_CREDENTIALS_ID` | `buildlog-storage-account` | Storage credential |
 | `BUILD_ARCHIVE_STORAGE_CONTAINER` | `jenkins-build-archive` | Blob container |
@@ -1224,4 +1224,3 @@ The following global environment variables configure the archive:
 | `BUILD_ARCHIVE_LOCAL_ONLY` | `false` | Archive back to Jenkins instead of Azure for local testing |
 | `BUILD_ARCHIVE_WAIT_TIMEOUT_MINUTES` | `300` | Maximum wait for the source build to finish |
 | `BUILD_ARCHIVE_OPERATION_TIMEOUT_MINUTES` | `120` | Maximum time for capture and upload |
-| `BUILD_ARCHIVE_HTTP_TIMEOUT_SECONDS` | `1800` | Timeout for each Jenkins API request |

--- a/src/uk/gov/hmcts/contino/CompletedBuildReader.groovy
+++ b/src/uk/gov/hmcts/contino/CompletedBuildReader.groovy
@@ -1,0 +1,157 @@
+package uk.gov.hmcts.contino
+
+import com.cloudbees.groovy.cps.NonCPS
+import hudson.FilePath
+import jenkins.model.Jenkins
+
+/**
+ * Reads completed builds directly from the Jenkins controller.
+ *
+ * This class deliberately has no state so it remains safe to retain across
+ * Pipeline suspensions while the archive worker waits for a source build.
+ */
+class CompletedBuildReader implements Serializable {
+
+  private static final long serialVersionUID = 1L
+
+  @NonCPS
+  Map snapshot(String jobName, int buildNumber) {
+    def build = requiredBuild(jobName, buildNumber)
+
+    [
+      building: build.isBuilding(),
+      result: build.getResult()?.toString(),
+      number: build.getNumber(),
+      url: build.getUrl(),
+      displayName: build.getDisplayName(),
+      fullDisplayName: build.getFullDisplayName(),
+      timestamp: build.getTimeInMillis(),
+      duration: build.getDuration(),
+      estimatedDuration: build.getEstimatedDuration(),
+      workflow: workflowMetadata(build),
+      tests: testMetadata(build)
+    ]
+  }
+
+  @NonCPS
+  void copyOutputs(String jobName, int buildNumber, FilePath archiveDirectory) {
+    def build = requiredBuild(jobName, buildNumber)
+    if (build.isBuilding()) {
+      throw new IllegalStateException("Refusing to copy outputs from running build ${jobName} #${buildNumber}")
+    }
+
+    archiveDirectory.mkdirs()
+    copyConsole(build, archiveDirectory.child('console.txt'))
+    copyArtifacts(build, archiveDirectory.child('artifacts.zip'))
+  }
+
+  @NonCPS
+  private static def requiredBuild(String jobName, int buildNumber) {
+    def job = Jenkins.get().getItemByFullName(jobName)
+    if (job == null) {
+      throw new IllegalArgumentException("Unable to find Jenkins job: ${jobName}")
+    }
+
+    def build = job.getBuildByNumber(buildNumber)
+    if (build == null) {
+      throw new IllegalArgumentException("Unable to find Jenkins build: ${jobName} #${buildNumber}")
+    }
+
+    build
+  }
+
+  @NonCPS
+  private static void copyConsole(def build, FilePath target) {
+    OutputStream output = target.write()
+    try {
+      build.writeWholeLogTo(output)
+    } finally {
+      output.close()
+    }
+  }
+
+  @NonCPS
+  private static void copyArtifacts(def build, FilePath target) {
+    if (!build.hasArtifact()) {
+      return
+    }
+
+    OutputStream output = target.write()
+    try {
+      build.getArtifactManager().root().zip(output, '**', null, true, '')
+    } finally {
+      output.close()
+    }
+  }
+
+  @NonCPS
+  private static Map testMetadata(def build) {
+    def action = build.getAllActions().find { candidate ->
+      candidate.metaClass.respondsTo(candidate, 'getFailCount') &&
+        candidate.metaClass.respondsTo(candidate, 'getSkipCount') &&
+        candidate.metaClass.respondsTo(candidate, 'getTotalCount')
+    }
+    if (action == null) {
+      return null
+    }
+
+    int totalCount = action.getTotalCount() as int
+    int failCount = action.getFailCount() as int
+    int skipCount = action.getSkipCount() as int
+
+    [
+      totalCount: totalCount,
+      failCount: failCount,
+      skipCount: skipCount,
+      passCount: totalCount - failCount - skipCount
+    ]
+  }
+
+  @NonCPS
+  private static Map workflowMetadata(def build) {
+    if (!build.metaClass.respondsTo(build, 'getExecution')) {
+      return null
+    }
+
+    def execution = build.getExecution()
+    if (execution == null) {
+      return null
+    }
+
+    try {
+      Class walkerType = build.class.classLoader.loadClass(
+        'org.jenkinsci.plugins.workflow.graph.FlowGraphWalker'
+      )
+      def walker = walkerType.newInstance(execution)
+      List nodes = walker.iterator().collect { it }
+      List stages = nodes.findResults { node ->
+        def stageAction = node.getAllActions().find { action ->
+          action.class.name == 'org.jenkinsci.plugins.workflow.actions.StageAction'
+        }
+        if (stageAction == null) {
+          return null
+        }
+
+        boolean failed = nodes.any { candidate ->
+          hasError(candidate) &&
+            (candidate == node || candidate.getEnclosingBlocks().contains(node))
+        }
+        [
+          name: stageAction.getStageName(),
+          status: failed ? 'FAILED' : 'SUCCESS'
+        ]
+      }.reverse()
+
+      stages ? [stages: stages] : null
+    } catch (Exception ignored) {
+      null
+    }
+  }
+
+  @NonCPS
+  private static boolean hasError(def node) {
+    node.getAllActions().any { action ->
+      action.class.name == 'org.jenkinsci.plugins.workflow.actions.ErrorAction'
+    }
+  }
+}

--- a/test/archiveCompletedBuildTest.groovy
+++ b/test/archiveCompletedBuildTest.groovy
@@ -1,24 +1,20 @@
 import com.lesfurets.jenkins.unit.BasePipelineTest
+import hudson.FilePath
 import hudson.model.Result
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
 import org.junit.Before
 import org.junit.Test
-import groovy.json.JsonSlurperClassic
 
 import static org.assertj.core.api.Assertions.assertThat
 
 class archiveCompletedBuildTest extends BasePipelineTest {
 
   def archived
-  def downloads = []
-  def requests = []
   def timeouts = []
   def uploads = []
   def writes = [:]
-  def metadataChecks = 0
-  def buildResult = 'FAILURE'
-  def workflowStages = []
-  def workflowFailure
+  def buildReader
+  def workspace
   def script
 
   @Override
@@ -27,14 +23,17 @@ class archiveCompletedBuildTest extends BasePipelineTest {
     super.setUp()
     binding.setVariable('env', [
       JENKINS_URL: 'https://build.example/',
-      BUILD_ARCHIVE_JENKINS_API_URL: 'http://localhost:8080/',
       BUILD_ARCHIVE_LOCAL_ONLY: 'true',
       BUILD_ARCHIVE_AGENT: ''
     ])
 
+    buildReader = new FakeCompletedBuildReader()
+    workspace = new FilePath(new File('build/archive-test-workspace'))
+
     helper.registerAllowedMethod('node', [String.class, Closure.class], { _, body -> body.call() })
     helper.registerAllowedMethod('deleteDir', [], {})
     helper.registerAllowedMethod('dir', [String.class, Closure.class], { _, body -> body.call() })
+    helper.registerAllowedMethod('getContext', [Class.class], { workspace })
     helper.registerAllowedMethod('timeout', [Map.class, Closure.class], { options, body ->
       timeouts << options
       body.call()
@@ -44,35 +43,6 @@ class archiveCompletedBuildTest extends BasePipelineTest {
         // Repeat until the mocked build reports completion.
       }
     })
-    helper.registerAllowedMethod('httpRequest', [Map.class], { request ->
-      requests << request
-      if (request.url.endsWith('/api/json') && !request.url.contains('testReport')) {
-        metadataChecks++
-        return [
-          status: 200,
-          content: metadataChecks == 1
-            ? '{"building":true}'
-            : """{"building":false,"result":"${buildResult}"}"""
-        ]
-      }
-
-      if (request.url.endsWith('/wfapi/describe')) {
-        if (workflowFailure) {
-          throw workflowFailure
-        }
-        return [
-          status: 200,
-          content: groovy.json.JsonOutput.toJson([stages: workflowStages])
-        ]
-      }
-
-      downloads << request
-      return [status: 200, content: '']
-    })
-    helper.registerAllowedMethod('readJSON', [Map.class], {
-      new JsonSlurperClassic().parseText(it.text)
-    })
-    helper.registerAllowedMethod('writeFile', [Map.class], { writes[it.file] = it.text })
     helper.registerAllowedMethod('writeJSON', [Map.class], { writes[it.file] = it.json })
     helper.registerAllowedMethod('archiveArtifacts', [Map.class], { archived = it })
     helper.registerAllowedMethod('azureBlobUpload', [String.class, String.class, String.class, String.class], {
@@ -88,42 +58,12 @@ class archiveCompletedBuildTest extends BasePipelineTest {
   }
 
   @Test
-  void streamsDownloadsAndAppliesConfiguredTimeouts() {
+  void copiesCompletedBuildOutputsWithoutAnApiCredential() {
     binding.getVariable('env').BUILD_ARCHIVE_WAIT_TIMEOUT_MINUTES = '301'
     binding.getVariable('env').BUILD_ARCHIVE_OPERATION_TIMEOUT_MINUTES = '121'
-    binding.getVariable('env').BUILD_ARCHIVE_HTTP_TIMEOUT_SECONDS = '1801'
-
-    script.call(
-      sourceBuildUrl: 'https://build.example/job/service/job/PR-1/4/',
-      sourceJobName: 'service/PR-1',
-      sourceBuildNumber: '4',
-      sourceBuildResult: 'SUCCESS',
-      sourceProduct: 'et',
-      sourceComponent: 'cos'
-    )
-
-    assertThat(metadataChecks).isEqualTo(2)
-    assertThat(downloads*.url).containsExactlyInAnyOrder(
-      'http://localhost:8080/job/service/job/PR-1/4/consoleText',
-      'http://localhost:8080/job/service/job/PR-1/4/artifact/*zip*/archive.zip',
-      'http://localhost:8080/job/service/job/PR-1/4/testReport/api/json'
-    )
-    assertThat(downloads*.responseHandle).containsOnly('NONE')
-    assertThat(requests*.timeout).containsOnly(1801)
-    assertThat(timeouts*.time).containsExactly(301, 121)
-    assertThat(writes['build.json'].toString()).contains('"result":"FAILURE"')
-    assertThat(writes['archive-metadata.json'].sourceJobName).isEqualTo('service/PR-1')
-    assertThat(writes['archive-metadata.json'].archivedAt).isEqualTo('2026-07-23T14:30:00Z')
-    assertThat(archived.artifacts.toString()).isEqualTo('completed-build_4_FAILURE/**')
-    assertThat(uploads).isEmpty()
-  }
-
-  @Test
-  void includesTheOutcomeAndFailedStageInTheArchiveName() {
-    buildResult = 'FAILURE'
-    workflowStages = [
-      [name: 'Build and test', status: 'SUCCESS'],
-      [name: 'Deploy to AKS / Preview', status: 'FAILED']
+    buildReader.snapshots = [
+      [building: true],
+      completedBuild()
     ]
 
     script.call(
@@ -132,25 +72,37 @@ class archiveCompletedBuildTest extends BasePipelineTest {
       sourceBuildNumber: '4',
       sourceBuildResult: 'SUCCESS',
       sourceProduct: 'et',
-      sourceComponent: 'cos'
+      sourceComponent: 'cos',
+      buildReader: buildReader
     )
 
+    assertThat(buildReader.snapshotRequests).containsExactly(
+      ['service/PR-1', 4],
+      ['service/PR-1', 4]
+    )
+    assertThat(buildReader.copyRequests).hasSize(1)
+    assertThat(buildReader.copyRequests[0].take(2)).containsExactly('service/PR-1', 4)
+    assertThat(timeouts*.time).containsExactly(301, 121)
+    assertThat(writes['build.json'].result).isEqualTo('FAILURE')
+    assertThat(writes['build.json']).doesNotContainKeys('workflow', 'tests')
+    assertThat(writes['test-results.json'].failCount).isEqualTo(2)
+    assertThat(writes['archive-metadata.json'].sourceJobName).isEqualTo('service/PR-1')
+    assertThat(writes['archive-metadata.json'].archivedAt).isEqualTo('2026-07-23T14:30:00Z')
     assertThat(archived.artifacts.toString())
       .isEqualTo('completed-build_4_FAILURE_Deploy_to_AKS_Preview/**')
-    assertThat(writes['archive-metadata.json'].sourceBuildResult).isEqualTo('FAILURE')
-    assertThat(writes['archive-metadata.json'].failedStage).isEqualTo('Deploy to AKS / Preview')
-    assertThat(writes['workflow.json'].stages[1].status).isEqualTo('FAILED')
+    assertThat(uploads).isEmpty()
   }
 
   @Test
   void uploadsToTheSandboxStorageSubscriptionByDefault() {
     binding.getVariable('env').BUILD_ARCHIVE_LOCAL_ONLY = 'false'
-    binding.getVariable('env').BUILD_ARCHIVE_JENKINS_CREDENTIALS_ID = 'jenkins-api'
+    buildReader.snapshots = [completedBuild(workflow: null, tests: null)]
 
     script.call(
       sourceBuildUrl: 'https://build.example/job/service/job/PR-1/4/',
       sourceJobName: 'service/PR-1',
-      sourceBuildNumber: '4'
+      sourceBuildNumber: '4',
+      buildReader: buildReader
     )
 
     assertThat(uploads).hasSize(1)
@@ -163,37 +115,39 @@ class archiveCompletedBuildTest extends BasePipelineTest {
   }
 
   @Test
-  void ignoresAnAbortedBuildAfterPollingItsFinalResult() {
-    buildResult = 'ABORTED'
+  void ignoresAnAbortedBuildAfterReadingItsFinalResult() {
+    buildReader.snapshots = [completedBuild(result: 'ABORTED')]
 
     script.call(
       sourceBuildUrl: 'https://build.example/job/service/job/PR-1/4/',
       sourceJobName: 'service/PR-1',
-      sourceBuildNumber: '4'
+      sourceBuildNumber: '4',
+      buildReader: buildReader
     )
 
-    assertThat(downloads).isEmpty()
+    assertThat(buildReader.copyRequests).isEmpty()
     assertThat(uploads).isEmpty()
     assertThat(archived).isNull()
   }
 
   @Test
-  void preservesAnInterruptionWhileReadingWorkflowMetadata() {
+  void preservesAnInterruptionWhileReadingTheCompletedBuild() {
     def interruption = new FlowInterruptedException(Result.ABORTED, true)
-    workflowFailure = interruption
+    buildReader.failure = interruption
 
     try {
       script.call(
         sourceBuildUrl: 'https://build.example/job/service/job/PR-1/4/',
         sourceJobName: 'service/PR-1',
-        sourceBuildNumber: '4'
+        sourceBuildNumber: '4',
+        buildReader: buildReader
       )
     } catch (FlowInterruptedException expected) {
       assertThat(expected).isSameAs(interruption)
       return
     }
 
-    throw new AssertionError('Expected the workflow metadata interruption to propagate')
+    throw new AssertionError('Expected the completed build interruption to propagate')
   }
 
   @Test
@@ -202,7 +156,8 @@ class archiveCompletedBuildTest extends BasePipelineTest {
       script.call(
         sourceBuildUrl: 'https://malicious.example/job/service/4/',
         sourceJobName: 'service',
-        sourceBuildNumber: '4'
+        sourceBuildNumber: '4',
+        buildReader: buildReader
       )
     } catch (IllegalArgumentException expected) {
       assertThat(expected.message).contains('invalid Jenkins build URL')
@@ -252,12 +207,39 @@ class archiveCompletedBuildTest extends BasePipelineTest {
     )
   }
 
+  private static Map completedBuild(Map overrides = [:]) {
+    [
+      building: false,
+      result: 'FAILURE',
+      number: 4,
+      url: 'job/service/job/PR-1/4/',
+      displayName: '#4',
+      fullDisplayName: 'service/PR-1 #4',
+      timestamp: 1785240000000,
+      duration: 5000,
+      estimatedDuration: 4000,
+      workflow: [
+        stages: [
+          [name: 'Build and test', status: 'SUCCESS'],
+          [name: 'Deploy to AKS / Preview', status: 'FAILED']
+        ]
+      ],
+      tests: [
+        totalCount: 10,
+        failCount: 2,
+        skipCount: 1,
+        passCount: 7
+      ]
+    ] + overrides
+  }
+
   private void assertInvalidBuildIdentity(Map params) {
     try {
       script.call(
         sourceBuildUrl: params.sourceBuildUrl,
         sourceJobName: params.sourceJobName,
-        sourceBuildNumber: params.sourceBuildNumber
+        sourceBuildNumber: params.sourceBuildNumber,
+        buildReader: buildReader
       )
     } catch (IllegalArgumentException expected) {
       assertThat(expected.message).contains(params.expectedMessage)
@@ -265,5 +247,27 @@ class archiveCompletedBuildTest extends BasePipelineTest {
     }
 
     throw new AssertionError("Expected build archive validation to reject ${params}")
+  }
+}
+
+class FakeCompletedBuildReader implements Serializable {
+
+  private static final long serialVersionUID = 1L
+
+  List<Map> snapshots = []
+  List snapshotRequests = []
+  List copyRequests = []
+  Throwable failure
+
+  Map snapshot(String jobName, int buildNumber) {
+    snapshotRequests << [jobName, buildNumber]
+    if (failure) {
+      throw failure
+    }
+    snapshots.remove(0)
+  }
+
+  void copyOutputs(String jobName, int buildNumber, FilePath workspace) {
+    copyRequests << [jobName, buildNumber, workspace]
   }
 }

--- a/test/withNightlyPipeline/withNightlyPipelineArchiveInterruptionTests.groovy
+++ b/test/withNightlyPipeline/withNightlyPipelineArchiveInterruptionTests.groovy
@@ -3,6 +3,7 @@ package withNightlyPipeline
 import groovy.mock.interceptor.StubFor
 import hudson.model.Result
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
+import org.junit.Before
 import org.junit.Test
 import uk.gov.hmcts.contino.GradleBuilder
 import withPipeline.BaseCnpPipelineTest
@@ -14,7 +15,10 @@ class withNightlyPipelineArchiveInterruptionTests extends BaseCnpPipelineTest {
 
   withNightlyPipelineArchiveInterruptionTests() {
     super("master", jenkinsFile)
+  }
 
+  @Before
+  void registerArchiveInterruptionSteps() {
     helper.registerAllowedMethod("node", [String, Closure], { _, body -> body.call() })
     helper.registerAllowedMethod("timeout", [Map, Closure], { _, body -> body.call() })
   }

--- a/test/withNightlyPipeline/withNightlyPipelineArchiveInterruptionTests.groovy
+++ b/test/withNightlyPipeline/withNightlyPipelineArchiveInterruptionTests.groovy
@@ -1,11 +1,9 @@
 package withNightlyPipeline
 
-import groovy.mock.interceptor.StubFor
 import hudson.model.Result
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
 import org.junit.Before
 import org.junit.Test
-import uk.gov.hmcts.contino.GradleBuilder
 import withPipeline.BaseCnpPipelineTest
 
 import static org.assertj.core.api.Assertions.assertThat
@@ -26,16 +24,16 @@ class withNightlyPipelineArchiveInterruptionTests extends BaseCnpPipelineTest {
   @Test
   void doesNotArchiveAnInterruptedNightlyPipeline() {
     def interruption = new FlowInterruptedException(Result.ABORTED, true)
-    def stubBuilder = new StubFor(GradleBuilder)
-    stubBuilder.demand.setupToolVersion(1) {
-      throw interruption
-    }
+    helper.registerAllowedMethod("sh", [Map], { options ->
+      if (options.script.startsWith('grep -F "JavaLanguageVersion')) {
+        throw interruption
+      }
+      return options.returnStatus ? 1 : ''
+    })
 
     def caughtInterruption = null
     try {
-      stubBuilder.use {
-        runScript("testResources/$jenkinsFile")
-      }
+      runScript("testResources/$jenkinsFile")
     } catch (FlowInterruptedException expected) {
       caughtInterruption = expected
     }

--- a/test/withPipeline/withPipelineArchiveInterruptionTests.groovy
+++ b/test/withPipeline/withPipelineArchiveInterruptionTests.groovy
@@ -3,6 +3,7 @@ package withPipeline
 import groovy.mock.interceptor.StubFor
 import hudson.model.Result
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
+import org.junit.Before
 import org.junit.Test
 import uk.gov.hmcts.contino.GradleBuilder
 
@@ -13,7 +14,10 @@ class withPipelineArchiveInterruptionTests extends BaseCnpPipelineTest {
 
   withPipelineArchiveInterruptionTests() {
     super("master", jenkinsFile)
+  }
 
+  @Before
+  void registerArchiveInterruptionSteps() {
     helper.registerAllowedMethod("retry", [LinkedHashMap, Closure], { _, body -> body.call() })
     helper.registerAllowedMethod("node", [String, Closure], { _, body -> body.call() })
     helper.registerAllowedMethod("timeout", [Map, Closure], { _, body -> body.call() })

--- a/test/withPipeline/withPipelineArchiveInterruptionTests.groovy
+++ b/test/withPipeline/withPipelineArchiveInterruptionTests.groovy
@@ -1,11 +1,9 @@
 package withPipeline
 
-import groovy.mock.interceptor.StubFor
 import hudson.model.Result
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
 import org.junit.Before
 import org.junit.Test
-import uk.gov.hmcts.contino.GradleBuilder
 
 import static org.assertj.core.api.Assertions.assertThat
 
@@ -26,16 +24,16 @@ class withPipelineArchiveInterruptionTests extends BaseCnpPipelineTest {
   @Test
   void doesNotArchiveAnInterruptedApplicationPipeline() {
     def interruption = new FlowInterruptedException(Result.ABORTED, true)
-    def stubBuilder = new StubFor(GradleBuilder)
-    stubBuilder.demand.setupToolVersion(1) {
-      throw interruption
-    }
+    helper.registerAllowedMethod("sh", [Map], { options ->
+      if (options.script.startsWith('grep -F "JavaLanguageVersion')) {
+        throw interruption
+      }
+      return options.returnStatus ? 1 : ''
+    })
 
     def caughtInterruption = null
     try {
-      stubBuilder.use {
-        runScript("testResources/$jenkinsFile")
-      }
+      runScript("testResources/$jenkinsFile")
     } catch (FlowInterruptedException expected) {
       caughtInterruption = expected
     }
@@ -72,15 +70,15 @@ class withPipelineArchiveInterruptionTests extends BaseCnpPipelineTest {
     binding.getVariable('env').JOB_NAME = 'service/PR-1'
     binding.getVariable('env').BUILD_NUMBER = '4'
 
-    def stubBuilder = new StubFor(GradleBuilder)
-    stubBuilder.demand.setupToolVersion(2) {
-      throw failure
-    }
+    helper.registerAllowedMethod("sh", [Map], { options ->
+      if (options.script.startsWith('grep -F "JavaLanguageVersion')) {
+        throw failure
+      }
+      return options.returnStatus ? 1 : ''
+    })
 
     try {
-      stubBuilder.use {
-        runScript("testResources/$jenkinsFile")
-      }
+      runScript("testResources/$jenkinsFile")
     } catch (RuntimeException expected) {
       assertThat(expected).isSameAs(failure)
     }

--- a/vars/archiveCompletedBuild.groovy
+++ b/vars/archiveCompletedBuild.groovy
@@ -1,39 +1,42 @@
-import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
+import hudson.FilePath
+import uk.gov.hmcts.contino.CompletedBuildReader
 
 def call(Map params = [:]) {
   def sourceBuildUrl = required(params, 'sourceBuildUrl')
   def sourceJobName = required(params, 'sourceJobName')
   def sourceBuildNumber = required(params, 'sourceBuildNumber')
   def localOnly = params.localOnly == true || env.BUILD_ARCHIVE_LOCAL_ONLY == 'true'
-
-  def jenkinsCredentialsId = params.jenkinsCredentialsId ?: env.BUILD_ARCHIVE_JENKINS_CREDENTIALS_ID
-  if (!jenkinsCredentialsId && !localOnly) {
-    error('A Jenkins API credential is required in BUILD_ARCHIVE_JENKINS_CREDENTIALS_ID')
-  }
+  def buildReader = params.buildReader ?: new CompletedBuildReader()
 
   validateBuildUrl(sourceBuildUrl)
   validateBuildIdentity(sourceBuildUrl, sourceJobName, sourceBuildNumber)
 
-  def buildApiUrl = apiBuildUrl(sourceBuildUrl)
   def storageSubscription = params.storageSubscription ?: env.BUILD_ARCHIVE_STORAGE_SUBSCRIPTION ?: 'sandbox'
-  def storageCredentialsId = params.storageCredentialsId ?: env.BUILD_ARCHIVE_STORAGE_CREDENTIALS_ID ?: 'buildlog-storage-account'
+  def storageCredentialsId = params.storageCredentialsId ?: env.BUILD_ARCHIVE_STORAGE_CREDENTIALS_ID ?:
+    'buildlog-storage-account'
   def storageContainer = params.storageContainer ?: env.BUILD_ARCHIVE_STORAGE_CONTAINER ?: 'jenkins-build-archive'
   def storagePrefix = params.storagePrefix ?: env.BUILD_ARCHIVE_STORAGE_PREFIX ?: 'builds'
-  def waitTimeoutMinutes = configuredTimeout(env.BUILD_ARCHIVE_WAIT_TIMEOUT_MINUTES, 300, 'BUILD_ARCHIVE_WAIT_TIMEOUT_MINUTES')
-  def operationTimeoutMinutes = configuredTimeout(env.BUILD_ARCHIVE_OPERATION_TIMEOUT_MINUTES, 120, 'BUILD_ARCHIVE_OPERATION_TIMEOUT_MINUTES')
-  def httpTimeoutSeconds = configuredTimeout(env.BUILD_ARCHIVE_HTTP_TIMEOUT_SECONDS, 1800, 'BUILD_ARCHIVE_HTTP_TIMEOUT_SECONDS')
+  def waitTimeoutMinutes = configuredTimeout(
+    env.BUILD_ARCHIVE_WAIT_TIMEOUT_MINUTES,
+    300,
+    'BUILD_ARCHIVE_WAIT_TIMEOUT_MINUTES'
+  )
+  def operationTimeoutMinutes = configuredTimeout(
+    env.BUILD_ARCHIVE_OPERATION_TIMEOUT_MINUTES,
+    120,
+    'BUILD_ARCHIVE_OPERATION_TIMEOUT_MINUTES'
+  )
 
   node(env.BUILD_ARCHIVE_AGENT ?: '') {
     try {
       deleteDir()
 
-      def buildMetadata = waitForBuildCompletion(
-        buildApiUrl,
-        jenkinsCredentialsId,
-        waitTimeoutMinutes,
-        httpTimeoutSeconds
+      def buildDetails = waitForBuildCompletion(
+        buildReader,
+        sourceJobName,
+        sourceBuildNumber,
+        waitTimeoutMinutes
       )
-      def buildDetails = readJSON(text: buildMetadata)
       def buildResult = (buildDetails.result ?: params.sourceBuildResult ?: 'UNKNOWN').toString().toUpperCase()
       if (buildResult != 'FAILURE') {
         echo "Skipping build archive because final result is ${buildResult}"
@@ -41,34 +44,31 @@ def call(Map params = [:]) {
       }
 
       timeout(time: operationTimeoutMinutes, unit: 'MINUTES') {
-        def workflowMetadata = getWorkflowMetadata(buildApiUrl, jenkinsCredentialsId, httpTimeoutSeconds)
+        def workflowMetadata = buildDetails.workflow as Map
         def failedStage = findFailedStage(workflowMetadata)
         def archiveName = archiveName(sourceBuildNumber, buildResult, failedStage)
         def destination = "${storageContainer}/${storagePrefix}/${safeJobPath(sourceJobName)}"
 
         dir(archiveName) {
-          writeFile(file: 'build.json', text: buildMetadata)
-
-          downloadRequired(
-            "${buildApiUrl}consoleText",
-            'console.txt',
-            jenkinsCredentialsId,
-            httpTimeoutSeconds
+          writeJSON(
+            file: 'build.json',
+            json: buildDetails.findAll { key, _ -> !(key in ['workflow', 'tests']) },
+            pretty: 2
           )
 
-          downloadOptional(
-            "${buildApiUrl}artifact/*zip*/archive.zip",
-            'artifacts.zip',
-            jenkinsCredentialsId,
-            httpTimeoutSeconds
+          buildReader.copyOutputs(
+            sourceJobName,
+            sourceBuildNumber.toInteger(),
+            getContext(FilePath)
           )
 
-          downloadOptional(
-            "${buildApiUrl}testReport/api/json",
-            'test-results.json',
-            jenkinsCredentialsId,
-            httpTimeoutSeconds
-          )
+          if (buildDetails.tests) {
+            writeJSON(
+              file: 'test-results.json',
+              json: buildDetails.tests,
+              pretty: 2
+            )
+          }
 
           if (workflowMetadata) {
             writeJSON(
@@ -119,25 +119,27 @@ def call(Map params = [:]) {
   }
 }
 
-private Map getWorkflowMetadata(String sourceBuildUrl, String credentialsId, int httpTimeoutSeconds) {
-  try {
-    def request = [
-      httpMode: 'GET',
-      quiet: true,
-      timeout: httpTimeoutSeconds,
-      url: "${sourceBuildUrl}wfapi/describe",
-      validResponseCodes: '200,404'
-    ]
-    addAuthentication(request, credentialsId)
-    def response = httpRequest(request)
+private Map waitForBuildCompletion(
+  def buildReader,
+  String sourceJobName,
+  String sourceBuildNumber,
+  int waitTimeoutMinutes
+) {
+  def completedBuildMetadata = null
 
-    response.status == 200 ? readJSON(text: response.content) as Map : null
-  } catch (FlowInterruptedException err) {
-    throw err
-  } catch (err) {
-    echo "Unable to determine failed build stage: ${err.message}"
-    null
+  timeout(time: waitTimeoutMinutes, unit: 'MINUTES') {
+    waitUntil(initialRecurrencePeriod: 5000) {
+      def metadata = buildReader.snapshot(sourceJobName, sourceBuildNumber.toInteger())
+      if (metadata.building) {
+        return false
+      }
+
+      completedBuildMetadata = metadata
+      return true
+    }
   }
+
+  completedBuildMetadata
 }
 
 private String findFailedStage(Map workflowMetadata) {
@@ -163,77 +165,6 @@ private String safeFileNamePart(String value) {
     .take(100) ?: 'unknown'
 }
 
-private String waitForBuildCompletion(
-  String sourceBuildUrl,
-  String credentialsId,
-  int waitTimeoutMinutes,
-  int httpTimeoutSeconds
-) {
-  def completedBuildMetadata = null
-
-  timeout(time: waitTimeoutMinutes, unit: 'MINUTES') {
-    waitUntil(initialRecurrencePeriod: 5000) {
-      def request = [
-        httpMode: 'GET',
-        quiet: true,
-        timeout: httpTimeoutSeconds,
-        url: "${sourceBuildUrl}api/json",
-        validResponseCodes: '200'
-      ]
-      addAuthentication(request, credentialsId)
-      def response = httpRequest(request)
-      def metadata = readJSON(text: response.content)
-
-      if (metadata.building) {
-        return false
-      }
-
-      completedBuildMetadata = response.content
-      return true
-    }
-  }
-
-  completedBuildMetadata
-}
-
-private void downloadRequired(String url, String outputFile, String credentialsId, int httpTimeoutSeconds) {
-  def request = [
-    httpMode: 'GET',
-    outputFile: outputFile,
-    quiet: true,
-    responseHandle: 'NONE',
-    timeout: httpTimeoutSeconds,
-    url: url,
-    validResponseCodes: '200'
-  ]
-  addAuthentication(request, credentialsId)
-  httpRequest(request)
-}
-
-private void downloadOptional(String url, String outputFile, String credentialsId, int httpTimeoutSeconds) {
-  def request = [
-    httpMode: 'GET',
-    outputFile: outputFile,
-    quiet: true,
-    responseHandle: 'NONE',
-    timeout: httpTimeoutSeconds,
-    url: url,
-    validResponseCodes: '200,404'
-  ]
-  addAuthentication(request, credentialsId)
-  def response = httpRequest(request)
-
-  if (response.status == 404) {
-    sh(label: "Remove missing ${outputFile}", script: "rm -f '${outputFile}'")
-  }
-}
-
-private void addAuthentication(Map request, String credentialsId) {
-  if (credentialsId) {
-    request.authentication = credentialsId
-  }
-}
-
 private int configuredTimeout(def value, int defaultValue, String variableName) {
   def configuredValue = value ?: defaultValue.toString()
   if (!(configuredValue.toString() ==~ /\d+/) || configuredValue.toString().toInteger() < 1) {
@@ -252,7 +183,8 @@ private String required(Map params, String name) {
 
 private void validateBuildUrl(String sourceBuildUrl) {
   def jenkinsUrl = env.JENKINS_URL
-  if (!jenkinsUrl || !sourceBuildUrl.startsWith(jenkinsUrl) || !(sourceBuildUrl ==~ /https?:\/\/[^\/]+\/job\/.+\/\d+\/$/)) {
+  if (!jenkinsUrl || !sourceBuildUrl.startsWith(jenkinsUrl) ||
+    !(sourceBuildUrl ==~ /https?:\/\/[^\/]+\/job\/.+\/\d+\/$/)) {
     error("Refusing to archive an invalid Jenkins build URL: ${sourceBuildUrl}")
   }
 }
@@ -266,7 +198,7 @@ private void validateBuildIdentity(String sourceBuildUrl, String sourceJobName, 
   def buildUrlParts = relativeBuildUrl =~ /^job\/(.+)\/(\d+)\/$/
   def buildNumberFromUrl = buildUrlParts[0][2]
   if (buildNumberFromUrl != sourceBuildNumber) {
-    error("Refusing to archive mismatched Jenkins build details")
+    error('Refusing to archive mismatched Jenkins build details')
   }
 
   def jobSegments = sourceJobName.split('/', -1)
@@ -279,21 +211,8 @@ private void validateBuildIdentity(String sourceBuildUrl, String sourceJobName, 
     .collect { segment -> new URI("https://jenkins.invalid/${segment}").path.substring(1) }
     .join('/')
   if (jobNameFromUrl != sourceJobName) {
-    error("Refusing to archive mismatched Jenkins build details")
+    error('Refusing to archive mismatched Jenkins build details')
   }
-}
-
-private String apiBuildUrl(String sourceBuildUrl) {
-  def apiBaseUrl = env.BUILD_ARCHIVE_JENKINS_API_URL
-  if (!apiBaseUrl) {
-    return sourceBuildUrl
-  }
-
-  if (!(apiBaseUrl ==~ /https?:\/\/[^\/]+(?::\d+)?\/$/)) {
-    error("Refusing to use an invalid Jenkins API base URL: ${apiBaseUrl}")
-  }
-
-  "${apiBaseUrl}${sourceBuildUrl.substring(env.JENKINS_URL.length())}"
 }
 
 private String safeJobPath(String sourceJobName) {


### PR DESCRIPTION
## What does this change?

Reworks completed-build archiving so the archive job reads source builds directly from the same Jenkins controller.

- removes the Jenkins API credential and controller self-HTTP requests
- streams the complete console log and artifact ZIP to the archive worker
- retains compact build, test-result and Pipeline-stage metadata
- continues to use the existing Azure storage credential and container configuration

This keeps the archive process free of a long-lived Jenkins API credential and does not require another plugin or secret.

## Relationship to the existing work

This PR targets `archive-complete-build-results`, the branch used by #1495, so it can be reviewed as a focused follow-up before that work is merged.

The root archive job is proposed in hmcts/cnp-jenkins-config#1291. The downstream trial is hmcts/et-ccd-callbacks#3347.

## Testing

- `./gradlew test check --no-daemon`
- 332 tests passed

Once this is merged into the feature branch and the root job is available, the downstream trial can confirm that a failed build is written to the `jenkins-build-archive` container.
