### PR TITLE
Allow branch for ignoring migration checks on labs pipelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ bin
 .tool-versions
 
 docs/superpowers/
+graphify-out/

--- a/resources/uk/gov/hmcts/library/allowed-library-branches.yml
+++ b/resources/uk/gov/hmcts/library/allowed-library-branches.yml
@@ -35,3 +35,5 @@ branches:
     allowed: true
   - name: feature/remove-state
     allowed: true
+  - name: acr-migration-check-graceful-failure
+    allowed: true


### PR DESCRIPTION
acr-migration-check-graceful-failure branch contains a fix to enable labs application pipelines to bypass the acr migration check.

It's failing now because the registry doesn't contain the image but the image hasn't been created yet.

Update .gitignore to ignore graphify tool output
