### PR TITLE
DTSPO-33915: Add DTSPO-33915-kubeconform-jenkins to allowed library branch

### DIFF
--- a/resources/uk/gov/hmcts/library/allowed-library-branches.yml
+++ b/resources/uk/gov/hmcts/library/allowed-library-branches.yml
@@ -43,3 +43,5 @@ branches:
     allowed: true
   - name: feat/stage-cost-metrics
     allowed: true
+  - name: DTSPO-33915-kubeconform-jenkins
+    allowed: true


### PR DESCRIPTION
Allows the cnp-plum-shared-infrastructure Pipeline Test job to test-drive the in-flight kubeconform library branch before it merges to master.

