### PR TITLE
HDPI-8019: exclude gradle build output from withEnvironmentAgent stashes

### DIFF
--- a/test/withEnvironmentAgentTest.groovy
+++ b/test/withEnvironmentAgentTest.groovy
@@ -139,6 +139,20 @@ class WithEnvironmentAgentTest extends BasePipelineTest {
   }
 
   @Test
+  void 'switching environment agent excludes gradle build output from stashes'() {
+    binding.env.ENVIRONMENT_AGENT_LABEL_TEMPLATE_CIVIL = 'civil-{environment}'
+
+    script.call('preview', 'civil') {
+    }
+
+    assertThat(stashArgs).hasSize(2)
+    stashArgs.each { Map args ->
+      assertThat(args.excludes as String).contains('build/**')
+      assertThat(args.excludes as String).contains('**/build/**')
+    }
+  }
+
+  @Test
   void 'failing environment agent body skips workspace propagation back'() {
     binding.env.ENVIRONMENT_AGENT_LABEL_TEMPLATE_CIVIL = 'civil-{environment}'
     binding.env.ORIGINAL_REMOTE_URL = 'https://github.com/HMCTS/civil-service.git'

--- a/vars/withEnvironmentAgent.groovy
+++ b/vars/withEnvironmentAgent.groovy
@@ -32,6 +32,8 @@ def call(String environment, String product, String agentLabelOverride, Closure 
     '**/.yarn/install-state.gz',
     '.gradle/**',
     '**/.gradle/**',
+    'build/**',
+    '**/build/**',
     '.venv/**',
     '**/.venv/**'
   ].join(',')


### PR DESCRIPTION
### What
Adds `build/**` and `**/build/**` to the `withEnvironmentAgent` stash excludes (plus the missing `**/.gradle/**` sibling was already present - list untouched otherwise). Test added alongside the yarn exclusion test.

### Why
The agent-hop stash ships the whole workspace through the controller twice per hop. On a java service (hmcts/pcs-api) the workspace measured **767MB, 742MB of which is `build/`** (du breakdown in build log, PR-2309 #3). Downstream stages recompile from source anyway - `.gradle/**` is already excluded, so a stashed `build/` is never a cache hit, just transfer cost.

Measured effect (pcs-api PR-2309, 31 Jul, degraded controller IO):
- fat stash (767MB): **18.4 min**
- slimmed stash (22MB after removing build output): restore in **36s**
- smoke stage regenerated build/ and paid **20 min** again on its exit stash

pcs-api currently works around this with rm hooks in its Jenkinsfile (afterAlways cleanup); a library-level exclude fixes every gradle consumer on the 2.4.4 line.

### Consideration
Node teams with a `build/` output directory (CRA-style) would also stop stashing it - same argument applies (deploy consumes the docker image, not the workspace), but flagging for review.

Refs: HDPI-7989. Targets the DTSPO-33377 line that 2.4.4 was tagged from.