### PR TITLE
DTSPO-34601 - Change nightly pipeline label to nightly

### DIFF
--- a/vars/withNightlyPipeline.groovy
+++ b/vars/withNightlyPipeline.groovy
@@ -53,13 +53,13 @@ def call(type, product, component, timeout = 300, Closure body) {
   String nodeSelector
 
   if (agentType == "") {
-    nodeSelector = "daily"
+    nodeSelector = "nightly"
   } else if (agentType == "civil") {
     nodeSelector = agentType
   } else if (agentType == "xui") {
     nodeSelector = agentType
   } else {
-    nodeSelector = agentType + ' && daily'
+    nodeSelector = agentType + ' && nightly'
   }
 
   def libraryBranchAllowed = new LibraryBranchControls(this).isBranchAllowed(pipelineConfig)


### PR DESCRIPTION
Currently a misnomer in the agent name

Agent pools have been added to [cft](https://github.com/hmcts/cnp-flux-config/pull/47324) and [sds](https://github.com/hmcts/sds-flux-config/pull/8908)

Changes have been merged into the `2.x` branch and released under version `2.7.0`

Mirroring the changes in master.

Daily pools are still there and the nightly agents are the same, just with a better label.

Ran on fpl-ccd-configuration pipeline and it scheduled fine:
<img width="2290" height="359" alt="image" src="https://github.com/user-attachments/assets/9a73e2c5-63dd-4ac5-bdb6-2b74a0b3bf1d" />
