### PR TITLE
Allow smoke secret branch for pipeline testing

### DIFF
--- a/resources/uk/gov/hmcts/library/allowed-library-branches.yml
+++ b/resources/uk/gov/hmcts/library/allowed-library-branches.yml
@@ -25,6 +25,8 @@ branches:
     allowed: true
   - name: archive-complete-build-results
     allowed: true
+  - name: feature/optional-smoke-test-secrets
+    allowed: true
   - name: feat/DTSPO-33498/fix-cause-serialization
     allowed: true
   - name: performance-stages-updatev5


### PR DESCRIPTION
## What changed

- allow `feature/optional-smoke-test-secrets` in the shared-library branch controls

## Why

This is a prerequisite for #1520. The Jenkins library validation job passes that feature branch to the downstream plum pipelines, but those pipelines read the approved branch list from `master`. Without this entry they stop before exercising the proposed library behaviour and report that the commit cannot be built.

## Validation

- `./gradlew check --rerun-tasks` on the feature branch — 336 tests, 0 failures
- `git diff --check`