### PR TITLE
DTSPO-33498: Fix NotSerializableException for Cause objects in sectionNightlyTests

### DIFF
--- a/resources/uk/gov/hmcts/library/allowed-library-branches.yml
+++ b/resources/uk/gov/hmcts/library/allowed-library-branches.yml
@@ -25,3 +25,5 @@ branches:
     allowed: true
   - name: archive-complete-build-results
     allowed: true
+  - name: feat/DTSPO-33498/fix-cause-serialization
+    allowed: true

--- a/vars/sectionNightlyTests.groovy
+++ b/vars/sectionNightlyTests.groovy
@@ -1,5 +1,14 @@
+import com.cloudbees.groovy.cps.NonCPS
 import org.springframework.security.task.DelegatingSecurityContextAsyncTaskExecutor
 import uk.gov.hmcts.contino.Environment
+
+@NonCPS
+boolean isTriggeredByTimer() {
+  def causes = currentBuild.rawBuild?.getCauses() ?: []
+  return causes.any {
+    it.getClass().getName().contains('TimerTriggerCause')
+  }
+}
 
 def call(pcr, config, pipelineType, String product, String component, String subscription) {
 
@@ -84,10 +93,7 @@ def call(pcr, config, pipelineType, String product, String component, String sub
     if (config.performanceTest) {
 
       //Check if build started by chron job
-      def causes = currentBuild.rawBuild?.getCauses() ?: []
-      def triggeredByTimer = causes.any { cause ->
-        cause.getClass().getSimpleName() == "TimerTriggerCause"
-      }
+      boolean triggeredByTimer = isTriggeredByTimer()
 
       boolean doSecondRun = false //This is set to true if first
       def stages = ['Performance test', 'Failed Test Rerun']


### PR DESCRIPTION
## Summary
- Cherry-pick of https://github.com/hmcts/cnp-jenkins-library/pull/1499 onto master
- Wraps timer-trigger cause check in `@NonCPS` so `BranchEventCause` / other Cause objects never enter CPS serialization scope
