### PR TITLE
Backport optional smoke-test secrets for 2.4.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,17 @@ called after each deployment to each environment.
 
 The smoke tests are to be non-destructive (i.e. have no data impact, such as not creating accounts) and a subset of component level functional tests.
 
+If a smoke test only uses `TEST_URL` and does not require the secrets configured by `loadVaultSecrets`, it can avoid loading them for that stage:
+
+```groovy
+withPipeline(type, product, component) {
+  loadVaultSecrets(secrets)
+  disableSmokeTestSecrets()
+}
+```
+
+The configured secrets remain available to deployment, functional and other test stages.
+
 #### Docker test build for continuous functional and smoke tests
 
 An application can configure running continuous smoke/functional tests on java app deployments managed through flux.

--- a/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineConfig.groovy
@@ -20,6 +20,7 @@ class AppPipelineConfig extends CommonPipelineConfig implements Serializable {
   boolean e2eTest = false
   boolean securityScan = false
   boolean serviceApp = true
+  boolean smokeTestSecrets = true
   boolean deployableApp = true
   boolean releaseOnMerge = false
   boolean aksStagingDeployment = false

--- a/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
+++ b/src/uk/gov/hmcts/contino/AppPipelineDsl.groovy
@@ -88,6 +88,10 @@ class AppPipelineDsl extends CommonPipelineDsl implements Serializable {
     config.serviceApp = false
   }
 
+  void disableSmokeTestSecrets() {
+    config.smokeTestSecrets = false
+  }
+
   void nonDeployableApp() {
     config.deployableApp = false
     nonServiceApp()

--- a/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
+++ b/test/uk/gov/hmcts/contino/AppPipelineConfigTest.groovy
@@ -33,6 +33,7 @@ class AppPipelineConfigTest extends Specification {
       assertThat(pipelineConfig.securityScan).isFalse()
       assertThat(pipelineConfig.legacyDeployment).isTrue()
       assertThat(pipelineConfig.serviceApp).isTrue()
+      assertThat(pipelineConfig.smokeTestSecrets).isTrue()
       assertThat(pipelineConfig.deployableApp).isTrue()
       assertThat(pipelineConfig.releaseOnMerge).isFalse()
       assertThat(pipelineConfig.pactBrokerEnabled).isFalse()
@@ -61,6 +62,13 @@ class AppPipelineConfigTest extends Specification {
       dsl.loadVaultSecrets(secrets)
     then:
       assertThat(pipelineConfig.vaultSecrets).isEqualTo(secrets)
+  }
+
+  def "disable smoke test secrets"() {
+    when:
+      dsl.disableSmokeTestSecrets()
+    then:
+      assertThat(pipelineConfig.smokeTestSecrets).isFalse()
   }
 
   def "ensure enable e2e test"() {

--- a/test/withPipeline/onPreview/withJavaPipelineOnPreviewTests.groovy
+++ b/test/withPipeline/onPreview/withJavaPipelineOnPreviewTests.groovy
@@ -5,8 +5,12 @@ import org.junit.Test
 import uk.gov.hmcts.contino.GradleBuilder
 import withPipeline.BaseCnpPipelineTest
 
+import static com.lesfurets.jenkins.unit.MethodCall.callArgsToString
+import static org.assertj.core.api.Assertions.assertThat
+
 class withJavaPipelineOnPreviewTests extends BaseCnpPipelineTest {
   final static jenkinsFile = "exampleJavaPipeline.jenkins"
+  final static pipelineWithSecrets = "exampleJavaPipelineWithSmokeSecretControl.jenkins"
 
   withJavaPipelineOnPreviewTests() {
     super("PR-999", jenkinsFile)
@@ -15,18 +19,7 @@ class withJavaPipelineOnPreviewTests extends BaseCnpPipelineTest {
   @Test
   void PipelineExecutesExpectedStepsInExpectedOrder() {
 
-    def stubBuilder = new StubFor(GradleBuilder)
-    stubBuilder.demand.with {
-      setupToolVersion(0) {}
-      build(0) {}
-      test(0) {}
-      securityCheck(0) {}
-      techStackMaintenance(0) {}
-      sonarScan(0) {}
-      smokeTest(0) {} //preview-staging
-      e2eTest(0) {}
-      functionalTest(0) {}
-    }
+    def stubBuilder = javaBuilderStub()
 
     binding.getVariable('env').putAt('CHANGE_URL', 'http://github.com/some-repo/pr/16')
     binding.getVariable('env').putAt('CHANGE_TITLE', 'Some change')
@@ -37,5 +30,76 @@ class withJavaPipelineOnPreviewTests extends BaseCnpPipelineTest {
 
     stubBuilder.expect.verify()
   }
-}
 
+  @Test
+  void smokeTestUsesTeamSecretsByDefault() {
+    enablePipelineExecution()
+
+    runScript("testResources/$pipelineWithSecrets")
+
+    def secretIndexes = teamSecretIndexes()
+    def smokeIndex = stageIndex('Smoke Test - AKS preview')
+    def functionalIndex = stageIndex('Functional Test - preview')
+
+    assertThat(secretIndexes).hasSize(4)
+    assertThat(smokeIndex).isNotNegative()
+    assertThat(functionalIndex).isNotNegative()
+    assertThat(secretIndexes[1]).isLessThan(smokeIndex)
+    assertThat(secretIndexes).anyMatch { it > smokeIndex && it < functionalIndex }
+    assertThat(smokeIndex).isLessThan(functionalIndex)
+  }
+
+  @Test
+  void smokeTestCanRunBeforeTeamSecretsAreLoaded() {
+    binding.getVariable('env').putAt('DISABLE_SMOKE_TEST_SECRETS', 'true')
+    enablePipelineExecution()
+
+    runScript("testResources/$pipelineWithSecrets")
+
+    def secretIndexes = teamSecretIndexes()
+    def smokeIndex = stageIndex('Smoke Test - AKS preview')
+    def functionalIndex = stageIndex('Functional Test - preview')
+
+    assertThat(secretIndexes).hasSize(3)
+    assertThat(smokeIndex).isNotNegative()
+    assertThat(functionalIndex).isNotNegative()
+    assertThat(smokeIndex).isLessThan(secretIndexes[1])
+    assertThat(secretIndexes[1]).isLessThan(functionalIndex)
+    assertThat(smokeIndex).isLessThan(functionalIndex)
+  }
+
+  private StubFor javaBuilderStub() {
+    def stubBuilder = new StubFor(GradleBuilder)
+    stubBuilder.demand.with {
+      setupToolVersion(0) {}
+      build(0) {}
+      test(0) {}
+      securityCheck(0) {}
+      techStackMaintenance(0) {}
+      sonarScan(0) {}
+      smokeTest(0) {}
+      e2eTest(0) {}
+      functionalTest(0) {}
+    }
+    stubBuilder
+  }
+
+  private void enablePipelineExecution() {
+    helper.registerAllowedMethod('retry', [LinkedHashMap.class, Closure.class], { Map ignored, Closure body ->
+      body.call()
+    })
+  }
+
+  private List<Integer> teamSecretIndexes() {
+    (0..<helper.callStack.size()).findAll { index ->
+      def call = helper.callStack[index]
+      call.methodName == 'withTeamSecrets'
+    }
+  }
+
+  private int stageIndex(String stageName) {
+    helper.callStack.findIndexOf { call ->
+      call.methodName == 'stage' && callArgsToString(call).contains(stageName)
+    }
+  }
+}

--- a/testResources/exampleJavaPipelineWithSmokeSecretControl.jenkins
+++ b/testResources/exampleJavaPipelineWithSmokeSecretControl.jenkins
@@ -1,0 +1,26 @@
+#!groovy
+
+@Library("Infrastructure")
+
+import uk.gov.hmcts.pipeline.DeploymentControls
+
+def secrets = [
+  'product-${env}': [[
+    $class: 'AzureKeyVaultSecret',
+    secretType: 'Secret',
+    name: 'example-secret',
+    version: '',
+    envVariable: 'EXAMPLE_SECRET'
+  ]]
+]
+
+DeploymentControls.deploymentControls = [
+  repositories: [[repo: env.GIT_URL, 'deployment-enabled': true]]
+]
+
+withPipeline('java', 'product', 'app') {
+  loadVaultSecrets(secrets)
+  if (env.DISABLE_SMOKE_TEST_SECRETS == 'true') {
+    disableSmokeTestSecrets()
+  }
+}

--- a/vars/sectionDeployToAKS.groovy
+++ b/vars/sectionDeployToAKS.groovy
@@ -26,7 +26,7 @@ def clearHelmReleaseForFailure(boolean enableHelmLabel, AppPipelineConfig config
   }
 }
 
-def stageWithEnvironmentAgentAndSecrets(String stageName, AppPipelineConfig config, String product, String environment, Closure body) {
+def stageWithEnvironmentAgentAndSecrets(String stageName, config, String product, String environment, Closure body) {
   stageWithEnvironmentAgent(stageName, product, environment) {
     // Fetch team secrets after the node hop so Key Vault auth/env injection runs on the target environment agent.
     withTeamSecrets(config, environment, product) {
@@ -119,28 +119,36 @@ def call(params) {
         }
       }
       if (config.serviceApp) {
-        withTeamSecrets(config, environment) {
-          stageWithEnvironmentAgentAndSecrets("Smoke Test - AKS ${environment}", config, product, environment) {
-            testEnv(aksUrl) {
-              def success = true
-              try {
-                pcr.callAround("smoketest:${environment}") {
-                  timeoutWithMsg(time: 120, unit: 'MINUTES', action: 'Smoke Test - AKS') {
-                    builder.smokeTest()
-                  }
+        def smokeTestStage = {
+          testEnv(aksUrl) {
+            def success = true
+            try {
+              pcr.callAround("smoketest:${environment}") {
+                timeoutWithMsg(time: 120, unit: 'MINUTES', action: 'Smoke Test - AKS') {
+                  builder.smokeTest()
                 }
-              } catch (err) {
-                success = false
-                throw err
-              } finally {
-                savePodsLogs(dockerImage, params, "smoke")
-                if (!success) {
-                  clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
-                }
+              }
+            } catch (err) {
+              success = false
+              throw err
+            } finally {
+              savePodsLogs(dockerImage, params, "smoke")
+              if (!success) {
+                clearHelmReleaseForFailure(enableHelmLabel, config, dockerImage, params, pcr)
               }
             }
           }
-    
+        }
+
+        if (!config.smokeTestSecrets) {
+          stageWithEnvironmentAgent("Smoke Test - AKS ${environment}", product, environment, smokeTestStage)
+        }
+
+        withTeamSecrets(config, environment) {
+          if (config.smokeTestSecrets) {
+            stageWithEnvironmentAgentAndSecrets("Smoke Test - AKS ${environment}", config, product, environment, smokeTestStage)
+          }
+
           onFunctionalTestEnvironment(environment) {
             if (testLabels.contains('enable_full_functional_tests')) {
               stageWithEnvironmentAgentAndSecrets('Functional test (Full)', config, product, environment) {


### PR DESCRIPTION
## What changed

Backports the optional smoke-test secret handling from #1520 onto the branch used for the 2.4.9 release line. Pipelines retain the existing behaviour by default and can call `disableSmokeTestSecrets()` to run the smoke stage without loading team Key Vault secrets.

## Why

Testing in et-ccd-callbacks showed that avoiding unnecessary smoke-stage secret retrieval reduced the stage by nearly one minute. Keeping this change on the 2.4.9 line allows PlatOps to review it for a possible 2.4.10 release without pulling in unrelated master changes.

## Compatibility

The default remains `smokeTestSecrets = true`, so existing consumers are unaffected. The opt-out path retains the environment-specific executor but bypasses team-secret retrieval for the smoke stage only. Functional and other test stages continue to load their secrets normally.

## Validation

- Focused configuration and preview pipeline tests: 34 passed
- Full library test suite: 400 passed
- `git diff --check` passed

Original change: #1520