### PR TITLE
Wait on rollout status instead of pod names after helm install

### DIFF
--- a/src/uk/gov/hmcts/contino/Helm.groovy
+++ b/src/uk/gov/hmcts/contino/Helm.groovy
@@ -294,11 +294,26 @@ class Helm {
            exit 1
         fi
 
-        echo 'Waiting for pods to be scheduled and ready...'
-        kubectl wait --for=condition=ready pod \\
-          -l app.kubernetes.io/instance=${releaseName},'!job-name' \\
-          -n ${this.namespace} \\
-          --timeout=1220s || ./aks-debug-info.sh ${releaseName} ${this.namespace}
+        echo 'Waiting for rollout to complete...'
+        DEADLINE=\$(( \$(date +%s) + 1220 ))
+        RESOURCES=\$(kubectl get deploy,sts -n ${this.namespace} -l app.kubernetes.io/instance=${releaseName} -o name 2>/dev/null || true)
+
+        if [ -z "\$RESOURCES" ]; then
+          echo "No deployments or statefulsets found for ${releaseName} - skipping rollout wait"
+        else
+          for RESOURCE in \$RESOURCES; do
+            REMAINING=\$(( \$DEADLINE - \$(date +%s) ))
+            if [ "\$REMAINING" -le 0 ]; then
+              echo "Deadline reached before rollout completed"
+              ./aks-debug-info.sh ${releaseName} ${this.namespace}
+              exit 1
+            fi
+            kubectl rollout status "\$RESOURCE" -n ${this.namespace} --timeout=\${REMAINING}s || {
+              ./aks-debug-info.sh ${releaseName} ${this.namespace}
+              exit 1
+            }
+          done
+        fi
         """)
     } else {
       this.steps.sh(label: 'helm upgrade', script: "helm upgrade ${releaseName}  ${this.chartLocation} ${valuesStr} ${optionsStr} || ./aks-debug-info.sh ${releaseName} ${this.namespace}")

--- a/test/uk/gov/hmcts/contino/HelmTest.groovy
+++ b/test/uk/gov/hmcts/contino/HelmTest.groovy
@@ -73,9 +73,9 @@ class HelmTest extends Specification {
       it.get('script').contains('timeout 60 kubectl get pods -n cnp -l app.kubernetes.io/instance=my-chart-pr-1,' + "'!job-name'" + ' -w 2>/dev/null | grep -m1 "Running\\|Pending" > /dev/null') &&
       it.get('script').contains('No pods found matching selector - this chart may only contain jobs/cronjobs') &&
       it.get('script').contains("ImagePullBackOff|ErrImagePull|CrashLoopBackOff|CreateContainerConfigError") &&
-      it.get('script').contains("Waiting for pods to be scheduled and ready...") &&
-      it.get('script').contains("kubectl wait --for=condition=ready pod") &&
-      it.get('script').contains("--timeout=1220s")
+      it.get('script').contains("Waiting for rollout to complete...") &&
+      it.get('script').contains("kubectl rollout status") &&
+      it.get('script').contains("kubectl get deploy,sts")
     })
     1 * steps.sh('rm aks-debug-info.sh')
   }


### PR DESCRIPTION
### Summary
After `helm install` on pull request environments, `Helm.groovy` waits for readiness with `kubectl wait --for=condition=ready pod -l app.kubernetes.io/instance=<release>,'!job-name' --timeout=1220s`. `kubectl wait` resolves the matching pod names once and then waits on each name in turn. When the preview autoscaler evicts a pod during the wait, the replacement has a new name, so the wait blocks on a name that never returns until the 1220 second timeout, then the stage uninstalls and retries, frequently into the 40 minute stage ceiling.

This change keeps the initial pod creation watch and the ImagePullBackOff / ErrImagePull / CrashLoopBackOff / CreateContainerConfigError fail fast exactly as they are, and replaces only the pod wait with `kubectl rollout status` over the release's deployments and statefulsets, inside the same 1220 second budget and with the same `./aks-debug-info.sh` failure path. `rollout status` follows the replica set, so a pod being replaced mid wait no longer blocks the build.

### Evidence
pcs-api PR-2311, 3 September 2026:
- Build 76 aborted and build 77 failed in `AKS deploy - preview` (1923 s). Build 78 sat in the wait from 12:44:58 UTC with every pod 1/1 Running while the console showed `condition met` for the first pod only.
- `kubectl get events -n pcs` in the same window: `ScaleDown deleting pod for node scale down` on the definition store pod and a replacement of the ccd-admin-web pod. The wait timed out at 13:05:18 on `pods/pcs-api-pr-2311-ccd-admin-web-7874fddbbb-jlp5z` (the replaced pod); the five remaining pods printed `condition met` in the same second.
- The retry reinstalled at 13:06:43 and passed at 13:08:04 with no eviction during the second wait.

### Change
`src/uk/gov/hmcts/contino/Helm.groovy` (install path): deadline computed from the start epoch; `kubectl get deploy,sts -o name` for the release; `kubectl rollout status <resource> --timeout=<remaining>s` per resource; on deadline or rollout failure run `./aks-debug-info.sh` and exit 1. If the release has no deployments or statefulsets (jobs only charts) the wait is skipped, matching the existing "no pods" exit path.

`test/uk/gov/hmcts/contino/HelmTest.groovy` updated to assert on the new script text.

### Notes for reviewers
- Behaviour on success is unchanged; the only difference is what the wait follows.
- A statefulset with `updateStrategy: OnDelete` would make `rollout status` wait until the deadline; none of the pcs charts use it, but worth a thought for other services.
- Raised from the pcs team (HDPI). Happy to attach a DTSPO key if you would like one for tracking; the full evidence pack can be shared.
