### PR TITLE
fix(fortify): use real OAuth credentials for library FoD scan runner

### DIFF
--- a/vars/fortifyOnDemandScan.groovy
+++ b/vars/fortifyOnDemandScan.groovy
@@ -73,10 +73,15 @@ EOF
 }
 trap cleanup EXIT
 
-client_id="\${FORTIFY_USER_NAME:-}"
-client_secret="\${FORTIFY_PASSWORD:-}"
+# Prefer real FoD OAuth API Key/Secret Key (FORTIFY_OAUTH_CLIENT_ID/CLIENT_SECRET, from the
+# 'fortify-on-demand-oauth' Jenkins credential). FORTIFY_USER_NAME/PASSWORD are SSC-style
+# tenant\\username + PAT credentials used by the Basic-Auth Gradle/Yarn fortifyScan tasks and
+# are NOT valid OAuth client_credentials - using them here caused 401s for repos without a
+# repo-level fortifyScan task (they fall back to this library runner with no other creds).
+client_id="\${FORTIFY_OAUTH_CLIENT_ID:-\${FORTIFY_USER_NAME:-}}"
+client_secret="\${FORTIFY_OAUTH_CLIENT_SECRET:-\${FORTIFY_PASSWORD:-}}"
 if [ -z "$client_id" ] || [ -z "$client_secret" ]; then
-  error='missing FoD credentials (expected FORTIFY_USER_NAME/FORTIFY_PASSWORD from Jenkins credentials binding)'
+  error='missing FoD OAuth credentials (expected FORTIFY_OAUTH_CLIENT_ID/FORTIFY_OAUTH_CLIENT_SECRET from Jenkins credentials binding)'
   echo "Fortify: $error"
   exit 1
 fi

--- a/vars/fortifyScan.groovy
+++ b/vars/fortifyScan.groovy
@@ -12,14 +12,18 @@ def call(params) {
 
   stageWithAgent("Fortify Scan", product) {
     withFortifySecrets(fortifyVaultName) {
-      warnError(message: 'Failure in Fortify Scan', stageResult: 'UNSTABLE') {
-        pcr.callAround('fortify-scan') {
-          builder.fortifyScan()
+      // The library FoD scan runner (fallback when the repo has no fortifyScan task/script)
+      // needs the real OAuth client_id/secret, not just the vault username/password.
+      withFortifyOAuthSecrets {
+        warnError(message: 'Failure in Fortify Scan', stageResult: 'UNSTABLE') {
+          pcr.callAround('fortify-scan') {
+            builder.fortifyScan()
+          }
         }
-      }
 
-      warnError(message: 'Failure in Fortify vulnerability report', stageResult: 'UNSTABLE') {
-        fortifyVulnerabilityReport()
+        warnError(message: 'Failure in Fortify vulnerability report', stageResult: 'UNSTABLE') {
+          fortifyVulnerabilityReport()
+        }
       }
 
       archiveArtifacts allowEmptyArchive: true, artifacts: 'Fortify Scan/FortifyScanReport.html,Fortify Scan/FortifyVulnerabilities.*'

--- a/vars/sectionBuildAndTest.groovy
+++ b/vars/sectionBuildAndTest.groovy
@@ -168,14 +168,18 @@ def call(params) {
             deleteDir()
             checkout scm
             withFortifySecrets(config.fortifyVaultName ?: "${product}-${params.environment}") {
-              warnError('Failure in Fortify Scan') {
-                pcr.callAround('fortify-scan') {
-                  builder.fortifyScan()
+              // The library FoD scan runner (fallback when the repo has no fortifyScan task/script)
+              // needs the real OAuth client_id/secret, not just the vault username/password.
+              withFortifyOAuthSecrets {
+                warnError('Failure in Fortify Scan') {
+                  pcr.callAround('fortify-scan') {
+                    builder.fortifyScan()
+                  }
                 }
-              }
 
-              warnError('Failure in Fortify vulnerability report') {
-                fortifyVulnerabilityReport()
+                warnError('Failure in Fortify vulnerability report') {
+                  fortifyVulnerabilityReport()
+                }
               }
 
               archiveArtifacts allowEmptyArchive: true, artifacts: 'Fortify Scan/FortifyScanReport.html,Fortify Scan/FortifyVulnerabilities.*'


### PR DESCRIPTION
Newly onboarded repos without a repo-level fortifyScan task fall back to the library's FoD scan runner, which authenticates via OAuth client_credentials. It was using FORTIFY_USER_NAME/FORTIFY_PASSWORD (SSC-style username/PAT from the per-product Key Vault) as the OAuth client_id/client_secret, which Fortify correctly rejects with 401.

- fortifyOnDemandScan: prefer FORTIFY_OAUTH_CLIENT_ID/CLIENT_SECRET, falling back to FORTIFY_USER_NAME/PASSWORD only if unset
- fortifyScan / sectionBuildAndTest: bind withFortifyOAuthSecrets around the scan step itself, not just the post-scan vulnerability report, so the real OAuth credential is actually available when needed

Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
*
*
*
