### PR TITLE
fix(cache): support Yarn and Gradle together

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ withPipeline(type, product, component) {
 }
 ```
 
+#### Build dependency caching
+
+Use a tagged version of the Infrastructure library (`2.7.0` or later), then opt in to caching Gradle and Yarn dependencies during the Build stage:
+
+```groovy
+withPipeline(type, product, component) {
+  enableBuildCache()
+}
+```
+
 #### Branch and Environment Mapping
 The opinionated pipeline uses the following branch mapping to deploy applications to different environments.
 

--- a/test/withBuildCacheTest.groovy
+++ b/test/withBuildCacheTest.groovy
@@ -52,6 +52,23 @@ class withBuildCacheTest extends BasePipelineTest {
   }
 
   @Test
+  void 'caches yarn and Gradle dependencies together'() {
+    files.addAll(['yarn.lock', 'gradlew'])
+    boolean called = false
+
+    script.call([buildCache: true]) { called = true }
+
+    assertThat(called).isTrue()
+    assertThat(cacheCalls).hasSize(1)
+    assertThat(cacheCalls[0].caches*.cacheName).containsExactly(
+      'yarn-node-modules',
+      'yarn-pnp',
+      'gradle-dependencies',
+      'gradle-wrapper'
+    )
+  }
+
+  @Test
   void 'does not call the plugin when caching is disabled'() {
     boolean called = false
 

--- a/vars/withBuildCache.groovy
+++ b/vars/withBuildCache.groovy
@@ -6,50 +6,49 @@ def call(config, Closure body) {
     return
   }
 
+  def caches = []
+
   if (fileExists('yarn.lock')) {
-    cache(
-      maxCacheSize: 2048,
-      defaultBranch: 'master',
-      caches: [
-        arbitraryFileCache(
-          path: 'node_modules',
-          cacheName: 'yarn-node-modules',
-          cacheValidityDecidingFile: 'yarn.lock,package.json,.yarnrc.yml',
-          compressionMethod: 'TARGZ_BEST_SPEED'
-        ),
-        arbitraryFileCache(
-          path: '.',
-          includes: '.pnp.cjs,.pnp.loader.mjs,.yarn/install-state.gz',
-          cacheName: 'yarn-pnp',
-          cacheValidityDecidingFile: 'yarn.lock,package.json,.yarnrc.yml',
-          compressionMethod: 'TARGZ_BEST_SPEED'
-        )
-      ]
-    ) {
-      body()
-    }
-    return
+    caches.addAll([
+      arbitraryFileCache(
+        path: 'node_modules',
+        cacheName: 'yarn-node-modules',
+        cacheValidityDecidingFile: 'yarn.lock,package.json,.yarnrc.yml',
+        compressionMethod: 'TARGZ_BEST_SPEED'
+      ),
+      arbitraryFileCache(
+        path: '.',
+        includes: '.pnp.cjs,.pnp.loader.mjs,.yarn/install-state.gz',
+        cacheName: 'yarn-pnp',
+        cacheValidityDecidingFile: 'yarn.lock,package.json,.yarnrc.yml',
+        compressionMethod: 'TARGZ_BEST_SPEED'
+      )
+    ])
   }
 
   if (fileExists('gradlew')) {
     env.GRADLE_USER_HOME = "${env.WORKSPACE}/.gradle-user-home"
+    caches.addAll([
+      arbitraryFileCache(
+        path: '.gradle-user-home/caches/modules-2/files-2.1',
+        cacheName: 'gradle-dependencies',
+        cacheValidityDecidingFile: 'gradle/wrapper/gradle-wrapper.properties',
+        compressionMethod: 'TARGZ_BEST_SPEED'
+      ),
+      arbitraryFileCache(
+        path: '.gradle-user-home/wrapper/dists',
+        cacheName: 'gradle-wrapper',
+        cacheValidityDecidingFile: 'gradle/wrapper/gradle-wrapper.properties',
+        compressionMethod: 'TARGZ_BEST_SPEED'
+      )
+    ])
+  }
+
+  if (caches) {
     cache(
       maxCacheSize: 2048,
       defaultBranch: 'master',
-      caches: [
-        arbitraryFileCache(
-          path: '.gradle-user-home/caches/modules-2/files-2.1',
-          cacheName: 'gradle-dependencies',
-          cacheValidityDecidingFile: 'gradle/wrapper/gradle-wrapper.properties',
-          compressionMethod: 'TARGZ_BEST_SPEED'
-        ),
-        arbitraryFileCache(
-          path: '.gradle-user-home/wrapper/dists',
-          cacheName: 'gradle-wrapper',
-          cacheValidityDecidingFile: 'gradle/wrapper/gradle-wrapper.properties',
-          compressionMethod: 'TARGZ_BEST_SPEED'
-        )
-      ]
+      caches: caches
     ) {
       body()
     }


### PR DESCRIPTION
Refs DTSPO-34914

- Detects yarn.lock and adds both Yarn caches.
- Detects gradlew and adds both Gradle caches.
- If both exist, sends all four cache definitions to one Job Cacher invocation.
 
