### PR TITLE
Re-add printVersionInit

### DIFF
--- a/resources/uk/gov/hmcts/gradle/init.gradle
+++ b/resources/uk/gov/hmcts/gradle/init.gradle
@@ -24,10 +24,6 @@ settingsEvaluated { settings ->
             }
         }
     }
-
-    task printVersionInit {
-        doLast { println project.version }
-    }
 }
 
 allprojects {
@@ -69,4 +65,8 @@ allprojects {
       }
     }
   }
+
+    task printVersionInit {
+        doLast { println project.version }
+    }
 }

--- a/resources/uk/gov/hmcts/gradle/init.gradle
+++ b/resources/uk/gov/hmcts/gradle/init.gradle
@@ -24,6 +24,10 @@ settingsEvaluated { settings ->
             }
         }
     }
+
+    task printVersionInit {
+        doLast { println project.version }
+    }
 }
 
 allprojects {


### PR DESCRIPTION
Resolves a non-fatal error occurring as a result of this gradle task not existing:

```
14:48:30  + mkdir -p src/main/resources/META-INF
14:48:30  + ./gradlew --no-daemon --init-script init.gradle -q :printVersionInit
14:48:39  
14:48:39  FAILURE: Build failed with an exception.
14:48:39  
14:48:39  * What went wrong:
14:48:39  Cannot locate tasks that match ':printVersionInit' as task 'printVersionInit' not found in root project 'ccd-cache-warm-performance'.
14:48:39  
14:48:39  * Try:
14:48:39  > Run gradlew tasks to get a list of available tasks.
14:48:39  > For more on name expansion, please refer to https://docs.gradle.org/8.14.5/userguide/command_line_interface.html#sec:name_abbreviation in the Gradle documentation.
14:48:39  > Run with --stacktrace option to get the stack trace.
14:48:39  > Run with --info or --debug option to get more log output.
14:48:39  > Run with --scan to get full insights.
14:48:39  > Get more help at https://help.gradle.org/.
14:48:39  
14:48:39  BUILD FAILED in 10s
14:48:39  + git rev-parse HEAD
14:48:39  + date
14:48:39  + tee src/main/resources/META-INF/build-info.properties
14:48:39  build.version=
14:48:39  build.number=17305
14:48:39  build.commit=abcd1234
14:48:39  build.date=Fri Jul 31 13:48:39 UTC 2026
```