### PR TITLE
DTSPO-34601 - update allowed branches

### DIFF
--- a/resources/uk/gov/hmcts/library/allowed-library-branches.yml
+++ b/resources/uk/gov/hmcts/library/allowed-library-branches.yml
@@ -21,6 +21,8 @@ branches:
     allowed: true
   - name: DTSPO-30107-jenkins-agents-2
     allowed: true
+  - name: DTSPO-30107-jenkins-agents-3
+    allowed: true
   - name: poll_for_helm
     allowed: true
   - name: archive-complete-build-results


### PR DESCRIPTION
Adding branch to allow list.

Branch changes nightly pipeline agent label from `daily` to `nightly`

Testing it works on pipelines not migrated to `2.x`
