### PR TITLE
Allow smoke tests to skip team secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,17 @@ called after each deployment to each environment.
 
 The smoke tests are to be non-destructive (i.e. have no data impact, such as not creating accounts) and a subset of component level functional tests.
 
+If a smoke test only uses `TEST_URL` and does not require the secrets configured by `loadVaultSecrets`, it can avoid loading them for that stage:
+
+```groovy
+withPipeline(type, product, component) {
+  loadVaultSecrets(secrets)
+  disableSmokeTestSecrets()
+}
+```
+
+The configured secrets remain available to deployment, functional and other test stages.
+
 #### Docker test build for continuous functional and smoke tests
 
 An application can configure running continuous smoke/functional tests on java app deployments managed through flux.

--- a/resources/uk/gov/hmcts/library/allowed-library-branches.yml
+++ b/resources/uk/gov/hmcts/library/allowed-library-branches.yml
@@ -25,6 +25,8 @@ branches:
     allowed: true
   - name: archive-complete-build-results
     allowed: true
+  - name: feature/optional-smoke-test-secrets
+    allowed: true
   - name: feat/DTSPO-33498/fix-cause-serialization
     allowed: true
   - name: performance-stages-updatev5

--- a/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
@@ -20,6 +20,7 @@ class AppPipelineConfig extends CommonPipelineConfig implements Serializable {
   boolean e2eTest = false
   boolean securityScan = false
   boolean serviceApp = true
+  boolean smokeTestSecrets = true
   boolean deployableApp = true
   boolean releaseOnMerge = false
   boolean libraryBranchAllowed = false

--- a/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
@@ -88,6 +88,10 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
     config.serviceApp = false
   }
 
+  void disableSmokeTestSecrets() {
+    config.smokeTestSecrets = false
+  }
+
   void nonDeployableApp() {
     config.deployableApp = false
     nonServiceApp()

--- a/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
+++ b/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
@@ -33,6 +33,7 @@ class AppPipelineConfigTest extends Specification {
       assertThat(pipelineConfig.securityScan).isFalse()
       assertThat(pipelineConfig.legacyDeployment).isTrue()
       assertThat(pipelineConfig.serviceApp).isTrue()
+      assertThat(pipelineConfig.smokeTestSecrets).isTrue()
       assertThat(pipelineConfig.deployableApp).isTrue()
       assertThat(pipelineConfig.libraryBranchAllowed).isFalse()
       assertThat(pipelineConfig.releaseOnMerge).isFalse()
@@ -61,6 +62,13 @@ class AppPipelineConfigTest extends Specification {
       dsl.loadVaultSecrets(secrets)
     then:
       assertThat(pipelineConfig.vaultSecrets).isEqualTo(secrets)
+  }
+
+  def "disable smoke test secrets"() {
+    when:
+      dsl.disableSmokeTestSecrets()
+    then:
+      assertThat(pipelineConfig.smokeTestSecrets).isFalse()
   }
 
   def "ensure enable e2e test"() {

--- a/test/withPipeline/onPreview/withJavaPipelineOnPreviewTests.groovy
+++ b/test/withPipeline/onPreview/withJavaPipelineOnPreviewTests.groovy
@@ -5,8 +5,12 @@ import org.junit.Test
 import uk.gov.hmcts.contino.GradleBuilder
 import withPipeline.BaseCnpPipelineTest
 
+import static com.lesfurets.jenkins.unit.MethodCall.callArgsToString
+import static org.assertj.core.api.Assertions.assertThat
+
 class withJavaPipelineOnPreviewTests extends BaseCnpPipelineTest {
   final static jenkinsFile = "exampleJavaPipeline.jenkins"
+  final static pipelineWithSecrets = "exampleJavaPipelineWithSmokeSecretControl.jenkins"
 
   withJavaPipelineOnPreviewTests() {
     super("PR-999", jenkinsFile)
@@ -15,18 +19,7 @@ class withJavaPipelineOnPreviewTests extends BaseCnpPipelineTest {
   @Test
   void PipelineExecutesExpectedStepsInExpectedOrder() {
 
-    def stubBuilder = new StubFor(GradleBuilder)
-    stubBuilder.demand.with {
-      setupToolVersion(0) {}
-      build(0) {}
-      test(0) {}
-      securityCheck(0) {}
-      techStackMaintenance(0) {}
-      sonarScan(0) {}
-      smokeTest(0) {} //preview-staging
-      e2eTest(0) {}
-      functionalTest(0) {}
-    }
+    def stubBuilder = javaBuilderStub()
 
     binding.getVariable('env').putAt('CHANGE_URL', 'http://github.com/some-repo/pr/16')
     binding.getVariable('env').putAt('CHANGE_TITLE', 'Some change')
@@ -37,5 +30,70 @@ class withJavaPipelineOnPreviewTests extends BaseCnpPipelineTest {
 
     stubBuilder.expect.verify()
   }
-}
 
+  @Test
+  void smokeTestUsesTeamSecretsByDefault() {
+    enablePipelineExecution()
+
+    runScript("testResources/$pipelineWithSecrets")
+
+    def secretIndexes = teamSecretIndexes()
+    def smokeIndex = stageIndex('Smoke Test - AKS preview')
+    def functionalIndex = stageIndex('Functional Test - preview')
+
+    assertThat(secretIndexes).hasSize(2)
+    assertThat(secretIndexes.last()).isLessThan(smokeIndex)
+    assertThat(smokeIndex).isLessThan(functionalIndex)
+  }
+
+  @Test
+  void smokeTestCanRunBeforeTeamSecretsAreLoaded() {
+    binding.getVariable('env').putAt('DISABLE_SMOKE_TEST_SECRETS', 'true')
+    enablePipelineExecution()
+
+    runScript("testResources/$pipelineWithSecrets")
+
+    def secretIndexes = teamSecretIndexes()
+    def smokeIndex = stageIndex('Smoke Test - AKS preview')
+    def functionalIndex = stageIndex('Functional Test - preview')
+
+    assertThat(secretIndexes).hasSize(2)
+    assertThat(smokeIndex).isLessThan(secretIndexes.last())
+    assertThat(secretIndexes.last()).isLessThan(functionalIndex)
+  }
+
+  private StubFor javaBuilderStub() {
+    def stubBuilder = new StubFor(GradleBuilder)
+    stubBuilder.demand.with {
+      setupToolVersion(0) {}
+      build(0) {}
+      test(0) {}
+      securityCheck(0) {}
+      techStackMaintenance(0) {}
+      sonarScan(0) {}
+      smokeTest(0) {}
+      e2eTest(0) {}
+      functionalTest(0) {}
+    }
+    stubBuilder
+  }
+
+  private void enablePipelineExecution() {
+    helper.registerAllowedMethod('retry', [LinkedHashMap.class, Closure.class], { Map ignored, Closure body ->
+      body.call()
+    })
+  }
+
+  private List<Integer> teamSecretIndexes() {
+    (0..<helper.callStack.size()).findAll { index ->
+      def call = helper.callStack[index]
+      call.methodName == 'withAzureKeyvault' && callArgsToString(call).contains('example-secret')
+    }
+  }
+
+  private int stageIndex(String stageName) {
+    helper.callStack.findIndexOf { call ->
+      call.methodName == 'stage' && callArgsToString(call).contains(stageName)
+    }
+  }
+}

--- a/test/withPipeline/onPreview/withJavaPipelineOnPreviewTests.groovy
+++ b/test/withPipeline/onPreview/withJavaPipelineOnPreviewTests.groovy
@@ -42,6 +42,8 @@ class withJavaPipelineOnPreviewTests extends BaseCnpPipelineTest {
     def functionalIndex = stageIndex('Functional Test - preview')
 
     assertThat(secretIndexes).hasSize(2)
+    assertThat(smokeIndex).isNotNegative()
+    assertThat(functionalIndex).isNotNegative()
     assertThat(secretIndexes.last()).isLessThan(smokeIndex)
     assertThat(smokeIndex).isLessThan(functionalIndex)
   }
@@ -58,6 +60,8 @@ class withJavaPipelineOnPreviewTests extends BaseCnpPipelineTest {
     def functionalIndex = stageIndex('Functional Test - preview')
 
     assertThat(secretIndexes).hasSize(2)
+    assertThat(smokeIndex).isNotNegative()
+    assertThat(functionalIndex).isNotNegative()
     assertThat(smokeIndex).isLessThan(secretIndexes.last())
     assertThat(secretIndexes.last()).isLessThan(functionalIndex)
   }

--- a/testResources/exampleJavaPipelineWithSmokeSecretControl.jenkins
+++ b/testResources/exampleJavaPipelineWithSmokeSecretControl.jenkins
@@ -1,0 +1,26 @@
+#!groovy
+
+@Library("Infrastructure")
+
+import uk.gov.hmcts.pipeline.DeploymentControls
+
+def secrets = [
+  'product-${env}': [[
+    $class: 'AzureKeyVaultSecret',
+    secretType: 'Secret',
+    name: 'example-secret',
+    version: '',
+    envVariable: 'EXAMPLE_SECRET'
+  ]]
+]
+
+DeploymentControls.deploymentControls = [
+  repositories: [[repo: env.GIT_URL, 'deployment-enabled': true]]
+]
+
+withPipeline('java', 'product', 'app') {
+  loadVaultSecrets(secrets)
+  if (env.DISABLE_SMOKE_TEST_SECRETS == 'true') {
+    disableSmokeTestSecrets()
+  }
+}

--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -108,7 +108,7 @@ def call(params) {
         }
       }
       if (config.serviceApp) {
-        withTeamSecrets(config, environment) {
+        def smokeTestStage = {
           stageWithAgent("Smoke Test - AKS ${environment}", product) {
             testEnv(aksUrl) {
               def success = true
@@ -128,6 +128,16 @@ def call(params) {
                 }
               }
             }
+          }
+        }
+
+        if (!config.smokeTestSecrets) {
+          smokeTestStage.call()
+        }
+
+        withTeamSecrets(config, environment) {
+          if (config.smokeTestSecrets) {
+            smokeTestStage.call()
           }
 
           onFunctionalTestEnvironment(environment) {
@@ -467,4 +477,3 @@ def call(params) {
     }
   }
 }
-


### PR DESCRIPTION
## What changed

- add a backwards-compatible `disableSmokeTestSecrets()` pipeline option
- run the smoke-test stage outside `withTeamSecrets` only when that option is enabled
- keep deployment, functional, performance, and other test secret loading unchanged
- document the option and cover both the default and opt-out paths with regression tests

## Why

Some smoke tests only use `TEST_URL` and should not receive the application secrets configured by `loadVaultSecrets`. This option scopes those secrets away from the smoke test while preserving existing behaviour by default.

On current `master`, smoke and subsequent test stages share one team-secret binding. If a later functional or performance test needs those secrets, they are still fetched once after smoke; this change therefore improves least-privilege access and stage attribution but does not guarantee a whole-pipeline timing reduction. It also does not bypass the subscription login or secret loading required by deployment and other stages.

## Prerequisite

- #1522 must merge first because downstream pipeline validation reads the permitted library branches from `master`

## Example

```groovy
withPipeline(type, product, component) {
  loadVaultSecrets(secrets)
  disableSmokeTestSecrets()
}
```

## Validation

- `./gradlew check --rerun-tasks` — 336 tests, 0 failures
- regression coverage verifies that smoke and functional stages exist before checking their secret-loading order
- `git diff --check`