### PR TITLE
DTSPO-34621 - Fix nightly agents being used in non-nightly pipelines

### DIFF
--- a/src/uk/gov/hmcts/pipeline/TerraformInfraApprovals.groovy
+++ b/src/uk/gov/hmcts/pipeline/TerraformInfraApprovals.groovy
@@ -74,17 +74,9 @@ class TerraformInfraApprovals {
   }
 
   boolean hasCachedInfraApprovals() {
-    try {
-      if (infraApprovals) {
-        return infraApprovals.every {
-          def f = new File(it)
-          f.bytes.length > 0
-        }
-      }
-    } catch(e) {
-      this.steps.sh("echo 'WARNING: ${e.message}'")
-    }  // Do nothing, just return false
-    return false
+    return infraApprovals && infraApprovals.every { approvalFile ->
+      this.steps.fileExists(approvalFile)
+    }
   }
 
 }

--- a/test/uk/gov/hmcts/pipeline/TerraformInfraApprovalsTest.groovy
+++ b/test/uk/gov/hmcts/pipeline/TerraformInfraApprovalsTest.groovy
@@ -10,7 +10,6 @@ class TerraformInfraApprovalsTest extends Specification {
   def steps
   def infraApprovals
   def approvalsFileName
-  def approvalsFile
   static def response = ["content":
   """{
       "resources": [
@@ -28,23 +27,13 @@ class TerraformInfraApprovalsTest extends Specification {
     steps.httpRequest(_) >> response
     steps.env >> [SUBSCRIPTION_NAME: 'aat', GIT_URL: 'https://github.com/hmcts/some-project']
     approvalsFileName = "terraform-infra-approvals.json"
-    approvalsFile = new File(approvalsFileName)
-    if (approvalsFile.exists()) {
-      approvalsFile.delete()
-    }
     infraApprovals = new TerraformInfraApprovals(steps)
-  }
-
-  void cleanup() {
-    if (approvalsFile.exists()) {
-      approvalsFile.delete()
-    }
   }
 
   def "isApproved() should return true when subscription is sandbox"() {
     infraApprovals.subscription = 'sandbox'
     def tfInfraPath = '.'
-    approvalsFile << response.content
+    steps.fileExists(_) >> true
     when:
     def approved = infraApprovals.isApproved(tfInfraPath)
 
@@ -54,7 +43,7 @@ class TerraformInfraApprovalsTest extends Specification {
 
   def "isApproved() should return true when a terraform approvals list doesn't exist"() {
     def tfInfraPath = '.'
-    approvalsFile << ""
+    steps.fileExists(_) >> false
     when:
     def approved = infraApprovals.isApproved(tfInfraPath)
 
@@ -63,8 +52,8 @@ class TerraformInfraApprovalsTest extends Specification {
   }
 
   def "hasCachedInfraApprovals() should return true when a terraform approvals list exists"() {
-    approvalsFile << response.content
     TerraformInfraApprovals.infraApprovals.add(approvalsFileName)
+    steps.fileExists(approvalsFileName) >> true
     when:
     def cached = infraApprovals.hasCachedInfraApprovals()
 
@@ -73,8 +62,8 @@ class TerraformInfraApprovalsTest extends Specification {
   }
 
   def "hasCachedInfraApprovals() should return false when a terraform approvals list doesn't exist"() {
-    approvalsFile << ""
     TerraformInfraApprovals.infraApprovals.add(approvalsFileName)
+    steps.fileExists(approvalsFileName) >> false
     when:
     def cached = infraApprovals.hasCachedInfraApprovals()
 

--- a/vars/spinInfra.groovy
+++ b/vars/spinInfra.groovy
@@ -50,9 +50,13 @@ def call(Map<String, ?> params) {
     throw new Exception("There is no SUBSCRIPTION_NAME environment variable, are you running inside a withSubscription block?")
   }
 
-  stage('Check Terraform approvals') {
-    approvedTerraformInfrastructure(config.environment, config.product, metricsPublisher) {
-      stateStoreInit(config.environment, config.subscription, config.deploymentTarget)
+  stage("Terraform Plan/Apply - ${environmentDeploymentTarget}") {
+    stage('Check Terraform approvals') {
+      approvedTerraformInfrastructure(config.environment, config.product, metricsPublisher) {
+      }
+    }
+
+    stateStoreInit(config.environment, config.subscription, config.deploymentTarget)
 
     Closure terraformInit = {
       sh """
@@ -175,7 +179,6 @@ def call(Map<String, ?> params) {
           }
         } else
           log.warning "Skipping apply due to tfPlanOnly flag set"
-      }
     }
   }
 }

--- a/vars/spinInfra.groovy
+++ b/vars/spinInfra.groovy
@@ -50,8 +50,9 @@ def call(Map<String, ?> params) {
     throw new Exception("There is no SUBSCRIPTION_NAME environment variable, are you running inside a withSubscription block?")
   }
 
-  approvedTerraformInfrastructure(config.environment, config.product, metricsPublisher) {
-    stateStoreInit(config.environment, config.subscription, config.deploymentTarget)
+  stage('Check Terraform approvals') {
+    approvedTerraformInfrastructure(config.environment, config.product, metricsPublisher) {
+      stateStoreInit(config.environment, config.subscription, config.deploymentTarget)
 
     Closure terraformInit = {
       sh """
@@ -63,8 +64,8 @@ def call(Map<String, ?> params) {
       """
     }
 
-    lock("${config.productName}-${environmentDeploymentTarget}") {
-      stageWithEnvironmentAgent("Plan ${config.productName} in ${environmentDeploymentTarget}", config.product, config.environment) {
+      lock("${config.productName}-${environmentDeploymentTarget}") {
+        stageWithEnvironmentAgent("Plan ${config.productName} in ${environmentDeploymentTarget}", config.product, config.environment) {
 
         teamName = env.TEAM_NAME
         def contactSlackChannel = env.CONTACT_SLACK_CHANNEL
@@ -157,8 +158,8 @@ def call(Map<String, ?> params) {
           }
         }
       }
-      if (!config.tfPlanOnly) {
-        stageWithEnvironmentAgent("Apply ${config.productName} in ${environmentDeploymentTarget}", config.product, config.environment) {
+        if (!config.tfPlanOnly) {
+          stageWithEnvironmentAgent("Apply ${config.productName} in ${environmentDeploymentTarget}", config.product, config.environment) {
           terraformInit()
           unstash terraformPlanStashName
           sh "terraform apply -auto-approve tfplan"
@@ -171,9 +172,10 @@ def call(Map<String, ?> params) {
             log.info("terraform output command failed! ${err} Assuming there was no result...")
           }
           return parseResult
-        }
-      } else
-        log.warning "Skipping apply due to tfPlanOnly flag set"
+          }
+        } else
+          log.warning "Skipping apply due to tfPlanOnly flag set"
+      }
     }
   }
 }

--- a/vars/withInfraPipeline.groovy
+++ b/vars/withInfraPipeline.groovy
@@ -34,8 +34,9 @@ def call(String product, String component = null, Closure body) {
   String primaryEnvironment = autoDeployTarget?.environmentName ?: environment.nonProdName
 
   String agentType = AgentSelector.labelForEnvironmentWithoutProductFallback(primaryEnvironment, env) ?: env.BUILD_AGENT_TYPE
+  String nodeSelector = agentType ? "${agentType} && !nightly" : '!nightly'
 
-  node(agentType) {
+  node(nodeSelector) {
     def slackChannel = env.BUILD_NOTICES_SLACK_CHANNEL
     try {
       echo "Using ${agentType} as primary pipeline agent for ${primaryEnvironment}"

--- a/vars/withParameterizedInfraPipeline.groovy
+++ b/vars/withParameterizedInfraPipeline.groovy
@@ -35,9 +35,9 @@ def call(String product, String environment, String subscription, Boolean planOn
   def teamConfig = new TeamConfig(this).setTeamConfigEnv(product)
   String primaryEnvironment = environment
   String agentType = AgentSelector.labelForEnvironmentWithoutProductFallback(primaryEnvironment, env) ?: env.BUILD_AGENT_TYPE
+  String nodeSelector = agentType ? "${agentType} && !nightly" : '!nightly'
 
-
-  node(agentType) {
+  node(nodeSelector) {
     def slackChannel = env.BUILD_NOTICES_SLACK_CHANNEL
     try {
       echo "Using ${agentType} as primary pipeline agent for ${primaryEnvironment}"

--- a/vars/withParameterizedPipeline.groovy
+++ b/vars/withParameterizedPipeline.groovy
@@ -66,8 +66,9 @@ def call(type, String product, String component, String environment, String subs
   def autoDeployTarget = autoDeployEnvironment()
   String primaryEnvironment = autoDeployTarget?.environmentName ?: environment
   String agentType = AgentSelector.labelForEnvironmentWithoutProductFallback(primaryEnvironment, env) ?: env.BUILD_AGENT_TYPE
+  String nodeSelector = agentType ? "${agentType} && !nightly" : '!nightly'
 
-  node(agentType) {
+  node(nodeSelector) {
     def slackChannel = env.BUILD_NOTICES_SLACK_CHANNEL
     try {
       echo "Using ${agentType} as primary pipeline agent for ${primaryEnvironment}"

--- a/vars/withPipeline.groovy
+++ b/vars/withPipeline.groovy
@@ -71,9 +71,10 @@ def call(type, String product, String component, Closure body) {
 
   def teamConfig = new TeamConfig(this).setTeamConfigEnv(product)
   String agentType = AgentSelector.labelForEnvironment(primaryEnvironment, env, product) ?: env.BUILD_AGENT_TYPE
+  String nodeSelector = agentType ? "${agentType} && !nightly" : '!nightly'
 
   retry(conditions: [agent()], count: 2) {
-    node(agentType) {
+    node(nodeSelector) {
       timeoutWithMsg(time: 180, unit: 'MINUTES', action: 'pipeline') {
         def slackChannel = env.BUILD_NOTICES_SLACK_CHANNEL
         try {


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-34621

Updating agent selection so nightly agents cannot be used in non-nightly pipelines
Updating the terraform infra approvals error so it's visible in the pipeline overview
Renaming terraform stage so infra approvals and plan/apply are substages
Using `fileExists` as an erroneous error was being thrown and caught about global.json not existing on the controller but it does exist on the agent
Tested in cnp-plum-shared-infrastructure

Before:
<img width="1195" height="287" alt="Screenshot 2026-09-09 at 11 38 39" src="https://github.com/user-attachments/assets/9c9f6ac2-a568-4d73-9925-fa1eb6223fa0" />

After:
<img width="1226" height="361" alt="Screenshot 2026-09-09 at 11 39 10" src="https://github.com/user-attachments/assets/2f0b75b2-77f8-4064-8a94-2895607fc9ba" />

